### PR TITLE
feat: ResourceTable server/client hybrid mode with smart data fetching

### DIFF
--- a/web/app/src/lib/components/Dashboard.tsx
+++ b/web/app/src/lib/components/Dashboard.tsx
@@ -21,15 +21,8 @@ interface ResourceSummary {
   loading: boolean;
 }
 
-const DISPLAY_MAX = 1000;
-
-function formatCount(count: number): string {
-  if (count > DISPLAY_MAX) return `${DISPLAY_MAX}+`;
-  return String(count);
-}
-
 /**
- * Generic dashboard showing all resources with counts
+ * Generic dashboard showing all resources with total counts
  */
 export function Dashboard() {
   const resourceNames = getResourceNames();
@@ -90,7 +83,7 @@ export function Dashboard() {
                   <Loader size="sm" />
                 ) : (
                   <Badge size="lg" variant="light">
-                    {formatCount(s.count)} resources
+                    {s.count} resources
                   </Badge>
                 )}
               </Group>

--- a/web/app/src/lib/components/table/ResourceTable.tsx
+++ b/web/app/src/lib/components/table/ResourceTable.tsx
@@ -1,8 +1,15 @@
 /**
- * ResourceTable - Generic resource list table with server-side pagination and sorting
+ * ResourceTable - Generic resource list table with lazy upgrade between
+ * server-side and client-side modes.
+ *
+ * Default: **server mode** — pagination, sorting, and filtering are delegated
+ * to the backend API.  When the user triggers an operation the backend cannot
+ * handle (global free-text search, non-indexed column sort/filter) the table
+ * automatically upgrades to **client mode** — fetches up to CLIENT_FETCH_LIMIT
+ * items and lets MRT handle everything locally.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import {
   Container,
@@ -14,21 +21,37 @@ import {
   ActionIcon,
   TextInput,
   Alert,
+  Badge,
 } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconRefresh, IconSearch, IconX, IconAlertCircle } from '@tabler/icons-react';
 import {
   MantineReactTable,
   useMantineReactTable,
-  type MRT_PaginationState,
   type MRT_SortingState,
+  type MRT_ColumnFiltersState,
+  type MRT_PaginationState,
   type MRT_RowData,
 } from 'mantine-react-table';
 import { useResourceList } from '../../hooks/useResourceList';
+import { formatTime } from '../common/TimeDisplay';
 import { AdvancedSearchPanel } from './AdvancedSearchPanel';
 import { buildTableColumns } from './buildColumns';
 import type { ActiveSearchState } from './searchUtils';
 import type { ResourceTableProps } from './types';
-import { sortByToSorts } from './utils';
+import {
+  sortByToSorts,
+  computeTableMode,
+  mrtSortingToSorts,
+  mrtFiltersToParams,
+  type TableMode,
+} from './utils';
+
+/** Maximum number of items fetched from the backend for client-side operations */
+const CLIENT_FETCH_LIMIT = 50;
+
+/** Debounce delay (ms) for globalFilter before triggering client mode */
+const GLOBAL_FILTER_DEBOUNCE_MS = 1000;
 
 /**
  * Generic resource list table with server-side pagination and sorting
@@ -91,13 +114,20 @@ export function ResourceTable<T extends MRT_RowData>({
   disableQB = true,
 }: ResourceTableProps<T>) {
   const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({ pageIndex: 0, pageSize: 20 });
+
+  // ── MRT state ──
   const [sorting, setSorting] = useState<MRT_SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>([]);
+  const [pagination, setPagination] = useState<MRT_PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  });
 
-  // 即時篩選（client-side）- 只篩當前頁面已載入的資料
+  // ── Global filter with debounce (triggers client mode after delay) ──
   const [globalFilter, setGlobalFilter] = useState('');
+  const [debouncedGlobalFilter] = useDebouncedValue(globalFilter, GLOBAL_FILTER_DEBOUNCE_MS);
 
-  // 已提交的搜尋狀態（由 AdvancedSearchPanel 管理，透過 callback 回傳）
+  // ── AdvancedSearchPanel state ──
   const [activeSearch, setActiveSearch] = useState<ActiveSearchState>({
     mode: 'condition',
     condition: { meta: {}, data: [] },
@@ -106,63 +136,138 @@ export function ResourceTable<T extends MRT_RowData>({
     sortBy: undefined,
   });
 
-  // AdvancedSearchPanel 搜尋狀態變更 — 重置分頁
   const handleSearchChange = useCallback((search: ActiveSearchState) => {
     setActiveSearch(search);
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  const params = useMemo(() => {
-    const baseParams: Record<string, unknown> = {
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-    };
+  // ── Compute table mode (server vs client) ──
+  const mode: TableMode = useMemo(
+    () =>
+      computeTableMode({
+        debouncedGlobalFilter,
+        sorting,
+        columnFilters,
+        indexedFields: config.indexedFields,
+      }),
+    [debouncedGlobalFilter, sorting, columnFilters, config.indexedFields],
+  );
 
-    // 根據 activeSearch 的模式設定參數
+  // Reset page index when mode changes
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (prevModeRef.current !== mode) {
+      prevModeRef.current = mode;
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }
+  }, [mode]);
+
+  // ── Build request params ──
+  const params = useMemo(() => {
+    const baseParams: Record<string, unknown> = {};
+
+    // --- Pagination ---
+    if (mode === 'server') {
+      baseParams.limit = pagination.pageSize;
+      baseParams.offset = pagination.pageIndex * pagination.pageSize;
+    } else {
+      baseParams.limit = CLIENT_FETCH_LIMIT;
+      // Sort by updated_time desc to fetch the most recently updated items
+      baseParams.sorts = JSON.stringify([
+        { type: 'meta', key: 'updated_time', direction: '-' },
+      ]);
+    }
+
+    // --- AdvancedSearchPanel conditions ---
     if (activeSearch.mode === 'qb' && activeSearch.qb) {
-      // QB 模式：只傳 qb 字串（limit 和 sorts 已包含在 QB 中）
+      // QB mode: just send the QB string
       baseParams.qb = activeSearch.qb;
     } else {
-      // Condition 模式：傳遞各別參數
-      const { meta, data } = activeSearch.condition;
+      // Condition mode
+      const { meta, data: advancedData } = activeSearch.condition;
 
-      // 後端結果數量限制（優先於 pagination.pageSize）
+      // Advanced panel result limit (cap at CLIENT_FETCH_LIMIT)
       if (activeSearch.resultLimit) {
-        baseParams.limit = activeSearch.resultLimit;
+        baseParams.limit = Math.min(
+          activeSearch.resultLimit,
+          mode === 'server' ? activeSearch.resultLimit : CLIENT_FETCH_LIMIT,
+        );
       }
 
-      // 後端排序（優先於前端 table sorting）
-      if (activeSearch.sortBy && activeSearch.sortBy.length > 0) {
+      // Advanced panel sorts (only in server mode — in client mode MRT handles sorting)
+      if (mode === 'server' && activeSearch.sortBy && activeSearch.sortBy.length > 0) {
         const sortsStr = sortByToSorts(activeSearch.sortBy);
-        if (sortsStr) {
-          baseParams.sorts = sortsStr;
-        }
+        if (sortsStr) baseParams.sorts = sortsStr;
       }
 
-      // 後端篩選參數（data_conditions）
-      if (data.length > 0) {
-        const dataConditions = data.map((condition) => ({
-          field_path: condition.field,
-          operator: condition.operator,
-          value: condition.value,
-        }));
-        baseParams.data_conditions = JSON.stringify(dataConditions);
-      }
+      // Advanced panel data_conditions
+      const advancedConditions = advancedData.map((condition) => ({
+        field_path: condition.field,
+        operator: condition.operator,
+        value: condition.value,
+      }));
 
-      // Meta 篩選參數
+      // Advanced panel meta filters
       if (meta.created_time_start) baseParams.created_time_start = meta.created_time_start;
       if (meta.created_time_end) baseParams.created_time_end = meta.created_time_end;
       if (meta.updated_time_start) baseParams.updated_time_start = meta.updated_time_start;
       if (meta.updated_time_end) baseParams.updated_time_end = meta.updated_time_end;
       if (meta.created_by) baseParams.created_bys = [meta.created_by];
       if (meta.updated_by) baseParams.updated_bys = [meta.updated_by];
+
+      // --- MRT column filters (server-filterable ones sent to backend in both modes) ---
+      const { serverParams, dataConditions: mrtDataConditions } = mrtFiltersToParams(
+        columnFilters,
+        config.indexedFields,
+      );
+      Object.assign(baseParams, serverParams);
+
+      // Merge advanced + MRT data_conditions
+      const allDataConditions = [...advancedConditions, ...mrtDataConditions];
+      if (allDataConditions.length > 0) {
+        baseParams.data_conditions = JSON.stringify(allDataConditions);
+      }
+    }
+
+    // --- MRT column sorting (server mode only — send sortable columns to backend) ---
+    if (mode === 'server' && sorting.length > 0 && !baseParams.sorts) {
+      const sortsStr = mrtSortingToSorts(sorting, config.indexedFields);
+      if (sortsStr) baseParams.sorts = sortsStr;
     }
 
     return baseParams;
-  }, [pagination.pageSize, pagination.pageIndex, activeSearch]);
+  }, [mode, pagination, activeSearch, sorting, columnFilters, config.indexedFields]);
 
   const { data, total, loading, error, refresh } = useResourceList(config, params);
 
+  // ── Client mode overflow info (cutoff timestamp) ──
+  const clientOverflowInfo = useMemo(() => {
+    if (mode !== 'client' || total <= data.length || data.length === 0) return null;
+
+    // Find the oldest updated_time in the loaded data set
+    let oldestTime: string | null = null;
+    for (const item of data) {
+      const ut = (item as Record<string, unknown> & { meta?: { updated_time?: string } })?.meta
+        ?.updated_time;
+      if (ut && (!oldestTime || ut < oldestTime)) {
+        oldestTime = ut;
+      }
+    }
+
+    if (!oldestTime) return null;
+    return {
+      cutoffTime: oldestTime,
+      unfetchedCount: total - data.length,
+    };
+  }, [mode, total, data]);
+
+  // ── Count label ──
+  const countLabel = useMemo(() => {
+    if (mode === 'server') return `${total} total resources`;
+    if (clientOverflowInfo) return `${data.length} / ${total} total resources`;
+    return `${total} total resources`;
+  }, [mode, total, data.length, clientOverflowInfo]);
+
+  // ── Columns ──
   const tableColumns = useMemo(
     () =>
       buildTableColumns(config, {
@@ -172,16 +277,41 @@ export function ResourceTable<T extends MRT_RowData>({
     [config.fields, columns],
   );
 
+  // ── MRT instance ──
+  const isServer = mode === 'server';
+
   const table = useMantineReactTable({
     columns: tableColumns,
     data,
-    manualPagination: true,
-    rowCount: total,
+
+    // Global filter
     enableGlobalFilter: true,
-    state: { isLoading: loading, pagination, sorting, globalFilter },
     onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
+
+    // Column filters
+    enableColumnFilters: true,
+    onColumnFiltersChange: setColumnFilters,
+
+    // Sorting
     onSortingChange: setSorting,
+
+    // Pagination
+    onPaginationChange: setPagination,
+
+    // Server / client mode toggle
+    manualPagination: isServer,
+    manualSorting: isServer,
+    manualFiltering: isServer,
+    rowCount: isServer ? total : undefined,
+
+    state: {
+      isLoading: loading,
+      sorting,
+      globalFilter,
+      columnFilters,
+      pagination,
+    },
+
     mantineTableBodyRowProps: ({ row }) => ({
       onClick: () =>
         navigate({
@@ -199,9 +329,20 @@ export function ResourceTable<T extends MRT_RowData>({
         <Group justify="space-between">
           <div>
             <Title order={2}>{config.label}</Title>
-            <Text c="dimmed" size="sm">
-              {total} total resources
-            </Text>
+            <Group gap="xs">
+              <Text c="dimmed" size="sm">
+                {countLabel}
+              </Text>
+              <Badge size="xs" variant="light" color={isServer ? 'blue' : 'orange'}>
+                {isServer ? 'Server' : 'Client'}
+              </Badge>
+              {clientOverflowInfo && (
+                <Text c="orange" size="xs">
+                  僅載入 {formatTime(clientOverflowInfo.cutoffTime, 'full')} 之後更新的資料，尚有{' '}
+                  {clientOverflowInfo.unfetchedCount} 筆未載入
+                </Text>
+              )}
+            </Group>
           </div>
           <Group>
             <Button variant="light" leftSection={<IconRefresh size={16} />} onClick={refresh}>
@@ -216,9 +357,9 @@ export function ResourceTable<T extends MRT_RowData>({
           </Group>
         </Group>
 
-        {/* 即時篩選 - 只篩當前頁面的資料 */}
+        {/* 即時篩選 - client-side free text search (triggers client mode after debounce) */}
         <TextInput
-          placeholder="在此頁中篩選..."
+          placeholder="Search all loaded resources..."
           value={globalFilter ?? ''}
           onChange={(e) => setGlobalFilter(e.currentTarget.value)}
           leftSection={<IconSearch size={16} />}

--- a/web/app/src/lib/components/table/utils.test.ts
+++ b/web/app/src/lib/components/table/utils.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for ResourceTable utility functions:
+ * - isServerSortable
+ * - isServerFilterable
+ * - computeTableMode
+ * - mrtSortingToSorts
+ * - mrtFiltersToParams
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isServerSortable,
+  isServerFilterable,
+  computeTableMode,
+  mrtSortingToSorts,
+  mrtFiltersToParams,
+} from './utils';
+
+// ---------------------------------------------------------------------------
+// isServerSortable
+// ---------------------------------------------------------------------------
+
+describe('isServerSortable', () => {
+  it('returns true for meta sort keys', () => {
+    expect(isServerSortable('resource_id')).toBe(true);
+    expect(isServerSortable('created_time')).toBe(true);
+    expect(isServerSortable('updated_time')).toBe(true);
+  });
+
+  it('returns false for non-sortable meta columns', () => {
+    expect(isServerSortable('created_by')).toBe(false);
+    expect(isServerSortable('updated_by')).toBe(false);
+    expect(isServerSortable('schema_version')).toBe(false);
+    expect(isServerSortable('is_deleted')).toBe(false);
+    expect(isServerSortable('current_revision_id')).toBe(false);
+  });
+
+  it('returns true for indexed data fields', () => {
+    expect(isServerSortable('level', ['level', 'name'])).toBe(true);
+    expect(isServerSortable('name', ['level', 'name'])).toBe(true);
+  });
+
+  it('returns false for non-indexed data fields', () => {
+    expect(isServerSortable('description', ['level', 'name'])).toBe(false);
+  });
+
+  it('returns false for data fields when indexedFields is undefined', () => {
+    expect(isServerSortable('level')).toBe(false);
+    expect(isServerSortable('level', undefined)).toBe(false);
+  });
+
+  it('returns false for data fields when indexedFields is empty', () => {
+    expect(isServerSortable('level', [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isServerFilterable
+// ---------------------------------------------------------------------------
+
+describe('isServerFilterable', () => {
+  it('returns true for dedicated meta filter columns', () => {
+    expect(isServerFilterable('created_by')).toBe(true);
+    expect(isServerFilterable('updated_by')).toBe(true);
+    expect(isServerFilterable('is_deleted')).toBe(true);
+  });
+
+  it('returns false for meta columns without dedicated filter support', () => {
+    expect(isServerFilterable('created_time')).toBe(false);
+    expect(isServerFilterable('updated_time')).toBe(false);
+    expect(isServerFilterable('resource_id')).toBe(false);
+    expect(isServerFilterable('current_revision_id')).toBe(false);
+    expect(isServerFilterable('schema_version')).toBe(false);
+  });
+
+  it('returns true for indexed data fields', () => {
+    expect(isServerFilterable('level', ['level', 'name'])).toBe(true);
+  });
+
+  it('returns false for non-indexed data fields', () => {
+    expect(isServerFilterable('description', ['level', 'name'])).toBe(false);
+    expect(isServerFilterable('description')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTableMode
+// ---------------------------------------------------------------------------
+
+describe('computeTableMode', () => {
+  const base = {
+    debouncedGlobalFilter: '',
+    sorting: [] as any[],
+    columnFilters: [] as any[],
+    indexedFields: ['level', 'name'],
+  };
+
+  it('returns "server" with no triggers', () => {
+    expect(computeTableMode(base)).toBe('server');
+  });
+
+  it('returns "client" when globalFilter is non-empty', () => {
+    expect(computeTableMode({ ...base, debouncedGlobalFilter: 'hello' })).toBe('client');
+  });
+
+  it('returns "server" when sorting on server-sortable meta column', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'created_time', desc: false }] }),
+    ).toBe('server');
+  });
+
+  it('returns "server" when sorting on indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'level', desc: true }] }),
+    ).toBe('server');
+  });
+
+  it('returns "client" when sorting on non-server-sortable column', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'created_by', desc: false }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when sorting on non-indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'description', desc: false }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when mixed sorts include a non-sortable column', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        sorting: [
+          { id: 'created_time', desc: false },
+          { id: 'description', desc: true },
+        ],
+      }),
+    ).toBe('client');
+  });
+
+  it('returns "server" when column filter targets server-filterable column', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'created_by', value: 'admin' }] }),
+    ).toBe('server');
+  });
+
+  it('returns "server" when column filter targets indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'level', value: '5' }] }),
+    ).toBe('server');
+  });
+
+  it('returns "client" when column filter targets non-filterable column', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'created_time', value: '2024' }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when column filter targets non-indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'description', value: 'test' }] }),
+    ).toBe('client');
+  });
+
+  it('ignores empty/null filter values', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        columnFilters: [
+          { id: 'description', value: '' },
+          { id: 'description', value: null },
+        ],
+      }),
+    ).toBe('server');
+  });
+
+  it('returns "client" on combined triggers', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        debouncedGlobalFilter: 'search',
+        sorting: [{ id: 'description', desc: false }],
+        columnFilters: [{ id: 'resource_id', value: 'abc' }],
+      }),
+    ).toBe('client');
+  });
+
+  it('returns "client" for any data sort when indexedFields is undefined', () => {
+    expect(
+      computeTableMode({
+        debouncedGlobalFilter: '',
+        sorting: [{ id: 'level', desc: false }],
+        columnFilters: [],
+        indexedFields: undefined,
+      }),
+    ).toBe('client');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mrtSortingToSorts
+// ---------------------------------------------------------------------------
+
+describe('mrtSortingToSorts', () => {
+  it('returns empty string for empty sorting', () => {
+    expect(mrtSortingToSorts([])).toBe('');
+  });
+
+  it('converts meta sort key ascending', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'created_time', desc: false }]));
+    expect(result).toEqual([{ type: 'meta', key: 'created_time', direction: '+' }]);
+  });
+
+  it('converts meta sort key descending', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'resource_id', desc: true }]));
+    expect(result).toEqual([{ type: 'meta', key: 'resource_id', direction: '-' }]);
+  });
+
+  it('converts indexed data field sort', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'level', desc: false }], ['level']));
+    expect(result).toEqual([{ type: 'data', field_path: 'level', direction: '+' }]);
+  });
+
+  it('omits non-server-sortable columns', () => {
+    expect(mrtSortingToSorts([{ id: 'description', desc: false }], ['level'])).toBe('');
+  });
+
+  it('handles mixed sortable and non-sortable columns', () => {
+    const result = JSON.parse(
+      mrtSortingToSorts(
+        [
+          { id: 'created_time', desc: false },
+          { id: 'description', desc: true },
+          { id: 'level', desc: true },
+        ],
+        ['level'],
+      ),
+    );
+    expect(result).toEqual([
+      { type: 'meta', key: 'created_time', direction: '+' },
+      { type: 'data', field_path: 'level', direction: '-' },
+    ]);
+  });
+
+  it('returns empty string when all columns are non-sortable', () => {
+    expect(
+      mrtSortingToSorts(
+        [
+          { id: 'created_by', desc: false },
+          { id: 'description', desc: true },
+        ],
+        [],
+      ),
+    ).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mrtFiltersToParams
+// ---------------------------------------------------------------------------
+
+describe('mrtFiltersToParams', () => {
+  it('returns empty results for empty filters', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('converts created_by filter to created_bys param', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_by', value: 'admin' },
+    ]);
+    expect(serverParams).toEqual({ created_bys: ['admin'] });
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('converts updated_by filter to updated_bys param', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'updated_by', value: 'user1' }]);
+    expect(serverParams).toEqual({ updated_bys: ['user1'] });
+  });
+
+  it('converts is_deleted filter to boolean param', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'is_deleted', value: 'true' }]);
+    expect(serverParams).toEqual({ is_deleted: true });
+  });
+
+  it('converts is_deleted "false" string correctly', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'is_deleted', value: 'false' }]);
+    expect(serverParams).toEqual({ is_deleted: false });
+  });
+
+  it('converts indexed data field string to contains condition', () => {
+    const { dataConditions } = mrtFiltersToParams(
+      [{ id: 'name', value: 'alice' }],
+      ['name', 'level'],
+    );
+    expect(dataConditions).toEqual([{ field_path: 'name', operator: 'contains', value: 'alice' }]);
+  });
+
+  it('converts indexed data field number to eq condition', () => {
+    const { dataConditions } = mrtFiltersToParams([{ id: 'level', value: 5 }], ['level']);
+    expect(dataConditions).toEqual([{ field_path: 'level', operator: 'eq', value: 5 }]);
+  });
+
+  it('ignores non-filterable columns', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_time', value: '2024-01-01' },
+      { id: 'description', value: 'test' },
+    ]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('ignores empty and null values', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_by', value: '' },
+      { id: 'created_by', value: null },
+    ]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('handles mixed meta and indexed data filters', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams(
+      [
+        { id: 'created_by', value: 'admin' },
+        { id: 'name', value: 'bob' },
+        { id: 'description', value: 'ignored' },
+      ],
+      ['name'],
+    );
+    expect(serverParams).toEqual({ created_bys: ['admin'] });
+    expect(dataConditions).toEqual([{ field_path: 'name', operator: 'contains', value: 'bob' }]);
+  });
+});

--- a/web/app/src/lib/components/table/utils.ts
+++ b/web/app/src/lib/components/table/utils.ts
@@ -2,7 +2,169 @@
  * Resource Table 工具函數
  */
 
+import type { MRT_ColumnFiltersState, MRT_SortingState } from 'mantine-react-table';
 import type { MetaFilters, SearchCondition } from './types';
+
+// ---------------------------------------------------------------------------
+// Server-capability constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Meta columns that the backend can sort on.
+ * Corresponds to ResourceMetaSortKey in autocrud/types.py.
+ */
+export const SERVER_META_SORT_KEYS = ['resource_id', 'created_time', 'updated_time'] as const;
+
+/**
+ * Meta columns that the backend can filter on via dedicated query params.
+ * Maps column id → the backend query parameter name(s) and conversion strategy.
+ */
+export const SERVER_META_FILTER_COLUMNS: Record<
+  string,
+  { paramName: string; convert: (value: unknown) => Record<string, unknown> }
+> = {
+  created_by: {
+    paramName: 'created_bys',
+    convert: (v) => ({ created_bys: [String(v)] }),
+  },
+  updated_by: {
+    paramName: 'updated_bys',
+    convert: (v) => ({ updated_bys: [String(v)] }),
+  },
+  is_deleted: {
+    paramName: 'is_deleted',
+    convert: (v) => {
+      const str = String(v).toLowerCase();
+      return { is_deleted: str === 'true' || str === '1' };
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Server-capability queries
+// ---------------------------------------------------------------------------
+
+/** Check whether a column can be sorted server-side. */
+export function isServerSortable(columnId: string, indexedFields?: string[]): boolean {
+  if ((SERVER_META_SORT_KEYS as readonly string[]).includes(columnId)) return true;
+  if (indexedFields && indexedFields.includes(columnId)) return true;
+  return false;
+}
+
+/** Check whether a column can be filtered server-side. */
+export function isServerFilterable(columnId: string, indexedFields?: string[]): boolean {
+  if (columnId in SERVER_META_FILTER_COLUMNS) return true;
+  if (indexedFields && indexedFields.includes(columnId)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Table mode computation
+// ---------------------------------------------------------------------------
+
+export type TableMode = 'server' | 'client';
+
+export interface ComputeTableModeArgs {
+  debouncedGlobalFilter: string;
+  sorting: MRT_SortingState;
+  columnFilters: MRT_ColumnFiltersState;
+  indexedFields?: string[];
+}
+
+/**
+ * Determine whether the table should operate in server or client mode.
+ *
+ * Returns 'client' when any operation requires client-side processing:
+ *  - globalFilter is non-empty (free-text search across all fields)
+ *  - any column sort targets a non-server-sortable column
+ *  - any column filter targets a non-server-filterable column
+ */
+export function computeTableMode({
+  debouncedGlobalFilter,
+  sorting,
+  columnFilters,
+  indexedFields,
+}: ComputeTableModeArgs): TableMode {
+  // Trigger 1: global free-text filter
+  if (debouncedGlobalFilter) return 'client';
+
+  // Trigger 2: non-server-sortable column in MRT sorting
+  for (const sort of sorting) {
+    if (!isServerSortable(sort.id, indexedFields)) return 'client';
+  }
+
+  // Trigger 3: non-server-filterable column in MRT column filters
+  for (const filter of columnFilters) {
+    if (filter.value == null || filter.value === '') continue;
+    if (!isServerFilterable(filter.id, indexedFields)) return 'client';
+  }
+
+  return 'server';
+}
+
+// ---------------------------------------------------------------------------
+// MRT state → backend params conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert MRT sorting state to backend `sorts` JSON string.
+ * Only includes server-sortable columns; non-sortable ones are omitted
+ * (they'll be handled client-side by MRT).
+ */
+export function mrtSortingToSorts(
+  sorting: MRT_SortingState,
+  indexedFields?: string[],
+): string {
+  const serverSorts = sorting.filter((s) => isServerSortable(s.id, indexedFields));
+  if (serverSorts.length === 0) return '';
+
+  const sortsArray = serverSorts.map((s) => {
+    const direction = s.desc ? '-' : '+';
+    if ((SERVER_META_SORT_KEYS as readonly string[]).includes(s.id)) {
+      return { type: 'meta', key: s.id, direction };
+    }
+    return { type: 'data', field_path: s.id, direction };
+  });
+
+  return JSON.stringify(sortsArray);
+}
+
+/**
+ * Convert MRT column filters to backend query params.
+ * Only includes server-filterable columns. Returns an object with
+ * backend param keys ready to merge into the request params.
+ *
+ * - Meta filter columns → dedicated params (created_bys, updated_bys, is_deleted)
+ * - Indexed data columns → data_conditions array (string uses "contains", others "eq")
+ */
+export function mrtFiltersToParams(
+  columnFilters: MRT_ColumnFiltersState,
+  indexedFields?: string[],
+): { serverParams: Record<string, unknown>; dataConditions: Array<{ field_path: string; operator: string; value: unknown }> } {
+  const serverParams: Record<string, unknown> = {};
+  const dataConditions: Array<{ field_path: string; operator: string; value: unknown }> = [];
+
+  for (const filter of columnFilters) {
+    if (filter.value == null || filter.value === '') continue;
+
+    // Meta filter columns
+    const metaDef = SERVER_META_FILTER_COLUMNS[filter.id];
+    if (metaDef) {
+      Object.assign(serverParams, metaDef.convert(filter.value));
+      continue;
+    }
+
+    // Indexed data columns
+    if (indexedFields && indexedFields.includes(filter.id)) {
+      const value = filter.value;
+      // Use "contains" for strings, "eq" for everything else
+      const operator = typeof value === 'string' ? 'contains' : 'eq';
+      dataConditions.push({ field_path: filter.id, operator, value });
+    }
+  }
+
+  return { serverParams, dataConditions };
+}
 
 /**
  * 將 ISO 時間字串轉換為 Python dt.datetime(...) 格式

--- a/web/generator/templates/base/src/lib/components/Dashboard.tsx
+++ b/web/generator/templates/base/src/lib/components/Dashboard.tsx
@@ -21,15 +21,8 @@ interface ResourceSummary {
   loading: boolean;
 }
 
-const DISPLAY_MAX = 1000;
-
-function formatCount(count: number): string {
-  if (count > DISPLAY_MAX) return `${DISPLAY_MAX}+`;
-  return String(count);
-}
-
 /**
- * Generic dashboard showing all resources with counts
+ * Generic dashboard showing all resources with total counts
  */
 export function Dashboard() {
   const resourceNames = getResourceNames();
@@ -90,7 +83,7 @@ export function Dashboard() {
                   <Loader size="sm" />
                 ) : (
                   <Badge size="lg" variant="light">
-                    {formatCount(s.count)} resources
+                    {s.count} resources
                   </Badge>
                 )}
               </Group>

--- a/web/generator/templates/base/src/lib/components/table/ResourceTable.tsx
+++ b/web/generator/templates/base/src/lib/components/table/ResourceTable.tsx
@@ -1,8 +1,15 @@
 /**
- * ResourceTable - Generic resource list table with server-side pagination and sorting
+ * ResourceTable - Generic resource list table with lazy upgrade between
+ * server-side and client-side modes.
+ *
+ * Default: **server mode** — pagination, sorting, and filtering are delegated
+ * to the backend API.  When the user triggers an operation the backend cannot
+ * handle (global free-text search, non-indexed column sort/filter) the table
+ * automatically upgrades to **client mode** — fetches up to CLIENT_FETCH_LIMIT
+ * items and lets MRT handle everything locally.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import {
   Container,
@@ -14,21 +21,37 @@ import {
   ActionIcon,
   TextInput,
   Alert,
+  Badge,
 } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconRefresh, IconSearch, IconX, IconAlertCircle } from '@tabler/icons-react';
 import {
   MantineReactTable,
   useMantineReactTable,
-  type MRT_PaginationState,
   type MRT_SortingState,
+  type MRT_ColumnFiltersState,
+  type MRT_PaginationState,
   type MRT_RowData,
 } from 'mantine-react-table';
 import { useResourceList } from '../../hooks/useResourceList';
+import { formatTime } from '../common/TimeDisplay';
 import { AdvancedSearchPanel } from './AdvancedSearchPanel';
 import { buildTableColumns } from './buildColumns';
 import type { ActiveSearchState } from './searchUtils';
 import type { ResourceTableProps } from './types';
-import { sortByToSorts } from './utils';
+import {
+  sortByToSorts,
+  computeTableMode,
+  mrtSortingToSorts,
+  mrtFiltersToParams,
+  type TableMode,
+} from './utils';
+
+/** Maximum number of items fetched from the backend for client-side operations */
+const CLIENT_FETCH_LIMIT = 50;
+
+/** Debounce delay (ms) for globalFilter before triggering client mode */
+const GLOBAL_FILTER_DEBOUNCE_MS = 1000;
 
 /**
  * Generic resource list table with server-side pagination and sorting
@@ -91,13 +114,20 @@ export function ResourceTable<T extends MRT_RowData>({
   disableQB = true,
 }: ResourceTableProps<T>) {
   const navigate = useNavigate();
-  const [pagination, setPagination] = useState<MRT_PaginationState>({ pageIndex: 0, pageSize: 20 });
+
+  // ── MRT state ──
   const [sorting, setSorting] = useState<MRT_SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>([]);
+  const [pagination, setPagination] = useState<MRT_PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  });
 
-  // 即時篩選（client-side）- 只篩當前頁面已載入的資料
+  // ── Global filter with debounce (triggers client mode after delay) ──
   const [globalFilter, setGlobalFilter] = useState('');
+  const [debouncedGlobalFilter] = useDebouncedValue(globalFilter, GLOBAL_FILTER_DEBOUNCE_MS);
 
-  // 已提交的搜尋狀態（由 AdvancedSearchPanel 管理，透過 callback 回傳）
+  // ── AdvancedSearchPanel state ──
   const [activeSearch, setActiveSearch] = useState<ActiveSearchState>({
     mode: 'condition',
     condition: { meta: {}, data: [] },
@@ -106,63 +136,138 @@ export function ResourceTable<T extends MRT_RowData>({
     sortBy: undefined,
   });
 
-  // AdvancedSearchPanel 搜尋狀態變更 — 重置分頁
   const handleSearchChange = useCallback((search: ActiveSearchState) => {
     setActiveSearch(search);
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  const params = useMemo(() => {
-    const baseParams: Record<string, unknown> = {
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-    };
+  // ── Compute table mode (server vs client) ──
+  const mode: TableMode = useMemo(
+    () =>
+      computeTableMode({
+        debouncedGlobalFilter,
+        sorting,
+        columnFilters,
+        indexedFields: config.indexedFields,
+      }),
+    [debouncedGlobalFilter, sorting, columnFilters, config.indexedFields],
+  );
 
-    // 根據 activeSearch 的模式設定參數
+  // Reset page index when mode changes
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (prevModeRef.current !== mode) {
+      prevModeRef.current = mode;
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }
+  }, [mode]);
+
+  // ── Build request params ──
+  const params = useMemo(() => {
+    const baseParams: Record<string, unknown> = {};
+
+    // --- Pagination ---
+    if (mode === 'server') {
+      baseParams.limit = pagination.pageSize;
+      baseParams.offset = pagination.pageIndex * pagination.pageSize;
+    } else {
+      baseParams.limit = CLIENT_FETCH_LIMIT;
+      // Sort by updated_time desc to fetch the most recently updated items
+      baseParams.sorts = JSON.stringify([
+        { type: 'meta', key: 'updated_time', direction: '-' },
+      ]);
+    }
+
+    // --- AdvancedSearchPanel conditions ---
     if (activeSearch.mode === 'qb' && activeSearch.qb) {
-      // QB 模式：只傳 qb 字串（limit 和 sorts 已包含在 QB 中）
+      // QB mode: just send the QB string
       baseParams.qb = activeSearch.qb;
     } else {
-      // Condition 模式：傳遞各別參數
-      const { meta, data } = activeSearch.condition;
+      // Condition mode
+      const { meta, data: advancedData } = activeSearch.condition;
 
-      // 後端結果數量限制（優先於 pagination.pageSize）
+      // Advanced panel result limit (cap at CLIENT_FETCH_LIMIT)
       if (activeSearch.resultLimit) {
-        baseParams.limit = activeSearch.resultLimit;
+        baseParams.limit = Math.min(
+          activeSearch.resultLimit,
+          mode === 'server' ? activeSearch.resultLimit : CLIENT_FETCH_LIMIT,
+        );
       }
 
-      // 後端排序（優先於前端 table sorting）
-      if (activeSearch.sortBy && activeSearch.sortBy.length > 0) {
+      // Advanced panel sorts (only in server mode — in client mode MRT handles sorting)
+      if (mode === 'server' && activeSearch.sortBy && activeSearch.sortBy.length > 0) {
         const sortsStr = sortByToSorts(activeSearch.sortBy);
-        if (sortsStr) {
-          baseParams.sorts = sortsStr;
-        }
+        if (sortsStr) baseParams.sorts = sortsStr;
       }
 
-      // 後端篩選參數（data_conditions）
-      if (data.length > 0) {
-        const dataConditions = data.map((condition) => ({
-          field_path: condition.field,
-          operator: condition.operator,
-          value: condition.value,
-        }));
-        baseParams.data_conditions = JSON.stringify(dataConditions);
-      }
+      // Advanced panel data_conditions
+      const advancedConditions = advancedData.map((condition) => ({
+        field_path: condition.field,
+        operator: condition.operator,
+        value: condition.value,
+      }));
 
-      // Meta 篩選參數
+      // Advanced panel meta filters
       if (meta.created_time_start) baseParams.created_time_start = meta.created_time_start;
       if (meta.created_time_end) baseParams.created_time_end = meta.created_time_end;
       if (meta.updated_time_start) baseParams.updated_time_start = meta.updated_time_start;
       if (meta.updated_time_end) baseParams.updated_time_end = meta.updated_time_end;
       if (meta.created_by) baseParams.created_bys = [meta.created_by];
       if (meta.updated_by) baseParams.updated_bys = [meta.updated_by];
+
+      // --- MRT column filters (server-filterable ones sent to backend in both modes) ---
+      const { serverParams, dataConditions: mrtDataConditions } = mrtFiltersToParams(
+        columnFilters,
+        config.indexedFields,
+      );
+      Object.assign(baseParams, serverParams);
+
+      // Merge advanced + MRT data_conditions
+      const allDataConditions = [...advancedConditions, ...mrtDataConditions];
+      if (allDataConditions.length > 0) {
+        baseParams.data_conditions = JSON.stringify(allDataConditions);
+      }
+    }
+
+    // --- MRT column sorting (server mode only — send sortable columns to backend) ---
+    if (mode === 'server' && sorting.length > 0 && !baseParams.sorts) {
+      const sortsStr = mrtSortingToSorts(sorting, config.indexedFields);
+      if (sortsStr) baseParams.sorts = sortsStr;
     }
 
     return baseParams;
-  }, [pagination.pageSize, pagination.pageIndex, activeSearch]);
+  }, [mode, pagination, activeSearch, sorting, columnFilters, config.indexedFields]);
 
   const { data, total, loading, error, refresh } = useResourceList(config, params);
 
+  // ── Client mode overflow info (cutoff timestamp) ──
+  const clientOverflowInfo = useMemo(() => {
+    if (mode !== 'client' || total <= data.length || data.length === 0) return null;
+
+    // Find the oldest updated_time in the loaded data set
+    let oldestTime: string | null = null;
+    for (const item of data) {
+      const ut = (item as Record<string, unknown> & { meta?: { updated_time?: string } })?.meta
+        ?.updated_time;
+      if (ut && (!oldestTime || ut < oldestTime)) {
+        oldestTime = ut;
+      }
+    }
+
+    if (!oldestTime) return null;
+    return {
+      cutoffTime: oldestTime,
+      unfetchedCount: total - data.length,
+    };
+  }, [mode, total, data]);
+
+  // ── Count label ──
+  const countLabel = useMemo(() => {
+    if (mode === 'server') return `${total} total resources`;
+    if (clientOverflowInfo) return `${data.length} / ${total} total resources`;
+    return `${total} total resources`;
+  }, [mode, total, data.length, clientOverflowInfo]);
+
+  // ── Columns ──
   const tableColumns = useMemo(
     () =>
       buildTableColumns(config, {
@@ -172,16 +277,41 @@ export function ResourceTable<T extends MRT_RowData>({
     [config.fields, columns],
   );
 
+  // ── MRT instance ──
+  const isServer = mode === 'server';
+
   const table = useMantineReactTable({
     columns: tableColumns,
     data,
-    manualPagination: true,
-    rowCount: total,
+
+    // Global filter
     enableGlobalFilter: true,
-    state: { isLoading: loading, pagination, sorting, globalFilter },
     onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
+
+    // Column filters
+    enableColumnFilters: true,
+    onColumnFiltersChange: setColumnFilters,
+
+    // Sorting
     onSortingChange: setSorting,
+
+    // Pagination
+    onPaginationChange: setPagination,
+
+    // Server / client mode toggle
+    manualPagination: isServer,
+    manualSorting: isServer,
+    manualFiltering: isServer,
+    rowCount: isServer ? total : undefined,
+
+    state: {
+      isLoading: loading,
+      sorting,
+      globalFilter,
+      columnFilters,
+      pagination,
+    },
+
     mantineTableBodyRowProps: ({ row }) => ({
       onClick: () =>
         navigate({
@@ -199,9 +329,20 @@ export function ResourceTable<T extends MRT_RowData>({
         <Group justify="space-between">
           <div>
             <Title order={2}>{config.label}</Title>
-            <Text c="dimmed" size="sm">
-              {total} total resources
-            </Text>
+            <Group gap="xs">
+              <Text c="dimmed" size="sm">
+                {countLabel}
+              </Text>
+              <Badge size="xs" variant="light" color={isServer ? 'blue' : 'orange'}>
+                {isServer ? 'Server' : 'Client'}
+              </Badge>
+              {clientOverflowInfo && (
+                <Text c="orange" size="xs">
+                  僅載入 {formatTime(clientOverflowInfo.cutoffTime, 'full')} 之後更新的資料，尚有{' '}
+                  {clientOverflowInfo.unfetchedCount} 筆未載入
+                </Text>
+              )}
+            </Group>
           </div>
           <Group>
             <Button variant="light" leftSection={<IconRefresh size={16} />} onClick={refresh}>
@@ -216,9 +357,9 @@ export function ResourceTable<T extends MRT_RowData>({
           </Group>
         </Group>
 
-        {/* 即時篩選 - 只篩當前頁面的資料 */}
+        {/* 即時篩選 - client-side free text search (triggers client mode after debounce) */}
         <TextInput
-          placeholder="在此頁中篩選..."
+          placeholder="Search all loaded resources..."
           value={globalFilter ?? ''}
           onChange={(e) => setGlobalFilter(e.currentTarget.value)}
           leftSection={<IconSearch size={16} />}

--- a/web/generator/templates/base/src/lib/components/table/utils.test.ts
+++ b/web/generator/templates/base/src/lib/components/table/utils.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for ResourceTable utility functions:
+ * - isServerSortable
+ * - isServerFilterable
+ * - computeTableMode
+ * - mrtSortingToSorts
+ * - mrtFiltersToParams
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isServerSortable,
+  isServerFilterable,
+  computeTableMode,
+  mrtSortingToSorts,
+  mrtFiltersToParams,
+} from './utils';
+
+// ---------------------------------------------------------------------------
+// isServerSortable
+// ---------------------------------------------------------------------------
+
+describe('isServerSortable', () => {
+  it('returns true for meta sort keys', () => {
+    expect(isServerSortable('resource_id')).toBe(true);
+    expect(isServerSortable('created_time')).toBe(true);
+    expect(isServerSortable('updated_time')).toBe(true);
+  });
+
+  it('returns false for non-sortable meta columns', () => {
+    expect(isServerSortable('created_by')).toBe(false);
+    expect(isServerSortable('updated_by')).toBe(false);
+    expect(isServerSortable('schema_version')).toBe(false);
+    expect(isServerSortable('is_deleted')).toBe(false);
+    expect(isServerSortable('current_revision_id')).toBe(false);
+  });
+
+  it('returns true for indexed data fields', () => {
+    expect(isServerSortable('level', ['level', 'name'])).toBe(true);
+    expect(isServerSortable('name', ['level', 'name'])).toBe(true);
+  });
+
+  it('returns false for non-indexed data fields', () => {
+    expect(isServerSortable('description', ['level', 'name'])).toBe(false);
+  });
+
+  it('returns false for data fields when indexedFields is undefined', () => {
+    expect(isServerSortable('level')).toBe(false);
+    expect(isServerSortable('level', undefined)).toBe(false);
+  });
+
+  it('returns false for data fields when indexedFields is empty', () => {
+    expect(isServerSortable('level', [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isServerFilterable
+// ---------------------------------------------------------------------------
+
+describe('isServerFilterable', () => {
+  it('returns true for dedicated meta filter columns', () => {
+    expect(isServerFilterable('created_by')).toBe(true);
+    expect(isServerFilterable('updated_by')).toBe(true);
+    expect(isServerFilterable('is_deleted')).toBe(true);
+  });
+
+  it('returns false for meta columns without dedicated filter support', () => {
+    expect(isServerFilterable('created_time')).toBe(false);
+    expect(isServerFilterable('updated_time')).toBe(false);
+    expect(isServerFilterable('resource_id')).toBe(false);
+    expect(isServerFilterable('current_revision_id')).toBe(false);
+    expect(isServerFilterable('schema_version')).toBe(false);
+  });
+
+  it('returns true for indexed data fields', () => {
+    expect(isServerFilterable('level', ['level', 'name'])).toBe(true);
+  });
+
+  it('returns false for non-indexed data fields', () => {
+    expect(isServerFilterable('description', ['level', 'name'])).toBe(false);
+    expect(isServerFilterable('description')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTableMode
+// ---------------------------------------------------------------------------
+
+describe('computeTableMode', () => {
+  const base = {
+    debouncedGlobalFilter: '',
+    sorting: [] as any[],
+    columnFilters: [] as any[],
+    indexedFields: ['level', 'name'],
+  };
+
+  it('returns "server" with no triggers', () => {
+    expect(computeTableMode(base)).toBe('server');
+  });
+
+  it('returns "client" when globalFilter is non-empty', () => {
+    expect(computeTableMode({ ...base, debouncedGlobalFilter: 'hello' })).toBe('client');
+  });
+
+  it('returns "server" when sorting on server-sortable meta column', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'created_time', desc: false }] }),
+    ).toBe('server');
+  });
+
+  it('returns "server" when sorting on indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'level', desc: true }] }),
+    ).toBe('server');
+  });
+
+  it('returns "client" when sorting on non-server-sortable column', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'created_by', desc: false }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when sorting on non-indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, sorting: [{ id: 'description', desc: false }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when mixed sorts include a non-sortable column', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        sorting: [
+          { id: 'created_time', desc: false },
+          { id: 'description', desc: true },
+        ],
+      }),
+    ).toBe('client');
+  });
+
+  it('returns "server" when column filter targets server-filterable column', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'created_by', value: 'admin' }] }),
+    ).toBe('server');
+  });
+
+  it('returns "server" when column filter targets indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'level', value: '5' }] }),
+    ).toBe('server');
+  });
+
+  it('returns "client" when column filter targets non-filterable column', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'created_time', value: '2024' }] }),
+    ).toBe('client');
+  });
+
+  it('returns "client" when column filter targets non-indexed data field', () => {
+    expect(
+      computeTableMode({ ...base, columnFilters: [{ id: 'description', value: 'test' }] }),
+    ).toBe('client');
+  });
+
+  it('ignores empty/null filter values', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        columnFilters: [
+          { id: 'description', value: '' },
+          { id: 'description', value: null },
+        ],
+      }),
+    ).toBe('server');
+  });
+
+  it('returns "client" on combined triggers', () => {
+    expect(
+      computeTableMode({
+        ...base,
+        debouncedGlobalFilter: 'search',
+        sorting: [{ id: 'description', desc: false }],
+        columnFilters: [{ id: 'resource_id', value: 'abc' }],
+      }),
+    ).toBe('client');
+  });
+
+  it('returns "client" for any data sort when indexedFields is undefined', () => {
+    expect(
+      computeTableMode({
+        debouncedGlobalFilter: '',
+        sorting: [{ id: 'level', desc: false }],
+        columnFilters: [],
+        indexedFields: undefined,
+      }),
+    ).toBe('client');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mrtSortingToSorts
+// ---------------------------------------------------------------------------
+
+describe('mrtSortingToSorts', () => {
+  it('returns empty string for empty sorting', () => {
+    expect(mrtSortingToSorts([])).toBe('');
+  });
+
+  it('converts meta sort key ascending', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'created_time', desc: false }]));
+    expect(result).toEqual([{ type: 'meta', key: 'created_time', direction: '+' }]);
+  });
+
+  it('converts meta sort key descending', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'resource_id', desc: true }]));
+    expect(result).toEqual([{ type: 'meta', key: 'resource_id', direction: '-' }]);
+  });
+
+  it('converts indexed data field sort', () => {
+    const result = JSON.parse(mrtSortingToSorts([{ id: 'level', desc: false }], ['level']));
+    expect(result).toEqual([{ type: 'data', field_path: 'level', direction: '+' }]);
+  });
+
+  it('omits non-server-sortable columns', () => {
+    expect(mrtSortingToSorts([{ id: 'description', desc: false }], ['level'])).toBe('');
+  });
+
+  it('handles mixed sortable and non-sortable columns', () => {
+    const result = JSON.parse(
+      mrtSortingToSorts(
+        [
+          { id: 'created_time', desc: false },
+          { id: 'description', desc: true },
+          { id: 'level', desc: true },
+        ],
+        ['level'],
+      ),
+    );
+    expect(result).toEqual([
+      { type: 'meta', key: 'created_time', direction: '+' },
+      { type: 'data', field_path: 'level', direction: '-' },
+    ]);
+  });
+
+  it('returns empty string when all columns are non-sortable', () => {
+    expect(
+      mrtSortingToSorts(
+        [
+          { id: 'created_by', desc: false },
+          { id: 'description', desc: true },
+        ],
+        [],
+      ),
+    ).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mrtFiltersToParams
+// ---------------------------------------------------------------------------
+
+describe('mrtFiltersToParams', () => {
+  it('returns empty results for empty filters', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('converts created_by filter to created_bys param', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_by', value: 'admin' },
+    ]);
+    expect(serverParams).toEqual({ created_bys: ['admin'] });
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('converts updated_by filter to updated_bys param', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'updated_by', value: 'user1' }]);
+    expect(serverParams).toEqual({ updated_bys: ['user1'] });
+  });
+
+  it('converts is_deleted filter to boolean param', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'is_deleted', value: 'true' }]);
+    expect(serverParams).toEqual({ is_deleted: true });
+  });
+
+  it('converts is_deleted "false" string correctly', () => {
+    const { serverParams } = mrtFiltersToParams([{ id: 'is_deleted', value: 'false' }]);
+    expect(serverParams).toEqual({ is_deleted: false });
+  });
+
+  it('converts indexed data field string to contains condition', () => {
+    const { dataConditions } = mrtFiltersToParams(
+      [{ id: 'name', value: 'alice' }],
+      ['name', 'level'],
+    );
+    expect(dataConditions).toEqual([{ field_path: 'name', operator: 'contains', value: 'alice' }]);
+  });
+
+  it('converts indexed data field number to eq condition', () => {
+    const { dataConditions } = mrtFiltersToParams([{ id: 'level', value: 5 }], ['level']);
+    expect(dataConditions).toEqual([{ field_path: 'level', operator: 'eq', value: 5 }]);
+  });
+
+  it('ignores non-filterable columns', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_time', value: '2024-01-01' },
+      { id: 'description', value: 'test' },
+    ]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('ignores empty and null values', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams([
+      { id: 'created_by', value: '' },
+      { id: 'created_by', value: null },
+    ]);
+    expect(serverParams).toEqual({});
+    expect(dataConditions).toEqual([]);
+  });
+
+  it('handles mixed meta and indexed data filters', () => {
+    const { serverParams, dataConditions } = mrtFiltersToParams(
+      [
+        { id: 'created_by', value: 'admin' },
+        { id: 'name', value: 'bob' },
+        { id: 'description', value: 'ignored' },
+      ],
+      ['name'],
+    );
+    expect(serverParams).toEqual({ created_bys: ['admin'] });
+    expect(dataConditions).toEqual([{ field_path: 'name', operator: 'contains', value: 'bob' }]);
+  });
+});

--- a/web/generator/templates/base/src/lib/components/table/utils.ts
+++ b/web/generator/templates/base/src/lib/components/table/utils.ts
@@ -2,7 +2,169 @@
  * Resource Table 工具函數
  */
 
+import type { MRT_ColumnFiltersState, MRT_SortingState } from 'mantine-react-table';
 import type { MetaFilters, SearchCondition } from './types';
+
+// ---------------------------------------------------------------------------
+// Server-capability constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Meta columns that the backend can sort on.
+ * Corresponds to ResourceMetaSortKey in autocrud/types.py.
+ */
+export const SERVER_META_SORT_KEYS = ['resource_id', 'created_time', 'updated_time'] as const;
+
+/**
+ * Meta columns that the backend can filter on via dedicated query params.
+ * Maps column id → the backend query parameter name(s) and conversion strategy.
+ */
+export const SERVER_META_FILTER_COLUMNS: Record<
+  string,
+  { paramName: string; convert: (value: unknown) => Record<string, unknown> }
+> = {
+  created_by: {
+    paramName: 'created_bys',
+    convert: (v) => ({ created_bys: [String(v)] }),
+  },
+  updated_by: {
+    paramName: 'updated_bys',
+    convert: (v) => ({ updated_bys: [String(v)] }),
+  },
+  is_deleted: {
+    paramName: 'is_deleted',
+    convert: (v) => {
+      const str = String(v).toLowerCase();
+      return { is_deleted: str === 'true' || str === '1' };
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Server-capability queries
+// ---------------------------------------------------------------------------
+
+/** Check whether a column can be sorted server-side. */
+export function isServerSortable(columnId: string, indexedFields?: string[]): boolean {
+  if ((SERVER_META_SORT_KEYS as readonly string[]).includes(columnId)) return true;
+  if (indexedFields && indexedFields.includes(columnId)) return true;
+  return false;
+}
+
+/** Check whether a column can be filtered server-side. */
+export function isServerFilterable(columnId: string, indexedFields?: string[]): boolean {
+  if (columnId in SERVER_META_FILTER_COLUMNS) return true;
+  if (indexedFields && indexedFields.includes(columnId)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Table mode computation
+// ---------------------------------------------------------------------------
+
+export type TableMode = 'server' | 'client';
+
+export interface ComputeTableModeArgs {
+  debouncedGlobalFilter: string;
+  sorting: MRT_SortingState;
+  columnFilters: MRT_ColumnFiltersState;
+  indexedFields?: string[];
+}
+
+/**
+ * Determine whether the table should operate in server or client mode.
+ *
+ * Returns 'client' when any operation requires client-side processing:
+ *  - globalFilter is non-empty (free-text search across all fields)
+ *  - any column sort targets a non-server-sortable column
+ *  - any column filter targets a non-server-filterable column
+ */
+export function computeTableMode({
+  debouncedGlobalFilter,
+  sorting,
+  columnFilters,
+  indexedFields,
+}: ComputeTableModeArgs): TableMode {
+  // Trigger 1: global free-text filter
+  if (debouncedGlobalFilter) return 'client';
+
+  // Trigger 2: non-server-sortable column in MRT sorting
+  for (const sort of sorting) {
+    if (!isServerSortable(sort.id, indexedFields)) return 'client';
+  }
+
+  // Trigger 3: non-server-filterable column in MRT column filters
+  for (const filter of columnFilters) {
+    if (filter.value == null || filter.value === '') continue;
+    if (!isServerFilterable(filter.id, indexedFields)) return 'client';
+  }
+
+  return 'server';
+}
+
+// ---------------------------------------------------------------------------
+// MRT state → backend params conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert MRT sorting state to backend `sorts` JSON string.
+ * Only includes server-sortable columns; non-sortable ones are omitted
+ * (they'll be handled client-side by MRT).
+ */
+export function mrtSortingToSorts(
+  sorting: MRT_SortingState,
+  indexedFields?: string[],
+): string {
+  const serverSorts = sorting.filter((s) => isServerSortable(s.id, indexedFields));
+  if (serverSorts.length === 0) return '';
+
+  const sortsArray = serverSorts.map((s) => {
+    const direction = s.desc ? '-' : '+';
+    if ((SERVER_META_SORT_KEYS as readonly string[]).includes(s.id)) {
+      return { type: 'meta', key: s.id, direction };
+    }
+    return { type: 'data', field_path: s.id, direction };
+  });
+
+  return JSON.stringify(sortsArray);
+}
+
+/**
+ * Convert MRT column filters to backend query params.
+ * Only includes server-filterable columns. Returns an object with
+ * backend param keys ready to merge into the request params.
+ *
+ * - Meta filter columns → dedicated params (created_bys, updated_bys, is_deleted)
+ * - Indexed data columns → data_conditions array (string uses "contains", others "eq")
+ */
+export function mrtFiltersToParams(
+  columnFilters: MRT_ColumnFiltersState,
+  indexedFields?: string[],
+): { serverParams: Record<string, unknown>; dataConditions: Array<{ field_path: string; operator: string; value: unknown }> } {
+  const serverParams: Record<string, unknown> = {};
+  const dataConditions: Array<{ field_path: string; operator: string; value: unknown }> = [];
+
+  for (const filter of columnFilters) {
+    if (filter.value == null || filter.value === '') continue;
+
+    // Meta filter columns
+    const metaDef = SERVER_META_FILTER_COLUMNS[filter.id];
+    if (metaDef) {
+      Object.assign(serverParams, metaDef.convert(filter.value));
+      continue;
+    }
+
+    // Indexed data columns
+    if (indexedFields && indexedFields.includes(filter.id)) {
+      const value = filter.value;
+      // Use "contains" for strings, "eq" for everything else
+      const operator = typeof value === 'string' ? 'contains' : 'eq';
+      dataConditions.push({ field_path: filter.id, operator, value });
+    }
+  }
+
+  return { serverParams, dataConditions };
+}
 
 /**
  * 將 ISO 時間字串轉換為 Python dt.datetime(...) 格式


### PR DESCRIPTION
Implement lazy upgrade mechanism for ResourceTable that automatically switches between server-side and client-side modes based on user operations.

Server mode (default):
- Pagination, sorting, filtering delegated to backend API
- Efficient for large datasets with indexed fields

Client mode (auto-triggered):
- Activated by global free-text search, non-indexed column sort/filter
- Fetches up to 1000 items sorted by updated_time desc (most recent first)
- MRT handles pagination, sorting, filtering locally
- Shows cutoff message: "僅載入 {timestamp} 之後更新的資料，尚有 N 筆未載入"

Changes:
- utils.ts: Add isServerSortable(), isServerFilterable(), computeTableMode(), mrtSortingToSorts(), mrtFiltersToParams() helper functions
- ResourceTable.tsx: Rewrite with hybrid mode, 1s debounced globalFilter, mode badge indicator, client overflow info display
- utils.test.ts: Add 41 unit tests for all new helper functions
- Sync generator templates

All 711 tests passing, 0 TypeScript errors.


fixes #156 fixes #157 