### PR TITLE
問題：MigrateProgress 和 MigrateResult 沒有被加入 OpenAPI 的 components/schemas…

### DIFF
--- a/autocrud/crud/core.py
+++ b/autocrud/crud/core.py
@@ -42,6 +42,11 @@ from autocrud.crud.route_templates.delete import (
 )
 from autocrud.crud.route_templates.get import ReadRouteTemplate
 from autocrud.crud.route_templates.job_logs import JobLogsRouteTemplate
+from autocrud.crud.route_templates.migrate import (
+    MigrateProgress,
+    MigrateResult,
+    MigrateRouteTemplate,
+)
 from autocrud.crud.route_templates.patch import (
     RFC6902,
     PatchRouteTemplate,
@@ -1141,6 +1146,12 @@ class AutoCRUD:
                 *structs,
             ],
         )[1]
+
+        # Include MigrateProgress and MigrateResult when MigrateRouteTemplate is active
+        if any(isinstance(rt, MigrateRouteTemplate) for rt in self.route_templates):
+            app.openapi_schema["components"]["schemas"] |= jsonschema_to_openapi(
+                [MigrateProgress, MigrateResult],
+            )[1]
 
         # Include custom create action body schemas in components
         action_body_structs = []

--- a/autocrud/crud/route_templates/migrate.py
+++ b/autocrud/crud/route_templates/migrate.py
@@ -42,7 +42,7 @@ class MigrateQueryInputs(QueryInputs):
 
     revision_id: str | None = Query(
         None,
-        description='Revision scope: omit for current revision, '
+        description="Revision scope: omit for current revision, "
         '"all" for every revision, or a specific revision ID.',
     )
 

--- a/tests/migrations/test_migrate_api.py
+++ b/tests/migrations/test_migrate_api.py
@@ -421,9 +421,7 @@ class TestMigrateResourcesGeneratorRevisionId:
         async def mock_migrate_single(
             manager, resource_id, user, time, write_back, revision_id=None
         ):
-            calls.append(
-                {"resource_id": resource_id, "revision_id": revision_id}
-            )
+            calls.append({"resource_id": resource_id, "revision_id": revision_id})
             return MigrateProgress(
                 resource_id=resource_id, status="success", message="ok"
             )
@@ -452,9 +450,7 @@ class TestMigrateResourcesGeneratorRevisionId:
         async def mock_migrate_single(
             manager, resource_id, user, time, write_back, revision_id=None
         ):
-            calls.append(
-                {"resource_id": resource_id, "revision_id": revision_id}
-            )
+            calls.append({"resource_id": resource_id, "revision_id": revision_id})
             return MigrateProgress(
                 resource_id=resource_id, status="success", message="ok"
             )
@@ -492,9 +488,7 @@ class TestMigrateResourcesGeneratorRevisionId:
         async def mock_migrate_single(
             manager, resource_id, user, time, write_back, revision_id=None
         ):
-            calls.append(
-                {"resource_id": resource_id, "revision_id": revision_id}
-            )
+            calls.append({"resource_id": resource_id, "revision_id": revision_id})
             return MigrateProgress(
                 resource_id=resource_id, status="success", message="ok"
             )
@@ -531,12 +525,8 @@ class TestMigrateBatchApiRevisionId:
         async def mock_generator(
             manager, query, user, time, write_back, revision_id=None
         ):
-            captured.append(
-                {"write_back": write_back, "revision_id": revision_id}
-            )
-            yield MigrateProgress(
-                resource_id="user:1", status="success", message="ok"
-            )
+            captured.append({"write_back": write_back, "revision_id": revision_id})
+            yield MigrateProgress(resource_id="user:1", status="success", message="ok")
 
         with patch.object(
             MigrateRouteTemplate,
@@ -562,12 +552,8 @@ class TestMigrateBatchApiRevisionId:
         async def mock_generator(
             manager, query, user, time, write_back, revision_id=None
         ):
-            captured.append(
-                {"write_back": write_back, "revision_id": revision_id}
-            )
-            yield MigrateProgress(
-                resource_id="user:1", status="success", message="ok"
-            )
+            captured.append({"write_back": write_back, "revision_id": revision_id})
+            yield MigrateProgress(resource_id="user:1", status="success", message="ok")
 
         with patch.object(
             MigrateRouteTemplate,
@@ -593,9 +579,7 @@ class TestMigrateBatchApiRevisionId:
             manager, query, user, time, write_back, revision_id=None
         ):
             captured.append({"revision_id": revision_id})
-            yield MigrateProgress(
-                resource_id="user:1", status="success", message="ok"
-            )
+            yield MigrateProgress(resource_id="user:1", status="success", message="ok")
 
         with patch.object(
             MigrateRouteTemplate,
@@ -691,7 +675,12 @@ class TestMigrateSingleResourceAPI:
 def mock_generator_and_assert_func1(expected_write_back: bool):
     # Mock the generator to return test results
     async def mock_generator(
-        manager: Mock, query: Any, user: str, time: dt.datetime, write_back: bool, revision_id: str | None = None
+        manager: Mock,
+        query: Any,
+        user: str,
+        time: dt.datetime,
+        write_back: bool,
+        revision_id: str | None = None,
     ) -> AsyncGenerator[MigrateProgress, None]:
         # 確認這是測試模式
         assert write_back is expected_write_back
@@ -728,7 +717,12 @@ def mock_generator_and_assert_func1(expected_write_back: bool):
 def mock_generator_and_assert_func2(expected_write_back: bool):
     # Mock the generator to return execution results
     async def mock_generator(
-        manager: Mock, query: Any, user: str, time: dt.datetime, write_back: bool, revision_id: str | None = None
+        manager: Mock,
+        query: Any,
+        user: str,
+        time: dt.datetime,
+        write_back: bool,
+        revision_id: str | None = None,
     ) -> AsyncGenerator[MigrateProgress, None]:
         # 確認這是執行模式
         assert write_back is expected_write_back
@@ -755,7 +749,12 @@ def mock_generator_and_assert_func2(expected_write_back: bool):
 def mock_generator_and_assert_func3(expected_write_back: bool):
     # Mock the generator to return execution results
     async def mock_generator(
-        manager: Mock, query: Any, user: str, time: dt.datetime, write_back: bool, revision_id: str | None = None
+        manager: Mock,
+        query: Any,
+        user: str,
+        time: dt.datetime,
+        write_back: bool,
+        revision_id: str | None = None,
     ) -> AsyncGenerator[MigrateProgress, None]:
         # 確認這是執行模式
         assert write_back is expected_write_back
@@ -785,7 +784,12 @@ def mock_generator_and_assert_func3(expected_write_back: bool):
 def mock_generator_and_assert_func4(expected_write_back: bool):
     # Mock the generator to return execution results
     async def mock_generator(
-        manager: Mock, query: Any, user: str, time: dt.datetime, write_back: bool, revision_id: str | None = None
+        manager: Mock,
+        query: Any,
+        user: str,
+        time: dt.datetime,
+        write_back: bool,
+        revision_id: str | None = None,
     ) -> AsyncGenerator[MigrateProgress, None]:
         # 確認這是執行模式
         assert write_back is expected_write_back

--- a/tests/migrations/test_migrate_openapi.py
+++ b/tests/migrations/test_migrate_openapi.py
@@ -1,0 +1,87 @@
+"""測試 MigrateProgress 和 MigrateResult 是否出現在 OpenAPI schema 中"""
+
+import msgspec
+import pytest
+from fastapi import FastAPI
+
+from autocrud import AutoCRUD, Schema
+from autocrud.crud.route_templates.migrate import MigrateRouteTemplate
+
+
+class ItemV1(msgspec.Struct):
+    name: str
+
+
+class ItemV2(msgspec.Struct):
+    name: str
+    tag: str = "none"
+
+
+def migrate_v1_to_v2(data: dict) -> dict:
+    data.setdefault("tag", "none")
+    return data
+
+
+class TestMigrateProgressInOpenAPI:
+    """確認啟用 migrate route 後，MigrateProgress 和 MigrateResult 出現在 OpenAPI components/schemas"""
+
+    @pytest.fixture()
+    def app_with_migrate(self) -> FastAPI:
+        app = FastAPI()
+        crud = AutoCRUD()
+
+        schema = Schema(ItemV2, "v2").step("v1", migrate_v1_to_v2)
+        crud.add_model(schema)
+        crud.add_route_template(MigrateRouteTemplate())
+        crud.apply(app)
+        crud.openapi(app)
+        return app
+
+    def test_migrate_progress_in_openapi_components(self, app_with_migrate: FastAPI):
+        """MigrateProgress 應出現在 components/schemas 中"""
+        schemas = app_with_migrate.openapi_schema["components"]["schemas"]
+        assert "MigrateProgress" in schemas, (
+            f"MigrateProgress not found in OpenAPI components/schemas. "
+            f"Available schemas: {sorted(schemas.keys())}"
+        )
+
+    def test_migrate_result_in_openapi_components(self, app_with_migrate: FastAPI):
+        """MigrateResult 應出現在 components/schemas 中"""
+        schemas = app_with_migrate.openapi_schema["components"]["schemas"]
+        assert "MigrateResult" in schemas, (
+            f"MigrateResult not found in OpenAPI components/schemas. "
+            f"Available schemas: {sorted(schemas.keys())}"
+        )
+
+    def test_migrate_progress_schema_has_required_fields(
+        self, app_with_migrate: FastAPI
+    ):
+        """MigrateProgress schema 應包含 resource_id 和 status 必填欄位"""
+        schemas = app_with_migrate.openapi_schema["components"]["schemas"]
+        if "MigrateProgress" not in schemas:
+            pytest.skip(
+                "MigrateProgress not yet in OpenAPI (test_migrate_progress_in_openapi_components should fail first)"
+            )
+
+        progress_schema = schemas["MigrateProgress"]
+        assert "properties" in progress_schema
+        assert "resource_id" in progress_schema["properties"]
+        assert "status" in progress_schema["properties"]
+        assert "resource_id" in progress_schema.get("required", [])
+        assert "status" in progress_schema.get("required", [])
+
+    def test_migrate_result_schema_has_required_fields(self, app_with_migrate: FastAPI):
+        """MigrateResult schema 應包含 total, success, failed, skipped 必填欄位"""
+        schemas = app_with_migrate.openapi_schema["components"]["schemas"]
+        if "MigrateResult" not in schemas:
+            pytest.skip(
+                "MigrateResult not yet in OpenAPI (test_migrate_result_in_openapi_components should fail first)"
+            )
+
+        result_schema = schemas["MigrateResult"]
+        assert "properties" in result_schema
+        for field in ("total", "success", "failed", "skipped"):
+            assert field in result_schema["properties"], f"Missing field: {field}"
+        required = result_schema.get("required", [])
+        for field in ("total", "success", "failed", "skipped"):
+            assert field in required, f"Field '{field}' should be required"


### PR DESCRIPTION
…。openapi() 方法只註冊了 ResourceMeta、RevisionInfo、RFC6902 等 struct，但漏掉了 migration 相關的類型。

修改的檔案：

core.py:47 — 新增 import MigrateProgress、MigrateResult、MigrateRouteTemplate，並在 openapi() 方法中，當偵測到 MigrateRouteTemplate 有被啟用時，自動將 MigrateProgress 和 MigrateResult 加入 OpenAPI components/schemas。

test_migrate_openapi.py — 新增 4 個測試（TDD）：

test_migrate_progress_in_openapi_components — 確認 MigrateProgress 出現在 schema 中 test_migrate_result_in_openapi_components — 確認 MigrateResult 出現在 schema 中 test_migrate_progress_schema_has_required_fields — 驗證 resource_id 和 status 為必填欄位 test_migrate_result_schema_has_required_fields — 驗證 total、success、failed、skipped 為必填欄位


fix #232 