### PR TITLE
在排序中增加兩層 tiebreaker

### DIFF
--- a/web/app/src/autocrud/lib/utils/revisionTree.test.ts
+++ b/web/app/src/autocrud/lib/utils/revisionTree.test.ts
@@ -259,6 +259,57 @@ describe('buildRevisionTreeLayout', () => {
     expect(layout.trunkIds.size).toBe(0);
   });
 
+  it('same timestamp: parent comes before child in asc order', () => {
+    // All three revisions have the exact same timestamp
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout = buildRevisionTreeLayout(
+      [rev('r1', null, sameTime), rev('r2', 'r1', sameTime), rev('r3', 'r2', sameTime)],
+      'asc',
+    );
+
+    const ids = layout.nodes.map((n) => n.id);
+    expect(ids).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('same timestamp: child comes before parent in desc order', () => {
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout = buildRevisionTreeLayout(
+      [rev('r1', null, sameTime), rev('r2', 'r1', sameTime), rev('r3', 'r2', sameTime)],
+      'desc',
+    );
+
+    const ids = layout.nodes.map((n) => n.id);
+    expect(ids).toEqual(['r3', 'r2', 'r1']);
+  });
+
+  it('same timestamp and depth: deterministic order by id', () => {
+    // Two branches from root at the same time — same depth, same time
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout1 = buildRevisionTreeLayout(
+      [
+        rev('root', null, sameTime),
+        rev('b-child', 'root', sameTime),
+        rev('a-child', 'root', sameTime),
+      ],
+      'asc',
+    );
+    const layout2 = buildRevisionTreeLayout(
+      [
+        rev('root', null, sameTime),
+        rev('a-child', 'root', sameTime),
+        rev('b-child', 'root', sameTime),
+      ],
+      'asc',
+    );
+
+    // Both should produce the same order regardless of input order
+    const ids1 = layout1.nodes.map((n) => n.id);
+    const ids2 = layout2.nodes.map((n) => n.id);
+    expect(ids1).toEqual(ids2);
+    // root first (depth 0), then children in id order
+    expect(ids1).toEqual(['root', 'a-child', 'b-child']);
+  });
+
   it('multiple roots: trunk root on lane 0, other roots on higher lanes', () => {
     // Two roots: root1 and root2. trunk passes through root1.
     const layout = buildRevisionTreeLayout(

--- a/web/app/src/autocrud/lib/utils/revisionTree.ts
+++ b/web/app/src/autocrud/lib/utils/revisionTree.ts
@@ -182,6 +182,25 @@ export function buildRevisionTreeLayout(
     }
   }
 
+  // --- Compute topological depth for stable tiebreaking ---
+  const depthMap = new Map<string, number>();
+  function getDepth(id: string): number {
+    if (depthMap.has(id)) {
+      return depthMap.get(id)!;
+    }
+    const item = byId.get(id);
+    if (!item || !item.parentId || !byId.has(item.parentId)) {
+      depthMap.set(id, 0);
+      return 0;
+    }
+    const depth = getDepth(item.parentId) + 1;
+    depthMap.set(id, depth);
+    return depth;
+  }
+  for (const item of items) {
+    getDepth(item.id);
+  }
+
   // Assign any remaining unassigned nodes via DFS from roots (handles fallback and edge cases)
   const itemsAsc = [...items].sort(sortByTimeAsc);
   for (const item of itemsAsc) {
@@ -214,8 +233,18 @@ export function buildRevisionTreeLayout(
   }
 
   const displayItems = [...items].sort((a, b) => {
-    const order = a.time.localeCompare(b.time);
-    return sortOrder === 'desc' ? -order : order;
+    const timeOrder = a.time.localeCompare(b.time);
+    if (timeOrder !== 0) {
+      return sortOrder === 'desc' ? -timeOrder : timeOrder;
+    }
+    // Tiebreaker 1: topological depth (parent before child in asc)
+    const depthOrder = (depthMap.get(a.id) ?? 0) - (depthMap.get(b.id) ?? 0);
+    if (depthOrder !== 0) {
+      return sortOrder === 'desc' ? -depthOrder : depthOrder;
+    }
+    // Tiebreaker 2: ID for deterministic ordering
+    const idOrder = a.id.localeCompare(b.id);
+    return sortOrder === 'desc' ? -idOrder : idOrder;
   });
 
   const nodes: RevisionTreeNode[] = displayItems.map((item, index) => {

--- a/web/generator/templates/base/src/autocrud/lib/utils/revisionTree.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/utils/revisionTree.test.ts
@@ -259,6 +259,65 @@ describe('buildRevisionTreeLayout', () => {
     expect(layout.trunkIds.size).toBe(0);
   });
 
+  it('same timestamp: parent comes before child in asc order', () => {
+    // All three revisions have the exact same timestamp
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout = buildRevisionTreeLayout(
+      [
+        rev('r1', null, sameTime),
+        rev('r2', 'r1', sameTime),
+        rev('r3', 'r2', sameTime),
+      ],
+      'asc',
+    );
+
+    const ids = layout.nodes.map((n) => n.id);
+    expect(ids).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('same timestamp: child comes before parent in desc order', () => {
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout = buildRevisionTreeLayout(
+      [
+        rev('r1', null, sameTime),
+        rev('r2', 'r1', sameTime),
+        rev('r3', 'r2', sameTime),
+      ],
+      'desc',
+    );
+
+    const ids = layout.nodes.map((n) => n.id);
+    expect(ids).toEqual(['r3', 'r2', 'r1']);
+  });
+
+  it('same timestamp and depth: deterministic order by id', () => {
+    // Two branches from root at the same time — same depth, same time
+    const sameTime = '2024-06-15T12:00:00Z';
+    const layout1 = buildRevisionTreeLayout(
+      [
+        rev('root', null, sameTime),
+        rev('b-child', 'root', sameTime),
+        rev('a-child', 'root', sameTime),
+      ],
+      'asc',
+    );
+    const layout2 = buildRevisionTreeLayout(
+      [
+        rev('root', null, sameTime),
+        rev('a-child', 'root', sameTime),
+        rev('b-child', 'root', sameTime),
+      ],
+      'asc',
+    );
+
+    // Both should produce the same order regardless of input order
+    const ids1 = layout1.nodes.map((n) => n.id);
+    const ids2 = layout2.nodes.map((n) => n.id);
+    expect(ids1).toEqual(ids2);
+    // root first (depth 0), then children in id order
+    expect(ids1).toEqual(['root', 'a-child', 'b-child']);
+  });
+
   it('multiple roots: trunk root on lane 0, other roots on higher lanes', () => {
     // Two roots: root1 and root2. trunk passes through root1.
     const layout = buildRevisionTreeLayout(

--- a/web/generator/templates/base/src/autocrud/lib/utils/revisionTree.ts
+++ b/web/generator/templates/base/src/autocrud/lib/utils/revisionTree.ts
@@ -182,6 +182,25 @@ export function buildRevisionTreeLayout(
     }
   }
 
+  // --- Compute topological depth for stable tiebreaking ---
+  const depthMap = new Map<string, number>();
+  function getDepth(id: string): number {
+    if (depthMap.has(id)) {
+      return depthMap.get(id)!;
+    }
+    const item = byId.get(id);
+    if (!item || !item.parentId || !byId.has(item.parentId)) {
+      depthMap.set(id, 0);
+      return 0;
+    }
+    const depth = getDepth(item.parentId) + 1;
+    depthMap.set(id, depth);
+    return depth;
+  }
+  for (const item of items) {
+    getDepth(item.id);
+  }
+
   // Assign any remaining unassigned nodes via DFS from roots (handles fallback and edge cases)
   const itemsAsc = [...items].sort(sortByTimeAsc);
   for (const item of itemsAsc) {
@@ -214,8 +233,18 @@ export function buildRevisionTreeLayout(
   }
 
   const displayItems = [...items].sort((a, b) => {
-    const order = a.time.localeCompare(b.time);
-    return sortOrder === 'desc' ? -order : order;
+    const timeOrder = a.time.localeCompare(b.time);
+    if (timeOrder !== 0) {
+      return sortOrder === 'desc' ? -timeOrder : timeOrder;
+    }
+    // Tiebreaker 1: topological depth (parent before child in asc)
+    const depthOrder = (depthMap.get(a.id) ?? 0) - (depthMap.get(b.id) ?? 0);
+    if (depthOrder !== 0) {
+      return sortOrder === 'desc' ? -depthOrder : depthOrder;
+    }
+    // Tiebreaker 2: ID for deterministic ordering
+    const idOrder = a.id.localeCompare(b.id);
+    return sortOrder === 'desc' ? -idOrder : idOrder;
   });
 
   const nodes: RevisionTreeNode[] = displayItems.map((item, index) => {


### PR DESCRIPTION
拓撲深度 (topological depth)：計算每個 node 到 root 的距離，parent 深度較小所以會排在 child 前面（asc 時） ID 字串比較：同深度同時間時，用 revision ID 做最終穩定排序

fix #257 