### PR TITLE
fix(web): support array values in SearchCondition for in/not_in opera…

### DIFF
--- a/tests/routes/test_qb_search_integration.py
+++ b/tests/routes/test_qb_search_integration.py
@@ -859,9 +859,7 @@ def test_qb_unsupported_ast_node(client: TestClient, sample_users: list[str]) ->
     assert "AST node type not supported" in response.json()["detail"]
 
 
-def test_qb_with_is_deleted_filter(
-    client: TestClient, sample_users: list[str]
-) -> None:
+def test_qb_with_is_deleted_filter(client: TestClient, sample_users: list[str]) -> None:
     """測試 QB 可以與 is_deleted 同時使用。
 
     Swagger UI 永遠會在 URL 帶上 is_deleted=false (因為有預設值)，

--- a/web/app/src/autocrud/lib/components/table/types.ts
+++ b/web/app/src/autocrud/lib/components/table/types.ts
@@ -13,7 +13,7 @@ import type { FullResourceRow } from '../../../types/api';
 export interface SearchCondition {
   field: string;
   operator: string;
-  value: string | number | boolean;
+  value: string | number | boolean | Array<string | number | boolean>;
 }
 
 /**

--- a/web/app/src/autocrud/lib/components/table/utils.test.ts
+++ b/web/app/src/autocrud/lib/components/table/utils.test.ts
@@ -828,6 +828,30 @@ describe('applyClientConditions', () => {
     expect(result).toHaveLength(1);
     expect(result[0].data.name).toBe('Bob');
   });
+
+  it('supports in operator with string array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'name', operator: 'in', value: ['Alice', 'Bob'] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.name)).toEqual(expect.arrayContaining(['Alice', 'Bob']));
+  });
+
+  it('supports not_in operator with string array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'name', operator: 'not_in', value: ['Alice'] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.name)).toEqual(expect.arrayContaining(['Bob', 'Charlie']));
+  });
+
+  it('supports in operator with number array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'level', operator: 'in', value: [10, 20] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.level)).toEqual(expect.arrayContaining([10, 20]));
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1081,6 +1105,25 @@ describe('conditionToQB', () => {
       [{ field: 'name', order: 'asc' }],
     );
     expect(result).toBe('QB["name"].contains("test").order_by("name")');
+  });
+
+  // --- in / not_in operators ---
+
+  it('generates in condition with string array', () => {
+    const result = conditionToQB({}, [
+      { field: 'status', operator: 'in', value: ['active', 'pending'] },
+    ]);
+    expect(result).toBe('QB["status"].in_(["active", "pending"])');
+  });
+
+  it('generates not_in condition with number array', () => {
+    const result = conditionToQB({}, [{ field: 'level', operator: 'not_in', value: [1, 2, 3] }]);
+    expect(result).toBe('QB["level"].not_in([1, 2, 3])');
+  });
+
+  it('generates in condition with number array', () => {
+    const result = conditionToQB({}, [{ field: 'score', operator: 'in', value: [10, 20] }]);
+    expect(result).toBe('QB["score"].in_([10, 20])');
   });
 });
 

--- a/web/app/src/autocrud/lib/components/table/utils.ts
+++ b/web/app/src/autocrud/lib/components/table/utils.ts
@@ -255,7 +255,11 @@ export function conditionToQB(
   // 轉換 Data conditions
   for (const cond of data) {
     const op = cond.operator;
-    const val = typeof cond.value === 'string' ? `"${cond.value}"` : cond.value;
+    const val = Array.isArray(cond.value)
+      ? `[${cond.value.map((v) => (typeof v === 'string' ? `"${v}"` : String(v))).join(', ')}]`
+      : typeof cond.value === 'string'
+        ? `"${cond.value}"`
+        : cond.value;
 
     // 使用 QB["field"] 語法
     const field = `QB["${cond.field}"]`;
@@ -290,6 +294,12 @@ export function conditionToQB(
         break;
       case 'ends_with':
         parts.push(`${field}.ends_with(${val})`);
+        break;
+      case 'in':
+        parts.push(`${field}.in_(${val})`);
+        break;
+      case 'not_in':
+        parts.push(`${field}.not_in(${val})`);
         break;
       default:
         parts.push(`(${field} == ${val})`);
@@ -619,6 +629,10 @@ export function applyClientConditions(rows: any[], conditions: SearchCondition[]
           return String(fieldValue ?? '').startsWith(String(condValue));
         case 'ends_with':
           return String(fieldValue ?? '').endsWith(String(condValue));
+        case 'in':
+          return Array.isArray(condValue) && condValue.some((v) => fieldValue == v);
+        case 'not_in':
+          return !Array.isArray(condValue) || condValue.every((v) => fieldValue != v);
         default:
           return fieldValue == condValue;
       }

--- a/web/app/src/autocrud/lib/hooks/useAdvancedSearch.ts
+++ b/web/app/src/autocrud/lib/hooks/useAdvancedSearch.ts
@@ -180,7 +180,7 @@ export function mrtFiltersToConditions(columnFilters: MRT_ColumnFiltersState): {
     dataConditions.push({
       field: filter.id,
       operator,
-      value: filter.value as string | number | boolean,
+      value: filter.value as string | number | boolean | Array<string | number | boolean>,
     });
   }
 

--- a/web/generator/templates/base/src/autocrud/lib/components/table/types.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/table/types.ts
@@ -13,7 +13,7 @@ import type { FullResourceRow } from '../../../types/api';
 export interface SearchCondition {
   field: string;
   operator: string;
-  value: string | number | boolean;
+  value: string | number | boolean | Array<string | number | boolean>;
 }
 
 /**

--- a/web/generator/templates/base/src/autocrud/lib/components/table/utils.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/table/utils.test.ts
@@ -828,6 +828,30 @@ describe('applyClientConditions', () => {
     expect(result).toHaveLength(1);
     expect(result[0].data.name).toBe('Bob');
   });
+
+  it('supports in operator with string array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'name', operator: 'in', value: ['Alice', 'Bob'] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.name)).toEqual(expect.arrayContaining(['Alice', 'Bob']));
+  });
+
+  it('supports not_in operator with string array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'name', operator: 'not_in', value: ['Alice'] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.name)).toEqual(expect.arrayContaining(['Bob', 'Charlie']));
+  });
+
+  it('supports in operator with number array', () => {
+    const result = applyClientConditions(rows, [
+      { field: 'level', operator: 'in', value: [10, 20] },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.data.level)).toEqual(expect.arrayContaining([10, 20]));
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1081,6 +1105,29 @@ describe('conditionToQB', () => {
       [{ field: 'name', order: 'asc' }],
     );
     expect(result).toBe('QB["name"].contains("test").order_by("name")');
+  });
+
+  // --- in / not_in operators ---
+
+  it('generates in condition with string array', () => {
+    const result = conditionToQB({}, [
+      { field: 'status', operator: 'in', value: ['active', 'pending'] },
+    ]);
+    expect(result).toBe('QB["status"].in_(["active", "pending"])');
+  });
+
+  it('generates not_in condition with number array', () => {
+    const result = conditionToQB({}, [
+      { field: 'level', operator: 'not_in', value: [1, 2, 3] },
+    ]);
+    expect(result).toBe('QB["level"].not_in([1, 2, 3])');
+  });
+
+  it('generates in condition with number array', () => {
+    const result = conditionToQB({}, [
+      { field: 'score', operator: 'in', value: [10, 20] },
+    ]);
+    expect(result).toBe('QB["score"].in_([10, 20])');
   });
 });
 

--- a/web/generator/templates/base/src/autocrud/lib/components/table/utils.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/table/utils.ts
@@ -255,7 +255,11 @@ export function conditionToQB(
   // 轉換 Data conditions
   for (const cond of data) {
     const op = cond.operator;
-    const val = typeof cond.value === 'string' ? `"${cond.value}"` : cond.value;
+    const val = Array.isArray(cond.value)
+      ? `[${cond.value.map((v) => (typeof v === 'string' ? `"${v}"` : String(v))).join(', ')}]`
+      : typeof cond.value === 'string'
+        ? `"${cond.value}"`
+        : cond.value;
 
     // 使用 QB["field"] 語法
     const field = `QB["${cond.field}"]`;
@@ -290,6 +294,12 @@ export function conditionToQB(
         break;
       case 'ends_with':
         parts.push(`${field}.ends_with(${val})`);
+        break;
+      case 'in':
+        parts.push(`${field}.in_(${val})`);
+        break;
+      case 'not_in':
+        parts.push(`${field}.not_in(${val})`);
         break;
       default:
         parts.push(`(${field} == ${val})`);
@@ -619,6 +629,10 @@ export function applyClientConditions(rows: any[], conditions: SearchCondition[]
           return String(fieldValue ?? '').startsWith(String(condValue));
         case 'ends_with':
           return String(fieldValue ?? '').endsWith(String(condValue));
+        case 'in':
+          return Array.isArray(condValue) && condValue.some((v) => fieldValue == v);
+        case 'not_in':
+          return !Array.isArray(condValue) || condValue.every((v) => fieldValue != v);
         default:
           return fieldValue == condValue;
       }

--- a/web/generator/templates/base/src/autocrud/lib/hooks/useAdvancedSearch.ts
+++ b/web/generator/templates/base/src/autocrud/lib/hooks/useAdvancedSearch.ts
@@ -180,7 +180,7 @@ export function mrtFiltersToConditions(columnFilters: MRT_ColumnFiltersState): {
     dataConditions.push({
       field: filter.id,
       operator,
-      value: filter.value as string | number | boolean,
+      value: filter.value as string | number | boolean | Array<string | number | boolean>,
     });
   }
 


### PR DESCRIPTION

## Problem

`SearchCondition.value` was typed as `string | number | boolean`, which excluded arrays. This caused two bugs:

1. **TypeScript type error** — passing an array value (e.g. `['active', 'pending']`) to `in`/`not_in` conditions was rejected at compile time
2. **Wrong QB output** — `conditionToQB()` had no `case 'in'` / `case 'not_in'`, so both operators fell through to `default`, generating incorrect `(field == value)` syntax instead of `field.in_([...])`

## Changes

### types.ts
- Extended `SearchCondition.value` type: `string | number | boolean` → `string | number | boolean | Array<string | number | boolean>`

### utils.ts
- `conditionToQB()`: added `case 'in'` / `case 'not_in'` generating correct QB syntax (`field.in_(["a","b"])`) aligned with `qb_parser.py` allowed methods
- `conditionToQB()`: updated value serializer to handle arrays (elements individually quoted/unquoted)
- `applyClientConditions()`: added `case 'in'` / `case 'not_in'` for client-side filtering using `Array.isArray` check

### useAdvancedSearch.ts
- Updated MRT filter value cast to include array type

### Generator templates (mirrored)
- Same fixes applied to all three files under base
- Added `in`/`not_in` test cases to `generator/templates/.../utils.test.ts` so generated apps include these tests

## Testing

- Added 6 new test cases (TDD — written before implementation):
  - `applyClientConditions`: `in` with string array, `not_in` with string array, `in` with number array
  - `conditionToQB`: `in` with string array, `not_in` with number array, `in` with number array
- All 1955 tests pass