### PR TITLE
fix(web): show toast notification on upload failure and zod validation error in form mode

### DIFF
--- a/web/app/src/autocrud/lib/components/form/useResourceForm.test.ts
+++ b/web/app/src/autocrud/lib/components/form/useResourceForm.test.ts
@@ -8,6 +8,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { useResourceForm } from './useResourceForm';
+import { notifications } from '@mantine/notifications';
+import { uploadFileToBlob } from '../../hooks/useBlobUpload';
+import { processSubmitValues } from '@/autocrud/lib/utils/formUtils';
 
 import {
   computeVisibleFieldsAndGroups,
@@ -65,6 +68,11 @@ vi.mock('../../hooks/useBlobUpload', () => ({
 // ── Mock mantine-form-zod-resolver ──
 vi.mock('mantine-form-zod-resolver', () => ({
   zodResolver: vi.fn(() => vi.fn(() => ({}))),
+}));
+
+// ── Mock @mantine/notifications ──
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: vi.fn() },
 }));
 
 beforeEach(() => {
@@ -545,5 +553,76 @@ describe('useResourceForm — internal helpers', () => {
     });
 
     expect(computeDepthTransitionUpdates).toHaveBeenCalled();
+  });
+});
+
+describe('useResourceForm — error notifications', () => {
+  it('handleSubmit upload failure shows toast notification', async () => {
+    const onSubmit = vi.fn();
+    const fields = [makeField('avatar', 'binary')];
+
+    // Make processSubmitValues return a binary field to trigger upload path
+    vi.mocked(processSubmitValues).mockReturnValueOnce({
+      skippedBinaryFields: ['avatar'],
+      binarySubFieldKeys: [],
+    } as any);
+
+    const uploadError = Object.assign(new Error('Network error'), {
+      response: { data: { detail: 'S3 unreachable' } },
+    });
+    vi.mocked(uploadFileToBlob).mockRejectedValueOnce(uploadError);
+
+    const { result } = renderUseResourceForm({
+      onSubmit,
+      config: { fields },
+    });
+
+    await act(async () => {
+      await result.current
+        .handleSubmit({
+          avatar: { _mode: 'file', file: new File(['x'], 'img.png') },
+        } as any)
+        .catch(() => {});
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(vi.mocked(notifications.show)).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'red', message: 'S3 unreachable' }),
+    );
+  });
+
+  it('handleSubmit zod post-validation failure shows toast notification', async () => {
+    const onSubmit = vi.fn();
+    const zodSchema = {
+      safeParse: vi.fn(() => ({
+        success: false,
+        error: {
+          issues: [
+            { path: ['name'], message: 'Too short' },
+            { path: ['age'], message: 'Must be positive' },
+          ],
+        },
+      })),
+    };
+
+    const { result } = renderUseResourceForm({
+      onSubmit,
+      config: {
+        zodSchema,
+        fields: [makeField('name'), makeField('age', 'number')],
+      },
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({ name: 'x', age: -1 } as any);
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(vi.mocked(notifications.show)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'red',
+        message: expect.stringContaining('Too short'),
+      }),
+    );
   });
 });

--- a/web/app/src/autocrud/lib/components/form/useResourceForm.ts
+++ b/web/app/src/autocrud/lib/components/form/useResourceForm.ts
@@ -9,6 +9,7 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useForm, type UseFormReturnType } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
+import { notifications } from '@mantine/notifications';
 import type { ResourceConfig, ResourceField } from '../../resources';
 import {
   getByPath,
@@ -541,6 +542,13 @@ export function useResourceForm<T extends Record<string, any>>({
             isUploading: false,
             error: msg,
           }));
+          notifications.show({
+            title: 'Upload Failed',
+            message: msg,
+            color: 'red',
+            autoClose: 8000,
+            withCloseButton: true,
+          });
           blobAbortRef.current = null;
           throw uploadError;
         }
@@ -562,6 +570,21 @@ export function useResourceForm<T extends Record<string, any>>({
           for (const issue of result.error.issues) {
             form.setFieldError(issue.path.join('.'), issue.message);
           }
+          const errorMessages = result.error.issues
+            .map((issue: { path: PropertyKey[]; message: string }) => {
+              const path = issue.path.map(String).join('.');
+              const fieldDef = config.fields.find((f) => f.name === path);
+              const label = fieldDef?.label || path || 'Root';
+              return `${label}: ${issue.message}`;
+            })
+            .join('\n');
+          notifications.show({
+            title: 'Validation Failed',
+            message: errorMessages,
+            color: 'red',
+            autoClose: 8000,
+            withCloseButton: true,
+          });
           return;
         }
       }

--- a/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.test.ts
@@ -8,6 +8,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
 import { useResourceForm } from './useResourceForm';
+import { notifications } from '@mantine/notifications';
+import { uploadFileToBlob } from '../../hooks/useBlobUpload';
+import { processSubmitValues } from '@/autocrud/lib/utils/formUtils';
 
 import {
   computeVisibleFieldsAndGroups,
@@ -65,6 +68,11 @@ vi.mock('../../hooks/useBlobUpload', () => ({
 // ── Mock mantine-form-zod-resolver ──
 vi.mock('mantine-form-zod-resolver', () => ({
   zodResolver: vi.fn(() => vi.fn(() => ({}))),
+}));
+
+// ── Mock @mantine/notifications ──
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: vi.fn() },
 }));
 
 beforeEach(() => {
@@ -545,5 +553,76 @@ describe('useResourceForm — internal helpers', () => {
     });
 
     expect(computeDepthTransitionUpdates).toHaveBeenCalled();
+  });
+});
+
+describe('useResourceForm — error notifications', () => {
+  it('handleSubmit upload failure shows toast notification', async () => {
+    const onSubmit = vi.fn();
+    const fields = [makeField('avatar', 'binary')];
+
+    // Make processSubmitValues return a binary field to trigger upload path
+    vi.mocked(processSubmitValues).mockReturnValueOnce({
+      skippedBinaryFields: ['avatar'],
+      binarySubFieldKeys: [],
+    } as any);
+
+    const uploadError = Object.assign(new Error('Network error'), {
+      response: { data: { detail: 'S3 unreachable' } },
+    });
+    vi.mocked(uploadFileToBlob).mockRejectedValueOnce(uploadError);
+
+    const { result } = renderUseResourceForm({
+      onSubmit,
+      config: { fields },
+    });
+
+    await act(async () => {
+      await result.current
+        .handleSubmit({
+          avatar: { _mode: 'file', file: new File(['x'], 'img.png') },
+        } as any)
+        .catch(() => {});
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(vi.mocked(notifications.show)).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'red', message: 'S3 unreachable' }),
+    );
+  });
+
+  it('handleSubmit zod post-validation failure shows toast notification', async () => {
+    const onSubmit = vi.fn();
+    const zodSchema = {
+      safeParse: vi.fn(() => ({
+        success: false,
+        error: {
+          issues: [
+            { path: ['name'], message: 'Too short' },
+            { path: ['age'], message: 'Must be positive' },
+          ],
+        },
+      })),
+    };
+
+    const { result } = renderUseResourceForm({
+      onSubmit,
+      config: {
+        zodSchema,
+        fields: [makeField('name'), makeField('age', 'number')],
+      },
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({ name: 'x', age: -1 } as any);
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(vi.mocked(notifications.show)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'red',
+        message: expect.stringContaining('Too short'),
+      }),
+    );
   });
 });

--- a/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.ts
@@ -9,6 +9,7 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useForm, type UseFormReturnType } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
+import { notifications } from '@mantine/notifications';
 import type { ResourceConfig, ResourceField } from '../../resources';
 import {
   getByPath,
@@ -541,6 +542,13 @@ export function useResourceForm<T extends Record<string, any>>({
             isUploading: false,
             error: msg,
           }));
+          notifications.show({
+            title: 'Upload Failed',
+            message: msg,
+            color: 'red',
+            autoClose: 8000,
+            withCloseButton: true,
+          });
           blobAbortRef.current = null;
           throw uploadError;
         }
@@ -562,6 +570,21 @@ export function useResourceForm<T extends Record<string, any>>({
           for (const issue of result.error.issues) {
             form.setFieldError(issue.path.join('.'), issue.message);
           }
+          const errorMessages = result.error.issues
+            .map((issue: { path: PropertyKey[]; message: string }) => {
+              const path = issue.path.map(String).join('.');
+              const fieldDef = config.fields.find((f) => f.name === path);
+              const label = fieldDef?.label || path || 'Root';
+              return `${label}: ${issue.message}`;
+            })
+            .join('\n');
+          notifications.show({
+            title: 'Validation Failed',
+            message: errorMessages,
+            color: 'red',
+            autoClose: 8000,
+            withCloseButton: true,
+          });
           return;
         }
       }

--- a/web/generator/templates/base/src/autocrud/lib/components/table/utils.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/table/utils.test.ts
@@ -1117,16 +1117,12 @@ describe('conditionToQB', () => {
   });
 
   it('generates not_in condition with number array', () => {
-    const result = conditionToQB({}, [
-      { field: 'level', operator: 'not_in', value: [1, 2, 3] },
-    ]);
+    const result = conditionToQB({}, [{ field: 'level', operator: 'not_in', value: [1, 2, 3] }]);
     expect(result).toBe('QB["level"].not_in([1, 2, 3])');
   });
 
   it('generates in condition with number array', () => {
-    const result = conditionToQB({}, [
-      { field: 'score', operator: 'in', value: [10, 20] },
-    ]);
+    const result = conditionToQB({}, [{ field: 'score', operator: 'in', value: [10, 20] }]);
     expect(result).toBe('QB["score"].in_([10, 20])');
   });
 });


### PR DESCRIPTION
**Problem**

Two silent failure cases in the resource create/edit form:

1. **File upload failure** — when `uploadFileToBlob` throws (e.g. S3 unreachable, network error), only an inline Alert at the bottom of the form was updated. There was no toast popup, so users could easily miss the error.

2. **Zod validation failure (form mode)** — the post-binary-processing zod check only called `console.warn` and attempted to set inline field errors via `form.setFieldError`. No notification was shown to the user. (JSON mode already showed a visible Alert via `setJsonError`.)

**Fix**

In useResourceForm.ts:
- Import `notifications` from `@mantine/notifications`
- Upload error catch block: add `notifications.show({ color: 'red', message: <api detail or error message>, ... })`
- Zod failure block: add `notifications.show(...)` with field-label-formatted error messages, matching the same format used by `handleJsonSubmit`

Existing behaviors are preserved:
- `blobUploadState.error` inline Alert is kept (belt-and-suspenders)
- `form.setFieldError` calls are kept for inline field-level display

**Tests**

Added 2 tests in useResourceForm.test.ts (TDD — written before implementation):
- `handleSubmit upload failure shows toast notification`
- `handleSubmit zod post-validation failure shows toast notification`

fix #313