### PR TITLE
fix: support `list[Binary]` fields in frontend form

### DIFF
--- a/examples/rpg_game_api.py
+++ b/examples/rpg_game_api.py
@@ -165,6 +165,9 @@ class Character(Struct):
     # N:N 關係：角色學會的技能（透過 skill resource_id 列表）
     skill_ids: list[Annotated[str, Ref("skill")]] = []
     equipments: list[Equipment | Item] = []  # 角色裝備列表（嵌入式，非 Ref）
+    # list[Binary] 欄位 — 展示多圖上傳功能 (v0.8.4 修復)
+    # 前端會渲染 BinaryArrayFieldRenderer，提供新增/刪除多張圖片的 UI
+    screenshots: list[Binary] = []
     created_at: dt.datetime = dt.datetime.now()
 
 
@@ -668,6 +671,11 @@ def create_sample_data():
                     icon=Binary(data=get_random_image()),
                 ),
             ],
+            # list[Binary] 示範：多張角色截圖（前端可新增/刪除多張圖片）
+            screenshots=[
+                Binary(data=get_random_image()),
+                Binary(data=get_random_image()),
+            ],
         ),
         Character(
             name="資料庫女王",
@@ -700,6 +708,9 @@ def create_sample_data():
                     price=500000,
                     icon=Binary(data=get_random_image()),
                 ),
+            ],
+            screenshots=[
+                Binary(data=get_random_image()),
             ],
         ),
         Character(

--- a/web/app/pnpm-lock.yaml
+++ b/web/app/pnpm-lock.yaml
@@ -15,37 +15,37 @@ importers:
     dependencies:
       '@mantine/core':
         specifier: ^8.3.15
-        version: 8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mantine/dates':
         specifier: ^8.3.15
-        version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mantine/form':
         specifier: ^8.3.15
-        version: 8.3.18(react@19.2.4)
+        version: 8.3.18(react@19.2.5)
       '@mantine/hooks':
         specifier: ^8.3.15
-        version: 8.3.18(react@19.2.4)
+        version: 8.3.18(react@19.2.5)
       '@mantine/notifications':
         specifier: ^8.3.15
-        version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@monaco-editor/react':
         specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tabler/icons-react':
         specifier: ^3.35.0
-        version: 3.41.1(react@19.2.4)
+        version: 3.41.1(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.93
-        version: 5.96.1(react@19.2.4)
+        version: 5.100.3(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.134.9
-        version: 1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.168.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-virtual':
         specifier: ^3.13.12
-        version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       axios:
         specifier: ^1.7.0
-        version: 1.14.0
+        version: 1.15.2
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -54,19 +54,19 @@ importers:
         version: 1.11.20
       mantine-form-zod-resolver:
         specifier: ^1.3.0
-        version: 1.3.0(@mantine/form@8.3.18(react@19.2.4))(zod@4.3.6)
+        version: 1.3.0(@mantine/form@8.3.18(react@19.2.5))(zod@4.3.6)
       mantine-react-table:
         specifier: 2.0.0-beta.9
-        version: 2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(@tabler/icons-react@3.41.1(react@19.2.4))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(@tabler/icons-react@3.41.1(react@19.2.5))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.1.0
-        version: 19.2.4
+        version: 19.2.5
       react-dom:
         specifier: ^19.1.0
-        version: 19.2.4(react@19.2.4)
+        version: 19.2.5(react@19.2.5)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -76,16 +76,16 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.1.0)
+        version: 10.0.1(eslint@10.2.1)
       '@tanstack/router-plugin':
         specifier: ^1.134.9
-        version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))
+        version: 1.167.26(@tanstack/react-router@1.168.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/node':
         specifier: ^24.6.0
-        version: 24.12.0
+        version: 24.12.2
       '@types/react':
         specifier: ^19.1.2
         version: 19.2.14
@@ -94,49 +94,49 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.1.2(vitest@4.1.2(@types/node@24.12.0)(happy-dom@20.8.9)(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)))
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^10.0.0
-        version: 10.1.0
+        version: 10.2.1
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.1.0)
+        version: 10.1.8(eslint@10.2.1)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@10.1.0)
+        version: 7.37.5(eslint@10.2.1)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@10.1.0)
+        version: 7.1.1(eslint@10.2.1)
       happy-dom:
         specifier: ^20.6.1
-        version: 20.8.9
+        version: 20.9.0
       postcss:
         specifier: ^8.5.6
-        version: 8.5.8
+        version: 8.5.10
       postcss-preset-mantine:
         specifier: ^1.18.0
-        version: 1.18.0(postcss@8.5.8)
+        version: 1.18.0(postcss@8.5.10)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.5.8)
+        version: 7.0.1(postcss@8.5.10)
       prettier:
         specifier: ^3.8.1
-        version: 3.8.1
+        version: 3.8.3
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.55.0
-        version: 8.58.0(eslint@10.1.0)(typescript@5.9.3)
+        version: 8.59.0(eslint@10.2.1)(typescript@5.9.3)
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)
+        version: 6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.2(@types/node@24.12.0)(happy-dom@20.8.9)(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))
 
 packages:
 
@@ -565,16 +565,16 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.3':
-    resolution: {integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==}
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.5.3':
-    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@1.1.1':
-    resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/js@10.0.1':
@@ -586,12 +586,12 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/object-schema@3.0.3':
-    resolution: {integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==}
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/plugin-kit@0.6.1':
-    resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@floating-ui/core@1.7.5':
@@ -615,12 +615,16 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -699,128 +703,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -843,16 +847,16 @@ packages:
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
 
-  '@tanstack/query-core@5.96.1':
-    resolution: {integrity: sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg==}
+  '@tanstack/query-core@5.100.3':
+    resolution: {integrity: sha512-oMO1imV4qStH+GqddafkI7Q7r2ktPL7/0Mu74W1XEhfHHd3oTIrwP3OOIsbtpnnbe8y/IU+8Lm7Bi2LlMhVdNA==}
 
-  '@tanstack/react-query@5.96.1':
-    resolution: {integrity: sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==}
+  '@tanstack/react-query@5.100.3':
+    resolution: {integrity: sha512-8Fgb4vKmBHllRHUjz3ZOwgV0v9b7cxCdN5T0iFQvvWJJVs6xvaxHERO1BclTL03bbK8vZAuXVKN3IeVS1sUdeQ==}
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-router@1.168.10':
-    resolution: {integrity: sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA==}
+  '@tanstack/react-router@1.168.24':
+    resolution: {integrity: sha512-CQWd9ywDZU6icG65SrjJMzWcNg/ehBKFxfxYssKSuELk0eM9SzJxJ3JBI760kdLXIsXewOX9PHpJDknxC/R5Ag==}
     engines: {node: '>=20.19'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -877,30 +881,30 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-virtual@3.13.23':
-    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/router-core@1.168.9':
-    resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
+  '@tanstack/router-core@1.168.16':
+    resolution: {integrity: sha512-2lkWNMzDWWxVqTf9Y54DH1ceZOrGrOGzx9CFVMq8gQSOxhr3x3+otjVei1Rlx4xmsCc4yCqccqjun5wDtE9MZA==}
     engines: {node: '>=20.19'}
     hasBin: true
 
-  '@tanstack/router-generator@1.166.24':
-    resolution: {integrity: sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA==}
+  '@tanstack/router-generator@1.166.34':
+    resolution: {integrity: sha512-VamHGCFqOntz9Ds6oOHtpzXLQg2yhOsXsCXSznLjoDzme3Rk69HvOzXkx9IIpDxo4v64QdvNjeV2IyfXuz5RFw==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/router-plugin@1.167.12':
-    resolution: {integrity: sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ==}
+  '@tanstack/router-plugin@1.167.26':
+    resolution: {integrity: sha512-NUbZriBBZDAoTO9ymcnuABbJdl0jMQYpPIa0JVKQn32S1xGWkVhJ8V9xmTPJU3rVdHZYedcmTHFTTadClG389w==}
     engines: {node: '>=20.19'}
     hasBin: true
     peerDependencies:
-      '@rsbuild/core': '>=1.0.2'
-      '@tanstack/react-router': ^1.168.10
-      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0'
-      vite-plugin-solid: ^2.11.10
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.168.24
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
+      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
       webpack: '>=5.92.0'
     peerDependenciesMeta:
       '@rsbuild/core':
@@ -914,8 +918,8 @@ packages:
       webpack:
         optional: true
 
-  '@tanstack/router-utils@1.161.6':
-    resolution: {integrity: sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw==}
+  '@tanstack/router-utils@1.161.7':
+    resolution: {integrity: sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng==}
     engines: {node: '>=20.19'}
 
   '@tanstack/store@0.9.3':
@@ -928,8 +932,8 @@ packages:
   '@tanstack/virtual-core@3.11.2':
     resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
 
-  '@tanstack/virtual-core@3.13.23':
-    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
   '@tanstack/virtual-file-routes@1.161.7':
     resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
@@ -1000,8 +1004,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1026,63 +1030,63 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.58.0':
-    resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
+  '@typescript-eslint/eslint-plugin@8.59.0':
+    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.58.0
+      '@typescript-eslint/parser': ^8.59.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.58.0':
-    resolution: {integrity: sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.58.0':
-    resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.58.0':
-    resolution: {integrity: sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.58.0':
-    resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.58.0':
-    resolution: {integrity: sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==}
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.58.0':
-    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.58.0':
-    resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.58.0':
-    resolution: {integrity: sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==}
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.0':
+    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.58.0':
-    resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -1094,20 +1098,20 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1117,20 +1121,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1142,8 +1146,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1196,10 +1200,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-types@0.16.1:
-    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
-    engines: {node: '>=4'}
-
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
@@ -1214,8 +1214,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1230,8 +1230,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.13:
-    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
+  baseline-browser-mapping@2.10.21:
+    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1239,8 +1239,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1259,8 +1259,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -1271,8 +1271,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001784:
-    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+  caniuse-lite@1.0.30001790:
+    resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1314,8 +1314,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-es@2.0.1:
-    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1402,15 +1402,15 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.331:
-    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-abstract@1.24.1:
-    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -1421,8 +1421,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-iterator-helpers@1.3.1:
-    resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
+  es-iterator-helpers@1.3.2:
+    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@2.0.0:
@@ -1472,11 +1472,11 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -1496,8 +1496,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.1.0:
-    resolution: {integrity: sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==}
+  eslint@10.2.1:
+    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1509,11 +1509,6 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1581,8 +1576,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -1637,8 +1632,8 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1656,8 +1651,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  happy-dom@20.8.9:
-    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
@@ -1683,8 +1678,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -1847,8 +1842,8 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  isbot@5.1.37:
-    resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
+  isbot@5.1.39:
+    resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -2132,8 +2127,8 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2251,16 +2246,16 @@ packages:
     peerDependencies:
       postcss: ^8.2.1
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2282,10 +2277,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.5
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2351,17 +2346,13 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  recast@0.23.11:
-    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
-    engines: {node: '>= 4'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2394,13 +2385,13 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
   safe-push-apply@1.0.0:
@@ -2423,14 +2414,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval-plugins@1.5.1:
-    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.1:
-    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
   set-function-length@1.2.2:
@@ -2453,8 +2444,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2476,14 +2467,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
-
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -2493,8 +2476,8 @@ packages:
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2545,18 +2528,15 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -2611,8 +2591,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.58.0:
-    resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
+  typescript-eslint@8.59.0:
+    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2648,9 +2628,9 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
-  unplugin@2.3.11:
-    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
-    engines: {node: '>=18.12.0'}
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2722,8 +2702,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2762,18 +2742,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2789,6 +2771,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3152,38 +3138,38 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.2.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.3':
+  '@eslint/config-array@0.23.5':
     dependencies:
-      '@eslint/object-schema': 3.0.3
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.3':
+  '@eslint/config-helpers@0.5.5':
     dependencies:
-      '@eslint/core': 1.1.1
+      '@eslint/core': 1.2.1
 
-  '@eslint/core@1.1.1':
+  '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.1.0)':
+  '@eslint/js@10.0.1(eslint@10.2.1)':
     optionalDependencies:
-      eslint: 10.1.0
+      eslint: 10.2.1
 
-  '@eslint/object-schema@3.0.3': {}
+  '@eslint/object-schema@3.0.5': {}
 
-  '@eslint/plugin-kit@0.6.1':
+  '@eslint/plugin-kit@0.7.1':
     dependencies:
-      '@eslint/core': 1.1.1
+      '@eslint/core': 1.2.1
       levn: 0.4.1
 
   '@floating-ui/core@1.7.5':
@@ -3195,28 +3181,33 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@floating-ui/react@0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@floating-ui/react@0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/utils': 0.2.11
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanfs/core': 0.19.1
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
       '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -3241,146 +3232,146 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@floating-ui/react': 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.18(react@19.2.4)
+      '@floating-ui/react': 0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks': 8.3.18(react@19.2.5)
       clsx: 2.1.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-number-format: 5.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-number-format: 5.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.14)(react@19.2.5)
       type-fest: 4.41.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.18(react@19.2.4)
+      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks': 8.3.18(react@19.2.5)
       clsx: 2.1.1
       dayjs: 1.11.20
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@mantine/form@8.3.18(react@19.2.4)':
+  '@mantine/form@8.3.18(react@19.2.5)':
     dependencies:
       fast-deep-equal: 3.1.3
       klona: 2.0.6
-      react: 19.2.4
+      react: 19.2.5
 
-  '@mantine/hooks@8.3.18(react@19.2.4)':
+  '@mantine/hooks@8.3.18(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
 
-  '@mantine/notifications@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@mantine/notifications@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.18(react@19.2.4)
-      '@mantine/store': 8.3.18(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks': 8.3.18(react@19.2.5)
+      '@mantine/store': 8.3.18(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-transition-group: 4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@mantine/store@8.3.18(react@19.2.4)':
+  '@mantine/store@8.3.18(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
 
-  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@monaco-editor/loader': 1.7.0
       monaco-editor: 0.55.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  '@rollup/rollup-darwin-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  '@rollup/rollup-freebsd-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
+  '@rollup/rollup-linux-x64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
+  '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
+  '@rollup/rollup-openharmony-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tabler/icons-react@3.41.1(react@19.2.4)':
+  '@tabler/icons-react@3.41.1(react@19.2.5)':
     dependencies:
       '@tabler/icons': 3.41.1
-      react: 19.2.4
+      react: 19.2.5
 
   '@tabler/icons@3.41.1': {}
 
@@ -3390,68 +3381,68 @@ snapshots:
     dependencies:
       remove-accents: 0.5.0
 
-  '@tanstack/query-core@5.96.1': {}
+  '@tanstack/query-core@5.100.3': {}
 
-  '@tanstack/react-query@5.96.1(react@19.2.4)':
+  '@tanstack/react-query@5.100.3(react@19.2.5)':
     dependencies:
-      '@tanstack/query-core': 5.96.1
-      react: 19.2.4
+      '@tanstack/query-core': 5.100.3
+      react: 19.2.5
 
-  '@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-router@1.168.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/history': 1.161.6
-      '@tanstack/react-store': 0.9.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-core': 1.168.9
-      isbot: 5.1.37
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.168.16
+      isbot: 5.1.39
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-store@0.9.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/store': 0.9.3
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      use-sync-external-store: 1.6.0(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
-  '@tanstack/react-table@8.20.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-table@8.20.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/table-core': 8.20.5
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-virtual@3.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-virtual@3.11.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/virtual-core': 3.11.2
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-virtual@3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.23
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@tanstack/virtual-core': 3.14.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/router-core@1.168.9':
+  '@tanstack/router-core@1.168.16':
     dependencies:
       '@tanstack/history': 1.161.6
-      cookie-es: 2.0.1
-      seroval: 1.5.1
-      seroval-plugins: 1.5.1(seroval@1.5.1)
+      cookie-es: 3.1.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
 
-  '@tanstack/router-generator@1.166.24':
+  '@tanstack/router-generator@1.166.34':
     dependencies:
-      '@tanstack/router-core': 1.168.9
-      '@tanstack/router-utils': 1.161.6
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.168.16
+      '@tanstack/router-utils': 1.161.7
       '@tanstack/virtual-file-routes': 1.161.7
-      prettier: 3.8.1
-      recast: 0.23.11
-      source-map: 0.7.6
+      magic-string: 0.30.21
+      prettier: 3.8.3
       tsx: 4.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.167.26(@tanstack/react-router@1.168.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -3459,20 +3450,20 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@tanstack/router-core': 1.168.9
-      '@tanstack/router-generator': 1.166.24
-      '@tanstack/router-utils': 1.161.6
+      '@tanstack/router-core': 1.168.16
+      '@tanstack/router-generator': 1.166.34
+      '@tanstack/router-utils': 1.161.7
       '@tanstack/virtual-file-routes': 1.161.7
       chokidar: 3.6.0
-      unplugin: 2.3.11
+      unplugin: 3.0.0
       zod: 3.25.76
     optionalDependencies:
-      '@tanstack/react-router': 1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)
+      '@tanstack/react-router': 1.168.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      vite: 6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-utils@1.161.6':
+  '@tanstack/router-utils@1.161.7':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -3482,7 +3473,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     transitivePeerDependencies:
       - supports-color
 
@@ -3492,7 +3483,7 @@ snapshots:
 
   '@tanstack/virtual-core@3.11.2': {}
 
-  '@tanstack/virtual-core@3.13.23': {}
+  '@tanstack/virtual-core@3.14.0': {}
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
@@ -3507,12 +3498,12 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -3571,7 +3562,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.12.0':
+  '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
@@ -3594,17 +3585,17 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
 
-  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.1.0)(typescript@5.9.3))(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/type-utils': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.0
-      eslint: 10.1.0
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      eslint: 10.2.1
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3612,84 +3603,84 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.0(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
-      eslint: 10.1.0
+      eslint: 10.2.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.58.0':
+  '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.0(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.1.0
+      eslint: 10.2.1
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.58.0': {}
+  '@typescript-eslint/types@8.59.0': {}
 
-  '@typescript-eslint/typescript-estree@8.58.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.0(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      eslint: 10.1.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      eslint: 10.2.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.58.0':
+  '@typescript-eslint/visitor-keys@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3697,62 +3688,62 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)
+      vite: 6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@24.12.0)(happy-dom@20.8.9)(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.5
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(happy-dom@20.8.9)(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)
+      vite: 6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.5':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.5': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.5':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3762,7 +3753,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ajv@6.14.0:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -3791,10 +3782,10 @@ snapshots:
 
   array-includes@3.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
@@ -3802,50 +3793,46 @@ snapshots:
 
   array.prototype.findlast@1.2.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.flat@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.tosorted@1.1.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-shim-unscopables: 1.1.0
 
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
-
-  ast-types@0.16.1:
-    dependencies:
-      tslib: 2.8.1
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
@@ -3861,9 +3848,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.14.0:
+  axios@1.15.2:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -3884,11 +3871,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.13: {}
+  baseline-browser-mapping@2.10.21: {}
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3903,10 +3890,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.13
-      caniuse-lite: 1.0.30001784
-      electron-to-chromium: 1.5.331
-      node-releases: 2.0.37
+      baseline-browser-mapping: 2.10.21
+      caniuse-lite: 1.0.30001790
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   call-bind-apply-helpers@1.0.2:
@@ -3914,7 +3901,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
+  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -3928,7 +3915,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001784: {}
+  caniuse-lite@1.0.30001790: {}
 
   ccount@2.0.1: {}
 
@@ -3966,7 +3953,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-es@2.0.1: {}
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4053,16 +4040,16 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.331: {}
+  electron-to-chromium@1.5.344: {}
 
   entities@7.0.1: {}
 
-  es-abstract@1.24.1:
+  es-abstract@1.24.2:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       data-view-buffer: 1.0.2
       data-view-byte-length: 1.0.2
@@ -4081,7 +4068,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -4099,7 +4086,7 @@ snapshots:
       object.assign: 4.1.7
       own-keys: 1.0.1
       regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.3
+      safe-array-concat: 1.1.4
       safe-push-apply: 1.0.0
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
@@ -4118,12 +4105,12 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-iterator-helpers@1.3.1:
+  es-iterator-helpers@1.3.2:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-set-tostringtag: 2.1.0
       function-bind: 1.1.2
@@ -4136,7 +4123,6 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
-      safe-array-concat: 1.1.3
 
   es-module-lexer@2.0.0: {}
 
@@ -4149,11 +4135,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -4225,32 +4211,32 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.1.0):
+  eslint-config-prettier@10.1.8(eslint@10.2.1):
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.2.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@10.1.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.2.1):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
-      eslint: 10.1.0
+      eslint: 10.2.1
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@10.1.0):
+  eslint-plugin-react@7.37.5(eslint@10.2.1):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.3
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.3.1
-      eslint: 10.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 10.2.1
       estraverse: 5.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.5
       object.entries: 1.1.9
@@ -4273,19 +4259,19 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.1.0:
+  eslint@10.2.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.3
-      '@eslint/config-helpers': 0.5.3
-      '@eslint/core': 1.1.1
-      '@eslint/plugin-kit': 0.6.1
-      '@humanfs/node': 0.16.7
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.14.0
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
@@ -4313,8 +4299,6 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
-
-  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -4368,7 +4352,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -4379,7 +4363,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   fsevents@2.3.3:
@@ -4389,11 +4373,11 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.3
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -4412,7 +4396,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -4428,7 +4412,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.13.7:
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -4447,9 +4431,9 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  happy-dom@20.8.9:
+  happy-dom@20.9.0:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -4477,7 +4461,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -4526,7 +4510,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       side-channel: 1.1.0
 
   is-alphabetical@2.0.1: {}
@@ -4538,7 +4522,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -4567,7 +4551,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-data-view@1.0.2:
     dependencies:
@@ -4620,7 +4604,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-set@2.0.3: {}
 
@@ -4656,7 +4640,7 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isbot@5.1.37: {}
+  isbot@5.1.39: {}
 
   isexe@2.0.0: {}
 
@@ -4744,24 +4728,24 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  mantine-form-zod-resolver@1.3.0(@mantine/form@8.3.18(react@19.2.4))(zod@4.3.6):
+  mantine-form-zod-resolver@1.3.0(@mantine/form@8.3.18(react@19.2.5))(zod@4.3.6):
     dependencies:
-      '@mantine/form': 8.3.18(react@19.2.4)
+      '@mantine/form': 8.3.18(react@19.2.5)
       zod: 4.3.6
 
-  mantine-react-table@2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(@tabler/icons-react@3.41.1(react@19.2.4))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  mantine-react-table@2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(@tabler/icons-react@3.41.1(react@19.2.5))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/dates': 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.18(react@19.2.4))(dayjs@1.11.20)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.18(react@19.2.4)
-      '@tabler/icons-react': 3.41.1(react@19.2.4)
+      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/dates': 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(dayjs@1.11.20)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks': 8.3.18(react@19.2.5)
+      '@tabler/icons-react': 3.41.1(react@19.2.5)
       '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/react-table': 8.20.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-virtual': 3.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-table': 8.20.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-virtual': 3.11.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       clsx: 2.1.1
       dayjs: 1.11.20
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   markdown-table@3.0.4: {}
 
@@ -5125,7 +5109,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.14
 
   monaco-editor@0.55.1:
     dependencies:
@@ -5145,7 +5129,7 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
@@ -5157,7 +5141,7 @@ snapshots:
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -5166,21 +5150,21 @@ snapshots:
 
   object.entries@1.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   object.fromentries@2.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
 
   object.values@1.2.1:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -5236,40 +5220,40 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-js@4.1.0(postcss@8.5.8):
+  postcss-js@4.1.0(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.8
+      postcss: 8.5.10
 
-  postcss-mixins@12.1.2(postcss@8.5.8):
+  postcss-mixins@12.1.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
-      postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-simple-vars: 7.0.1(postcss@8.5.8)
-      sugarss: 5.0.1(postcss@8.5.8)
-      tinyglobby: 0.2.15
+      postcss: 8.5.10
+      postcss-js: 4.1.0(postcss@8.5.10)
+      postcss-simple-vars: 7.0.1(postcss@8.5.10)
+      sugarss: 5.0.1(postcss@8.5.10)
+      tinyglobby: 0.2.16
 
-  postcss-nested@7.0.2(postcss@8.5.8):
+  postcss-nested@7.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-preset-mantine@1.18.0(postcss@8.5.8):
+  postcss-preset-mantine@1.18.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
-      postcss-mixins: 12.1.2(postcss@8.5.8)
-      postcss-nested: 7.0.2(postcss@8.5.8)
+      postcss: 8.5.10
+      postcss-mixins: 12.1.2(postcss@8.5.10)
+      postcss-nested: 7.0.2(postcss@8.5.10)
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-simple-vars@7.0.1(postcss@8.5.8):
+  postcss-simple-vars@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5277,7 +5261,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -5297,16 +5281,16 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  react-dom@19.2.4(react@19.2.4):
+  react-dom@19.2.5(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
-  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -5315,7 +5299,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
-      react: 19.2.4
+      react: 19.2.5
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
@@ -5324,77 +5308,69 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-number-format@5.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-number-format@5.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   react-refresh@0.17.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.4):
+  react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
-      react: 19.2.4
-      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.4)
-      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.5)
+      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
       - '@types/react'
 
-  react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-transition-group@4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  react@19.2.4: {}
+  react@19.2.5: {}
 
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
 
-  recast@0.23.11:
-    dependencies:
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
-      tiny-invariant: 1.3.3
-      tslib: 2.8.1
-
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -5403,7 +5379,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -5457,40 +5433,40 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rollup@4.60.1:
+  rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
-  safe-array-concat@1.1.3:
+  safe-array-concat@1.1.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
@@ -5513,11 +5489,11 @@ snapshots:
 
   semver@7.7.4: {}
 
-  seroval-plugins@1.5.1(seroval@1.5.1):
+  seroval-plugins@1.5.2(seroval@1.5.2):
     dependencies:
-      seroval: 1.5.1
+      seroval: 1.5.2
 
-  seroval@1.5.1: {}
+  seroval@1.5.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5547,7 +5523,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -5571,7 +5547,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -5579,17 +5555,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1: {}
-
-  source-map@0.7.6: {}
-
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
 
   state-local@1.0.7: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5598,10 +5570,10 @@ snapshots:
 
   string.prototype.matchall@4.0.12:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -5615,28 +5587,28 @@ snapshots:
   string.prototype.repeat@1.0.0:
     dependencies:
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -5653,9 +5625,9 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  sugarss@5.0.1(postcss@8.5.8):
+  sugarss@5.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.10
 
   supports-color@7.2.0:
     dependencies:
@@ -5665,13 +5637,11 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tiny-invariant@1.3.3: {}
-
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -5695,7 +5665,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -5713,7 +5683,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -5722,7 +5692,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -5731,20 +5701,20 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.58.0(eslint@10.1.0)(typescript@5.9.3):
+  typescript-eslint@8.59.0(eslint@10.2.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.1.0)(typescript@5.9.3))(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@10.1.0)(typescript@5.9.3)
-      eslint: 10.1.0
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      eslint: 10.2.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5793,10 +5763,9 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin@2.3.11:
+  unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      acorn: 8.16.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
@@ -5810,43 +5779,43 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.4):
+  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.4):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.4):
+  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sync-external-store@1.6.0(react@19.2.4):
+  use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 
@@ -5860,45 +5829,46 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0):
+  vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
       fsevents: 2.3.3
-      sugarss: 5.0.1(postcss@8.5.8)
+      sugarss: 5.0.1(postcss@8.5.10)
       tsx: 4.21.0
 
-  vitest@4.1.2(@types/node@24.12.0)(happy-dom@20.8.9)(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)):
+  vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@24.12.0)(sugarss@5.0.1(postcss@8.5.8))(tsx@4.21.0)
+      vite: 6.4.2(@types/node@24.12.2)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.0
-      happy-dom: 20.8.9
+      '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -5940,7 +5910,7 @@ snapshots:
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1

--- a/web/app/src/autocrud/generated/resources.ts
+++ b/web/app/src/autocrud/generated/resources.ts
@@ -53,6 +53,7 @@ export type CharacterFieldName =
   | 'special_ability'
   | 'skill_ids'
   | 'equipments'
+  | 'screenshots'
   | 'created_at';
 export type GuildFieldName =
   | 'name'
@@ -537,6 +538,14 @@ Object.assign(registry, {
         },
       },
       {
+        name: 'screenshots',
+        label: 'Screenshots',
+        type: 'binary',
+        isArray: true,
+        isRequired: false,
+        isNullable: false,
+      },
+      {
         name: 'created_at',
         label: 'Created At',
         type: 'date',
@@ -585,6 +594,7 @@ Object.assign(registry, {
           ]),
         )
         .optional(),
+      screenshots: z.array(z.any()).optional(),
       created_at: z.union([z.string(), z.date()]).optional(),
     }),
     apiClient: characterApi,

--- a/web/app/src/autocrud/generated/types.ts
+++ b/web/app/src/autocrud/generated/types.ts
@@ -69,8 +69,9 @@ import * as zod from 'zod';
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -83,7 +84,7 @@ import * as zod from 'zod';
 - Direct access to resource content only
 
 **Examples:**
-- `GET /character/data` - Get first 10 resources (data only)
+- `GET /character/data` - Get the default first page of resources (data only)
 - `GET /character/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /character/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /character/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -94,7 +95,7 @@ import * as zod from 'zod';
  * @summary List character Data Only
  */
 export const listResourcesDataV1AutocrudCharacterDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudCharacterDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudCharacterDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudCharacterDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudCharacterDataGetQueryParams = zod.object({
@@ -102,7 +103,7 @@ export const ListResourcesDataV1AutocrudCharacterDataGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -153,7 +154,9 @@ export const ListResourcesDataV1AutocrudCharacterDataGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudCharacterDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudCharacterDataGetQueryOffsetDefault)
@@ -190,7 +193,8 @@ export const listResourcesDataV1AutocrudCharacterDataGetResponseEquipmentsItemTw
 export const listResourcesDataV1AutocrudCharacterDataGetResponseEquipmentsItemTwoPriceDefault = 100;
 export const listResourcesDataV1AutocrudCharacterDataGetResponseEquipmentsItemTwoIconDefault = null;
 export const listResourcesDataV1AutocrudCharacterDataGetResponseEquipmentsDefault = [];
-export const listResourcesDataV1AutocrudCharacterDataGetResponseCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const listResourcesDataV1AutocrudCharacterDataGetResponseScreenshotsDefault = [];
+export const listResourcesDataV1AutocrudCharacterDataGetResponseCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 
 export const ListResourcesDataV1AutocrudCharacterDataGetResponseItem = zod
   .object({
@@ -324,6 +328,20 @@ export const ListResourcesDataV1AutocrudCharacterDataGetResponseItem = zod
         ]),
       )
       .default(listResourcesDataV1AutocrudCharacterDataGetResponseEquipmentsDefault),
+    screenshots: zod
+      .array(
+        zod
+          .object({
+            file_id: zod.string().optional(),
+            size: zod.number().optional(),
+            content_type: zod.string().optional(),
+            data: zod.string().optional(),
+          })
+          .describe(
+            'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+          ),
+      )
+      .default(listResourcesDataV1AutocrudCharacterDataGetResponseScreenshotsDefault),
     created_at: zod
       .string()
       .default(listResourcesDataV1AutocrudCharacterDataGetResponseCreatedAtDefault),
@@ -383,8 +401,9 @@ export const ListResourcesDataV1AutocrudCharacterDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -393,7 +412,7 @@ export const ListResourcesDataV1AutocrudCharacterDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /character/meta` - Get metadata for first 10 resources
+- `GET /character/meta` - Get metadata for the default first page of resources
 - `GET /character/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /character/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -403,7 +422,7 @@ export const ListResourcesDataV1AutocrudCharacterDataGetResponse = zod.array(
  * @summary List character Metadata Only
  */
 export const listResourcesMetaV1AutocrudCharacterMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudCharacterMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudCharacterMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudCharacterMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudCharacterMetaGetQueryParams = zod.object({
@@ -411,7 +430,7 @@ export const ListResourcesMetaV1AutocrudCharacterMetaGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -462,7 +481,9 @@ export const ListResourcesMetaV1AutocrudCharacterMetaGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudCharacterMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudCharacterMetaGetQueryOffsetDefault)
@@ -541,8 +562,9 @@ export const ListResourcesMetaV1AutocrudCharacterMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -551,8 +573,8 @@ export const ListResourcesMetaV1AutocrudCharacterMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /character/revision-info` - Get current revision info for first 10 resources
-- `GET /character/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /character/revision-info` - Get current revision info for the default first page of resources
+- `GET /character/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /character/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -561,7 +583,7 @@ export const ListResourcesMetaV1AutocrudCharacterMetaGetResponse = zod.array(
  * @summary List character Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryParams = zod.object({
@@ -569,7 +591,7 @@ export const ListResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryPar
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -620,7 +642,9 @@ export const ListResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryPar
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetQueryOffsetDefault)
@@ -672,7 +696,7 @@ export const ListResourcesRevisionInfoV1AutocrudCharacterRevisionInfoGetResponse
  * @summary List character Complete Information
  */
 export const listResourcesFullV1AutocrudCharacterFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudCharacterFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudCharacterFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudCharacterFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudCharacterFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -681,7 +705,7 @@ export const ListResourcesFullV1AutocrudCharacterFullGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -732,7 +756,9 @@ export const ListResourcesFullV1AutocrudCharacterFullGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudCharacterFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudCharacterFullGetQueryOffsetDefault)
@@ -775,7 +801,8 @@ export const listResourcesFullV1AutocrudCharacterFullGetResponseDataEquipmentsIt
 export const listResourcesFullV1AutocrudCharacterFullGetResponseDataEquipmentsItemTwoIconDefault =
   null;
 export const listResourcesFullV1AutocrudCharacterFullGetResponseDataEquipmentsDefault = [];
-export const listResourcesFullV1AutocrudCharacterFullGetResponseDataCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const listResourcesFullV1AutocrudCharacterFullGetResponseDataScreenshotsDefault = [];
+export const listResourcesFullV1AutocrudCharacterFullGetResponseDataCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 export const listResourcesFullV1AutocrudCharacterFullGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const listResourcesFullV1AutocrudCharacterFullGetResponseRevisionInfoSchemaVersionDefault =
@@ -922,6 +949,20 @@ export const ListResourcesFullV1AutocrudCharacterFullGetResponseItem = zod.objec
           ]),
         )
         .default(listResourcesFullV1AutocrudCharacterFullGetResponseDataEquipmentsDefault),
+      screenshots: zod
+        .array(
+          zod
+            .object({
+              file_id: zod.string().optional(),
+              size: zod.number().optional(),
+              content_type: zod.string().optional(),
+              data: zod.string().optional(),
+            })
+            .describe(
+              'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+            ),
+        )
+        .default(listResourcesFullV1AutocrudCharacterFullGetResponseDataScreenshotsDefault),
       created_at: zod
         .string()
         .default(listResourcesFullV1AutocrudCharacterFullGetResponseDataCreatedAtDefault),
@@ -1024,7 +1065,7 @@ export const ListResourcesFullV1AutocrudCharacterFullGetResponse = zod.array(
  * @summary Count character Resources
  */
 export const getResourcesCountV1AutocrudCharacterCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudCharacterCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudCharacterCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudCharacterCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudCharacterCountGetQueryParams = zod.object({
@@ -1032,7 +1073,7 @@ export const GetResourcesCountV1AutocrudCharacterCountGetQueryParams = zod.objec
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -1083,7 +1124,9 @@ export const GetResourcesCountV1AutocrudCharacterCountGetQueryParams = zod.objec
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudCharacterCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudCharacterCountGetQueryOffsetDefault)
@@ -1120,7 +1163,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List character resources
  */
 export const listResourcesV1AutocrudCharacterGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudCharacterGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudCharacterGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudCharacterGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudCharacterGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -1129,7 +1172,7 @@ export const ListResourcesV1AutocrudCharacterGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -1180,7 +1223,9 @@ export const ListResourcesV1AutocrudCharacterGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudCharacterGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudCharacterGetQueryOffsetDefault)
@@ -1220,7 +1265,8 @@ export const listResourcesV1AutocrudCharacterGetResponseDataEquipmentsItemTwoDes
 export const listResourcesV1AutocrudCharacterGetResponseDataEquipmentsItemTwoPriceDefault = 100;
 export const listResourcesV1AutocrudCharacterGetResponseDataEquipmentsItemTwoIconDefault = null;
 export const listResourcesV1AutocrudCharacterGetResponseDataEquipmentsDefault = [];
-export const listResourcesV1AutocrudCharacterGetResponseDataCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const listResourcesV1AutocrudCharacterGetResponseDataScreenshotsDefault = [];
+export const listResourcesV1AutocrudCharacterGetResponseDataCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 export const listResourcesV1AutocrudCharacterGetResponseRevisionInfoParentRevisionIdDefault = null;
 export const listResourcesV1AutocrudCharacterGetResponseRevisionInfoSchemaVersionDefault = null;
 export const listResourcesV1AutocrudCharacterGetResponseMetaSchemaVersionDefault = null;
@@ -1357,6 +1403,20 @@ export const ListResourcesV1AutocrudCharacterGetResponseItem = zod.object({
           ]),
         )
         .default(listResourcesV1AutocrudCharacterGetResponseDataEquipmentsDefault),
+      screenshots: zod
+        .array(
+          zod
+            .object({
+              file_id: zod.string().optional(),
+              size: zod.number().optional(),
+              content_type: zod.string().optional(),
+              data: zod.string().optional(),
+            })
+            .describe(
+              'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+            ),
+        )
+        .default(listResourcesV1AutocrudCharacterGetResponseDataScreenshotsDefault),
       created_at: zod
         .string()
         .default(listResourcesV1AutocrudCharacterGetResponseDataCreatedAtDefault),
@@ -1457,7 +1517,8 @@ export const createResourceV1AutocrudCharacterPostBodyEquipmentsItemTwoDescripti
 export const createResourceV1AutocrudCharacterPostBodyEquipmentsItemTwoPriceDefault = 100;
 export const createResourceV1AutocrudCharacterPostBodyEquipmentsItemTwoIconDefault = null;
 export const createResourceV1AutocrudCharacterPostBodyEquipmentsDefault = [];
-export const createResourceV1AutocrudCharacterPostBodyCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const createResourceV1AutocrudCharacterPostBodyScreenshotsDefault = [];
+export const createResourceV1AutocrudCharacterPostBodyCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 
 export const CreateResourceV1AutocrudCharacterPostBody = zod
   .object({
@@ -1577,6 +1638,20 @@ export const CreateResourceV1AutocrudCharacterPostBody = zod
         ]),
       )
       .default(createResourceV1AutocrudCharacterPostBodyEquipmentsDefault),
+    screenshots: zod
+      .array(
+        zod
+          .object({
+            file_id: zod.string().optional(),
+            size: zod.number().optional(),
+            content_type: zod.string().optional(),
+            data: zod.string().optional(),
+          })
+          .describe(
+            'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+          ),
+      )
+      .default(createResourceV1AutocrudCharacterPostBodyScreenshotsDefault),
     created_at: zod.string().default(createResourceV1AutocrudCharacterPostBodyCreatedAtDefault),
   })
   .describe('遊戲角色');
@@ -1634,7 +1709,7 @@ export const CreateResourceV1AutocrudCharacterPostResponse = zod
  * @summary Batch delete character
  */
 export const batchDeleteV1AutocrudCharacterDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudCharacterDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudCharacterDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudCharacterDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudCharacterDeleteQueryParams = zod.object({
@@ -1642,7 +1717,7 @@ export const BatchDeleteV1AutocrudCharacterDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -1693,7 +1768,9 @@ export const BatchDeleteV1AutocrudCharacterDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudCharacterDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudCharacterDeleteQueryOffsetDefault)
@@ -1739,7 +1816,7 @@ which resources are included.
  * @summary Export character data
  */
 export const exportModelV1AutocrudCharacterExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudCharacterExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudCharacterExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudCharacterExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudCharacterExportGetQueryParams = zod.object({
@@ -1747,7 +1824,7 @@ export const ExportModelV1AutocrudCharacterExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -1798,7 +1875,9 @@ export const ExportModelV1AutocrudCharacterExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudCharacterExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudCharacterExportGetQueryOffsetDefault)
@@ -2036,7 +2115,8 @@ export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataEqui
 export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataEquipmentsItemTwoIconDefault =
   null;
 export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataEquipmentsDefault = [];
-export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataScreenshotsDefault = [];
+export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const getResourceFullV1AutocrudCharacterResourceIdFullGetResponseRevisionInfoSchemaVersionDefault =
@@ -2190,6 +2270,20 @@ export const GetResourceFullV1AutocrudCharacterResourceIdFullGetResponse = zod.o
           ]),
         )
         .default(getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataEquipmentsDefault),
+      screenshots: zod
+        .array(
+          zod
+            .object({
+              file_id: zod.string().optional(),
+              size: zod.number().optional(),
+              content_type: zod.string().optional(),
+              data: zod.string().optional(),
+            })
+            .describe(
+              'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+            ),
+        )
+        .default(getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataScreenshotsDefault),
       created_at: zod
         .string()
         .default(getResourceFullV1AutocrudCharacterResourceIdFullGetResponseDataCreatedAtDefault),
@@ -2508,7 +2602,8 @@ export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseEquipmen
 export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseEquipmentsItemTwoIconDefault =
   null;
 export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseEquipmentsDefault = [];
-export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseScreenshotsDefault = [];
+export const getResourceDataV1AutocrudCharacterResourceIdDataGetResponseCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 
 export const GetResourceDataV1AutocrudCharacterResourceIdDataGetResponse = zod
   .object({
@@ -2648,6 +2743,20 @@ export const GetResourceDataV1AutocrudCharacterResourceIdDataGetResponse = zod
         ]),
       )
       .default(getResourceDataV1AutocrudCharacterResourceIdDataGetResponseEquipmentsDefault),
+    screenshots: zod
+      .array(
+        zod
+          .object({
+            file_id: zod.string().optional(),
+            size: zod.number().optional(),
+            content_type: zod.string().optional(),
+            data: zod.string().optional(),
+          })
+          .describe(
+            'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+          ),
+      )
+      .default(getResourceDataV1AutocrudCharacterResourceIdDataGetResponseScreenshotsDefault),
     created_at: zod
       .string()
       .default(getResourceDataV1AutocrudCharacterResourceIdDataGetResponseCreatedAtDefault),
@@ -2739,7 +2848,8 @@ export const getResourceV1AutocrudCharacterResourceIdGetResponseDataEquipmentsIt
 export const getResourceV1AutocrudCharacterResourceIdGetResponseDataEquipmentsItemTwoIconDefault =
   null;
 export const getResourceV1AutocrudCharacterResourceIdGetResponseDataEquipmentsDefault = [];
-export const getResourceV1AutocrudCharacterResourceIdGetResponseDataCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const getResourceV1AutocrudCharacterResourceIdGetResponseDataScreenshotsDefault = [];
+export const getResourceV1AutocrudCharacterResourceIdGetResponseDataCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 export const getResourceV1AutocrudCharacterResourceIdGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const getResourceV1AutocrudCharacterResourceIdGetResponseRevisionInfoSchemaVersionDefault =
@@ -2886,6 +2996,20 @@ export const GetResourceV1AutocrudCharacterResourceIdGetResponse = zod.object({
           ]),
         )
         .default(getResourceV1AutocrudCharacterResourceIdGetResponseDataEquipmentsDefault),
+      screenshots: zod
+        .array(
+          zod
+            .object({
+              file_id: zod.string().optional(),
+              size: zod.number().optional(),
+              content_type: zod.string().optional(),
+              data: zod.string().optional(),
+            })
+            .describe(
+              'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+            ),
+        )
+        .default(getResourceV1AutocrudCharacterResourceIdGetResponseDataScreenshotsDefault),
       created_at: zod
         .string()
         .default(getResourceV1AutocrudCharacterResourceIdGetResponseDataCreatedAtDefault),
@@ -3012,7 +3136,8 @@ export const updateResourceV1AutocrudCharacterResourceIdPutBodyEquipmentsItemTwo
 export const updateResourceV1AutocrudCharacterResourceIdPutBodyEquipmentsItemTwoPriceDefault = 100;
 export const updateResourceV1AutocrudCharacterResourceIdPutBodyEquipmentsItemTwoIconDefault = null;
 export const updateResourceV1AutocrudCharacterResourceIdPutBodyEquipmentsDefault = [];
-export const updateResourceV1AutocrudCharacterResourceIdPutBodyCreatedAtDefault = `2026-04-03T14:48:54.131332`;
+export const updateResourceV1AutocrudCharacterResourceIdPutBodyScreenshotsDefault = [];
+export const updateResourceV1AutocrudCharacterResourceIdPutBodyCreatedAtDefault = `2026-04-25T19:35:28.991480`;
 
 export const UpdateResourceV1AutocrudCharacterResourceIdPutBody = zod
   .object({
@@ -3144,6 +3269,20 @@ export const UpdateResourceV1AutocrudCharacterResourceIdPutBody = zod
         ]),
       )
       .default(updateResourceV1AutocrudCharacterResourceIdPutBodyEquipmentsDefault),
+    screenshots: zod
+      .array(
+        zod
+          .object({
+            file_id: zod.string().optional(),
+            size: zod.number().optional(),
+            content_type: zod.string().optional(),
+            data: zod.string().optional(),
+          })
+          .describe(
+            'A wrapper for binary data that handles storage optimization.\n\nWhen creating a resource, you can populate the `data` field with bytes.\nThe system will automatically extract it, store it in the blob store,\nand populate `file_id` (which is the hash of the content) and `size`.\nThe `data` field will be cleared in the stored resource.',
+          ),
+      )
+      .default(updateResourceV1AutocrudCharacterResourceIdPutBodyScreenshotsDefault),
     created_at: zod
       .string()
       .default(updateResourceV1AutocrudCharacterResourceIdPutBodyCreatedAtDefault),
@@ -3563,7 +3702,7 @@ export const RestoreResourceV1AutocrudCharacterResourceIdRestorePostResponse = z
  * @summary Batch restore deleted character
  */
 export const batchRestoreV1AutocrudCharacterRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudCharacterRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudCharacterRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudCharacterRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudCharacterRestorePostQueryParams = zod.object({
@@ -3571,7 +3710,7 @@ export const BatchRestoreV1AutocrudCharacterRestorePostQueryParams = zod.object(
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -3622,7 +3761,9 @@ export const BatchRestoreV1AutocrudCharacterRestorePostQueryParams = zod.object(
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudCharacterRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudCharacterRestorePostQueryOffsetDefault)
@@ -3761,7 +3902,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryParams = zod.object({
@@ -3769,7 +3910,7 @@ export const TestMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryParams =
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -3820,7 +3961,9 @@ export const TestMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryParams =
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudCharacterMigrateTestPostQueryOffsetDefault)
@@ -3850,7 +3993,7 @@ export const TestMigrateResourcesV1AutocrudCharacterMigrateTestPostResponse = zo
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryParams = zod.object({
@@ -3858,7 +4001,7 @@ export const ExecuteMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryPa
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -3909,7 +4052,9 @@ export const ExecuteMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryPa
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudCharacterMigrateExecutePostQueryOffsetDefault)
@@ -4048,8 +4193,9 @@ export const MigrateSingleResourceV1AutocrudCharacterMigrateSingleResourceIdPost
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -4062,7 +4208,7 @@ export const MigrateSingleResourceV1AutocrudCharacterMigrateSingleResourceIdPost
 - Direct access to resource content only
 
 **Examples:**
-- `GET /guild/data` - Get first 10 resources (data only)
+- `GET /guild/data` - Get the default first page of resources (data only)
 - `GET /guild/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /guild/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /guild/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -4073,7 +4219,7 @@ export const MigrateSingleResourceV1AutocrudCharacterMigrateSingleResourceIdPost
  * @summary List guild Data Only
  */
 export const listResourcesDataV1AutocrudGuildDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudGuildDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudGuildDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudGuildDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudGuildDataGetQueryParams = zod.object({
@@ -4081,7 +4227,7 @@ export const ListResourcesDataV1AutocrudGuildDataGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4132,7 +4278,9 @@ export const ListResourcesDataV1AutocrudGuildDataGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudGuildDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudGuildDataGetQueryOffsetDefault)
@@ -4146,7 +4294,7 @@ export const ListResourcesDataV1AutocrudGuildDataGetQueryParams = zod.object({
 export const listResourcesDataV1AutocrudGuildDataGetResponseMemberCountDefault = 1;
 export const listResourcesDataV1AutocrudGuildDataGetResponseLevelDefault = 1;
 export const listResourcesDataV1AutocrudGuildDataGetResponseTreasuryDefault = 1000;
-export const listResourcesDataV1AutocrudGuildDataGetResponseFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const listResourcesDataV1AutocrudGuildDataGetResponseFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 
 export const ListResourcesDataV1AutocrudGuildDataGetResponseItem = zod
   .object({
@@ -4217,8 +4365,9 @@ export const ListResourcesDataV1AutocrudGuildDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -4227,7 +4376,7 @@ export const ListResourcesDataV1AutocrudGuildDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /guild/meta` - Get metadata for first 10 resources
+- `GET /guild/meta` - Get metadata for the default first page of resources
 - `GET /guild/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /guild/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -4237,7 +4386,7 @@ export const ListResourcesDataV1AutocrudGuildDataGetResponse = zod.array(
  * @summary List guild Metadata Only
  */
 export const listResourcesMetaV1AutocrudGuildMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudGuildMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudGuildMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudGuildMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudGuildMetaGetQueryParams = zod.object({
@@ -4245,7 +4394,7 @@ export const ListResourcesMetaV1AutocrudGuildMetaGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4296,7 +4445,9 @@ export const ListResourcesMetaV1AutocrudGuildMetaGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudGuildMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudGuildMetaGetQueryOffsetDefault)
@@ -4375,8 +4526,9 @@ export const ListResourcesMetaV1AutocrudGuildMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -4385,8 +4537,8 @@ export const ListResourcesMetaV1AutocrudGuildMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /guild/revision-info` - Get current revision info for first 10 resources
-- `GET /guild/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /guild/revision-info` - Get current revision info for the default first page of resources
+- `GET /guild/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /guild/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -4395,7 +4547,7 @@ export const ListResourcesMetaV1AutocrudGuildMetaGetResponse = zod.array(
  * @summary List guild Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryParams = zod.object({
@@ -4403,7 +4555,7 @@ export const ListResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryParams 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4454,7 +4606,9 @@ export const ListResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryParams 
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetQueryOffsetDefault)
@@ -4504,7 +4658,7 @@ export const ListResourcesRevisionInfoV1AutocrudGuildRevisionInfoGetResponse = z
  * @summary List guild Complete Information
  */
 export const listResourcesFullV1AutocrudGuildFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudGuildFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudGuildFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudGuildFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudGuildFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -4513,7 +4667,7 @@ export const ListResourcesFullV1AutocrudGuildFullGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4564,7 +4718,9 @@ export const ListResourcesFullV1AutocrudGuildFullGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudGuildFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudGuildFullGetQueryOffsetDefault)
@@ -4582,7 +4738,7 @@ export const ListResourcesFullV1AutocrudGuildFullGetQueryParams = zod.object({
 export const listResourcesFullV1AutocrudGuildFullGetResponseDataMemberCountDefault = 1;
 export const listResourcesFullV1AutocrudGuildFullGetResponseDataLevelDefault = 1;
 export const listResourcesFullV1AutocrudGuildFullGetResponseDataTreasuryDefault = 1000;
-export const listResourcesFullV1AutocrudGuildFullGetResponseDataFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const listResourcesFullV1AutocrudGuildFullGetResponseDataFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 export const listResourcesFullV1AutocrudGuildFullGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const listResourcesFullV1AutocrudGuildFullGetResponseRevisionInfoSchemaVersionDefault = null;
@@ -4702,7 +4858,7 @@ export const ListResourcesFullV1AutocrudGuildFullGetResponse = zod.array(
  * @summary Count guild Resources
  */
 export const getResourcesCountV1AutocrudGuildCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudGuildCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudGuildCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudGuildCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudGuildCountGetQueryParams = zod.object({
@@ -4710,7 +4866,7 @@ export const GetResourcesCountV1AutocrudGuildCountGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4761,7 +4917,9 @@ export const GetResourcesCountV1AutocrudGuildCountGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudGuildCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudGuildCountGetQueryOffsetDefault)
@@ -4798,7 +4956,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List guild resources
  */
 export const listResourcesV1AutocrudGuildGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudGuildGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudGuildGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudGuildGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudGuildGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -4807,7 +4965,7 @@ export const ListResourcesV1AutocrudGuildGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -4858,7 +5016,9 @@ export const ListResourcesV1AutocrudGuildGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudGuildGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudGuildGetQueryOffsetDefault)
@@ -4876,7 +5036,7 @@ export const ListResourcesV1AutocrudGuildGetQueryParams = zod.object({
 export const listResourcesV1AutocrudGuildGetResponseDataMemberCountDefault = 1;
 export const listResourcesV1AutocrudGuildGetResponseDataLevelDefault = 1;
 export const listResourcesV1AutocrudGuildGetResponseDataTreasuryDefault = 1000;
-export const listResourcesV1AutocrudGuildGetResponseDataFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const listResourcesV1AutocrudGuildGetResponseDataFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 export const listResourcesV1AutocrudGuildGetResponseRevisionInfoParentRevisionIdDefault = null;
 export const listResourcesV1AutocrudGuildGetResponseRevisionInfoSchemaVersionDefault = null;
 export const listResourcesV1AutocrudGuildGetResponseMetaSchemaVersionDefault = null;
@@ -4970,7 +5130,7 @@ export const ListResourcesV1AutocrudGuildGetResponse = zod.array(
 export const createResourceV1AutocrudGuildPostBodyMemberCountDefault = 1;
 export const createResourceV1AutocrudGuildPostBodyLevelDefault = 1;
 export const createResourceV1AutocrudGuildPostBodyTreasuryDefault = 1000;
-export const createResourceV1AutocrudGuildPostBodyFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const createResourceV1AutocrudGuildPostBodyFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 
 export const CreateResourceV1AutocrudGuildPostBody = zod
   .object({
@@ -5037,7 +5197,7 @@ export const CreateResourceV1AutocrudGuildPostResponse = zod
  * @summary Batch delete guild
  */
 export const batchDeleteV1AutocrudGuildDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudGuildDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudGuildDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudGuildDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudGuildDeleteQueryParams = zod.object({
@@ -5045,7 +5205,7 @@ export const BatchDeleteV1AutocrudGuildDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -5096,7 +5256,9 @@ export const BatchDeleteV1AutocrudGuildDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudGuildDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudGuildDeleteQueryOffsetDefault)
@@ -5142,7 +5304,7 @@ which resources are included.
  * @summary Export guild data
  */
 export const exportModelV1AutocrudGuildExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudGuildExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudGuildExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudGuildExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudGuildExportGetQueryParams = zod.object({
@@ -5150,7 +5312,7 @@ export const ExportModelV1AutocrudGuildExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -5201,7 +5363,9 @@ export const ExportModelV1AutocrudGuildExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudGuildExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudGuildExportGetQueryOffsetDefault)
@@ -5408,7 +5572,7 @@ export const GetResourceFullV1AutocrudGuildResourceIdFullGetQueryParams = zod.ob
 export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseDataMemberCountDefault = 1;
 export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseDataLevelDefault = 1;
 export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseDataTreasuryDefault = 1000;
-export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseDataFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseDataFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const getResourceFullV1AutocrudGuildResourceIdFullGetResponseRevisionInfoSchemaVersionDefault =
@@ -5710,7 +5874,7 @@ export const GetResourceDataV1AutocrudGuildResourceIdDataGetQueryParams = zod.ob
 export const getResourceDataV1AutocrudGuildResourceIdDataGetResponseMemberCountDefault = 1;
 export const getResourceDataV1AutocrudGuildResourceIdDataGetResponseLevelDefault = 1;
 export const getResourceDataV1AutocrudGuildResourceIdDataGetResponseTreasuryDefault = 1000;
-export const getResourceDataV1AutocrudGuildResourceIdDataGetResponseFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const getResourceDataV1AutocrudGuildResourceIdDataGetResponseFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 
 export const GetResourceDataV1AutocrudGuildResourceIdDataGetResponse = zod
   .object({
@@ -5792,7 +5956,7 @@ export const GetResourceV1AutocrudGuildResourceIdGetQueryParams = zod.object({
 export const getResourceV1AutocrudGuildResourceIdGetResponseDataMemberCountDefault = 1;
 export const getResourceV1AutocrudGuildResourceIdGetResponseDataLevelDefault = 1;
 export const getResourceV1AutocrudGuildResourceIdGetResponseDataTreasuryDefault = 1000;
-export const getResourceV1AutocrudGuildResourceIdGetResponseDataFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const getResourceV1AutocrudGuildResourceIdGetResponseDataFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 export const getResourceV1AutocrudGuildResourceIdGetResponseRevisionInfoParentRevisionIdDefault =
   null;
 export const getResourceV1AutocrudGuildResourceIdGetResponseRevisionInfoSchemaVersionDefault = null;
@@ -5913,7 +6077,7 @@ export const UpdateResourceV1AutocrudGuildResourceIdPutQueryParams = zod.object(
 export const updateResourceV1AutocrudGuildResourceIdPutBodyMemberCountDefault = 1;
 export const updateResourceV1AutocrudGuildResourceIdPutBodyLevelDefault = 1;
 export const updateResourceV1AutocrudGuildResourceIdPutBodyTreasuryDefault = 1000;
-export const updateResourceV1AutocrudGuildResourceIdPutBodyFoundedAtDefault = `2026-04-03T14:48:54.131419`;
+export const updateResourceV1AutocrudGuildResourceIdPutBodyFoundedAtDefault = `2026-04-25T19:35:28.991655`;
 
 export const UpdateResourceV1AutocrudGuildResourceIdPutBody = zod
   .object({
@@ -6342,7 +6506,7 @@ export const RestoreResourceV1AutocrudGuildResourceIdRestorePostResponse = zod
  * @summary Batch restore deleted guild
  */
 export const batchRestoreV1AutocrudGuildRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudGuildRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudGuildRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudGuildRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudGuildRestorePostQueryParams = zod.object({
@@ -6350,7 +6514,7 @@ export const BatchRestoreV1AutocrudGuildRestorePostQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -6401,7 +6565,9 @@ export const BatchRestoreV1AutocrudGuildRestorePostQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudGuildRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudGuildRestorePostQueryOffsetDefault)
@@ -6451,7 +6617,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudGuildMigrateTestPostQueryParams = zod.object({
@@ -6459,7 +6625,7 @@ export const TestMigrateResourcesV1AutocrudGuildMigrateTestPostQueryParams = zod
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -6510,7 +6676,9 @@ export const TestMigrateResourcesV1AutocrudGuildMigrateTestPostQueryParams = zod
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudGuildMigrateTestPostQueryOffsetDefault)
@@ -6540,7 +6708,7 @@ export const TestMigrateResourcesV1AutocrudGuildMigrateTestPostResponse = zod.un
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryParams = zod.object({
@@ -6548,7 +6716,7 @@ export const ExecuteMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -6599,7 +6767,9 @@ export const ExecuteMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryParams
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudGuildMigrateExecutePostQueryOffsetDefault)
@@ -6732,8 +6902,9 @@ export const MigrateSingleResourceV1AutocrudGuildMigrateSingleResourceIdPostResp
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -6746,7 +6917,7 @@ export const MigrateSingleResourceV1AutocrudGuildMigrateSingleResourceIdPostResp
 - Direct access to resource content only
 
 **Examples:**
-- `GET /skill/data` - Get first 10 resources (data only)
+- `GET /skill/data` - Get the default first page of resources (data only)
 - `GET /skill/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /skill/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /skill/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -6757,7 +6928,7 @@ export const MigrateSingleResourceV1AutocrudGuildMigrateSingleResourceIdPostResp
  * @summary List skill Data Only
  */
 export const listResourcesDataV1AutocrudSkillDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudSkillDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudSkillDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudSkillDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudSkillDataGetQueryParams = zod.object({
@@ -6765,7 +6936,7 @@ export const ListResourcesDataV1AutocrudSkillDataGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -6816,7 +6987,9 @@ export const ListResourcesDataV1AutocrudSkillDataGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudSkillDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudSkillDataGetQueryOffsetDefault)
@@ -6955,8 +7128,9 @@ export const ListResourcesDataV1AutocrudSkillDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -6965,7 +7139,7 @@ export const ListResourcesDataV1AutocrudSkillDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /skill/meta` - Get metadata for first 10 resources
+- `GET /skill/meta` - Get metadata for the default first page of resources
 - `GET /skill/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /skill/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -6975,7 +7149,7 @@ export const ListResourcesDataV1AutocrudSkillDataGetResponse = zod.array(
  * @summary List skill Metadata Only
  */
 export const listResourcesMetaV1AutocrudSkillMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudSkillMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudSkillMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudSkillMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudSkillMetaGetQueryParams = zod.object({
@@ -6983,7 +7157,7 @@ export const ListResourcesMetaV1AutocrudSkillMetaGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7034,7 +7208,9 @@ export const ListResourcesMetaV1AutocrudSkillMetaGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudSkillMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudSkillMetaGetQueryOffsetDefault)
@@ -7113,8 +7289,9 @@ export const ListResourcesMetaV1AutocrudSkillMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -7123,8 +7300,8 @@ export const ListResourcesMetaV1AutocrudSkillMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /skill/revision-info` - Get current revision info for first 10 resources
-- `GET /skill/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /skill/revision-info` - Get current revision info for the default first page of resources
+- `GET /skill/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /skill/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -7133,7 +7310,7 @@ export const ListResourcesMetaV1AutocrudSkillMetaGetResponse = zod.array(
  * @summary List skill Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryParams = zod.object({
@@ -7141,7 +7318,7 @@ export const ListResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryParams 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7192,7 +7369,9 @@ export const ListResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryParams 
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetQueryOffsetDefault)
@@ -7242,7 +7421,7 @@ export const ListResourcesRevisionInfoV1AutocrudSkillRevisionInfoGetResponse = z
  * @summary List skill Complete Information
  */
 export const listResourcesFullV1AutocrudSkillFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudSkillFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudSkillFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudSkillFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudSkillFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -7251,7 +7430,7 @@ export const ListResourcesFullV1AutocrudSkillFullGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7302,7 +7481,9 @@ export const ListResourcesFullV1AutocrudSkillFullGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudSkillFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudSkillFullGetQueryOffsetDefault)
@@ -7496,7 +7677,7 @@ export const ListResourcesFullV1AutocrudSkillFullGetResponse = zod.array(
  * @summary Count skill Resources
  */
 export const getResourcesCountV1AutocrudSkillCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudSkillCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudSkillCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudSkillCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudSkillCountGetQueryParams = zod.object({
@@ -7504,7 +7685,7 @@ export const GetResourcesCountV1AutocrudSkillCountGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7555,7 +7736,9 @@ export const GetResourcesCountV1AutocrudSkillCountGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudSkillCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudSkillCountGetQueryOffsetDefault)
@@ -7592,7 +7775,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List skill resources
  */
 export const listResourcesV1AutocrudSkillGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudSkillGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudSkillGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudSkillGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudSkillGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -7601,7 +7784,7 @@ export const ListResourcesV1AutocrudSkillGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7652,7 +7835,9 @@ export const ListResourcesV1AutocrudSkillGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudSkillGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudSkillGetQueryOffsetDefault)
@@ -7933,7 +8118,7 @@ export const CreateResourceV1AutocrudSkillPostResponse = zod
  * @summary Batch delete skill
  */
 export const batchDeleteV1AutocrudSkillDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudSkillDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudSkillDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudSkillDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudSkillDeleteQueryParams = zod.object({
@@ -7941,7 +8126,7 @@ export const BatchDeleteV1AutocrudSkillDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -7992,7 +8177,9 @@ export const BatchDeleteV1AutocrudSkillDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudSkillDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudSkillDeleteQueryOffsetDefault)
@@ -8038,7 +8225,7 @@ which resources are included.
  * @summary Export skill data
  */
 export const exportModelV1AutocrudSkillExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudSkillExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudSkillExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudSkillExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudSkillExportGetQueryParams = zod.object({
@@ -8046,7 +8233,7 @@ export const ExportModelV1AutocrudSkillExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -8097,7 +8284,9 @@ export const ExportModelV1AutocrudSkillExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudSkillExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudSkillExportGetQueryOffsetDefault)
@@ -9466,7 +9655,7 @@ export const RestoreResourceV1AutocrudSkillResourceIdRestorePostResponse = zod
  * @summary Batch restore deleted skill
  */
 export const batchRestoreV1AutocrudSkillRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudSkillRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudSkillRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudSkillRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudSkillRestorePostQueryParams = zod.object({
@@ -9474,7 +9663,7 @@ export const BatchRestoreV1AutocrudSkillRestorePostQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -9525,7 +9714,9 @@ export const BatchRestoreV1AutocrudSkillRestorePostQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudSkillRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudSkillRestorePostQueryOffsetDefault)
@@ -9575,7 +9766,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudSkillMigrateTestPostQueryParams = zod.object({
@@ -9583,7 +9774,7 @@ export const TestMigrateResourcesV1AutocrudSkillMigrateTestPostQueryParams = zod
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -9634,7 +9825,9 @@ export const TestMigrateResourcesV1AutocrudSkillMigrateTestPostQueryParams = zod
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudSkillMigrateTestPostQueryOffsetDefault)
@@ -9664,7 +9857,7 @@ export const TestMigrateResourcesV1AutocrudSkillMigrateTestPostResponse = zod.un
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryParams = zod.object({
@@ -9672,7 +9865,7 @@ export const ExecuteMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -9723,7 +9916,9 @@ export const ExecuteMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryParams
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudSkillMigrateExecutePostQueryOffsetDefault)
@@ -9856,8 +10051,9 @@ export const MigrateSingleResourceV1AutocrudSkillMigrateSingleResourceIdPostResp
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -9870,7 +10066,7 @@ export const MigrateSingleResourceV1AutocrudSkillMigrateSingleResourceIdPostResp
 - Direct access to resource content only
 
 **Examples:**
-- `GET /equipment/data` - Get first 10 resources (data only)
+- `GET /equipment/data` - Get the default first page of resources (data only)
 - `GET /equipment/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /equipment/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /equipment/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -9881,7 +10077,7 @@ export const MigrateSingleResourceV1AutocrudSkillMigrateSingleResourceIdPostResp
  * @summary List equipment Data Only
  */
 export const listResourcesDataV1AutocrudEquipmentDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudEquipmentDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudEquipmentDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudEquipmentDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudEquipmentDataGetQueryParams = zod.object({
@@ -9889,7 +10085,7 @@ export const ListResourcesDataV1AutocrudEquipmentDataGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -9940,7 +10136,9 @@ export const ListResourcesDataV1AutocrudEquipmentDataGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudEquipmentDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudEquipmentDataGetQueryOffsetDefault)
@@ -10054,8 +10252,9 @@ export const ListResourcesDataV1AutocrudEquipmentDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -10064,7 +10263,7 @@ export const ListResourcesDataV1AutocrudEquipmentDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /equipment/meta` - Get metadata for first 10 resources
+- `GET /equipment/meta` - Get metadata for the default first page of resources
 - `GET /equipment/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /equipment/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -10074,7 +10273,7 @@ export const ListResourcesDataV1AutocrudEquipmentDataGetResponse = zod.array(
  * @summary List equipment Metadata Only
  */
 export const listResourcesMetaV1AutocrudEquipmentMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudEquipmentMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudEquipmentMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudEquipmentMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudEquipmentMetaGetQueryParams = zod.object({
@@ -10082,7 +10281,7 @@ export const ListResourcesMetaV1AutocrudEquipmentMetaGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -10133,7 +10332,9 @@ export const ListResourcesMetaV1AutocrudEquipmentMetaGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudEquipmentMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudEquipmentMetaGetQueryOffsetDefault)
@@ -10212,8 +10413,9 @@ export const ListResourcesMetaV1AutocrudEquipmentMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -10222,8 +10424,8 @@ export const ListResourcesMetaV1AutocrudEquipmentMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /equipment/revision-info` - Get current revision info for first 10 resources
-- `GET /equipment/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /equipment/revision-info` - Get current revision info for the default first page of resources
+- `GET /equipment/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /equipment/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -10232,7 +10434,7 @@ export const ListResourcesMetaV1AutocrudEquipmentMetaGetResponse = zod.array(
  * @summary List equipment Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryParams = zod.object({
@@ -10240,7 +10442,7 @@ export const ListResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryPar
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -10291,7 +10493,9 @@ export const ListResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryPar
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetQueryOffsetDefault)
@@ -10343,7 +10547,7 @@ export const ListResourcesRevisionInfoV1AutocrudEquipmentRevisionInfoGetResponse
  * @summary List equipment Complete Information
  */
 export const listResourcesFullV1AutocrudEquipmentFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudEquipmentFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudEquipmentFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudEquipmentFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudEquipmentFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -10352,7 +10556,7 @@ export const ListResourcesFullV1AutocrudEquipmentFullGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -10403,7 +10607,9 @@ export const ListResourcesFullV1AutocrudEquipmentFullGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudEquipmentFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudEquipmentFullGetQueryOffsetDefault)
@@ -10573,7 +10779,7 @@ export const ListResourcesFullV1AutocrudEquipmentFullGetResponse = zod.array(
  * @summary Count equipment Resources
  */
 export const getResourcesCountV1AutocrudEquipmentCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudEquipmentCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudEquipmentCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudEquipmentCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudEquipmentCountGetQueryParams = zod.object({
@@ -10581,7 +10787,7 @@ export const GetResourcesCountV1AutocrudEquipmentCountGetQueryParams = zod.objec
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -10632,7 +10838,9 @@ export const GetResourcesCountV1AutocrudEquipmentCountGetQueryParams = zod.objec
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudEquipmentCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudEquipmentCountGetQueryOffsetDefault)
@@ -10669,7 +10877,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List equipment resources
  */
 export const listResourcesV1AutocrudEquipmentGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudEquipmentGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudEquipmentGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudEquipmentGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudEquipmentGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -10678,7 +10886,7 @@ export const ListResourcesV1AutocrudEquipmentGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -10729,7 +10937,9 @@ export const ListResourcesV1AutocrudEquipmentGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudEquipmentGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudEquipmentGetQueryOffsetDefault)
@@ -10970,7 +11180,7 @@ export const CreateResourceV1AutocrudEquipmentPostResponse = zod
  * @summary Batch delete equipment
  */
 export const batchDeleteV1AutocrudEquipmentDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudEquipmentDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudEquipmentDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudEquipmentDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudEquipmentDeleteQueryParams = zod.object({
@@ -10978,7 +11188,7 @@ export const BatchDeleteV1AutocrudEquipmentDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -11029,7 +11239,9 @@ export const BatchDeleteV1AutocrudEquipmentDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudEquipmentDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudEquipmentDeleteQueryOffsetDefault)
@@ -11075,7 +11287,7 @@ which resources are included.
  * @summary Export equipment data
  */
 export const exportModelV1AutocrudEquipmentExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudEquipmentExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudEquipmentExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudEquipmentExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudEquipmentExportGetQueryParams = zod.object({
@@ -11083,7 +11295,7 @@ export const ExportModelV1AutocrudEquipmentExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -11134,7 +11346,9 @@ export const ExportModelV1AutocrudEquipmentExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudEquipmentExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudEquipmentExportGetQueryOffsetDefault)
@@ -12420,7 +12634,7 @@ export const RestoreResourceV1AutocrudEquipmentResourceIdRestorePostResponse = z
  * @summary Batch restore deleted equipment
  */
 export const batchRestoreV1AutocrudEquipmentRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudEquipmentRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudEquipmentRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudEquipmentRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudEquipmentRestorePostQueryParams = zod.object({
@@ -12428,7 +12642,7 @@ export const BatchRestoreV1AutocrudEquipmentRestorePostQueryParams = zod.object(
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -12479,7 +12693,9 @@ export const BatchRestoreV1AutocrudEquipmentRestorePostQueryParams = zod.object(
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudEquipmentRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudEquipmentRestorePostQueryOffsetDefault)
@@ -12529,7 +12745,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryParams = zod.object({
@@ -12537,7 +12753,7 @@ export const TestMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryParams =
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -12588,7 +12804,9 @@ export const TestMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryParams =
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudEquipmentMigrateTestPostQueryOffsetDefault)
@@ -12618,7 +12836,7 @@ export const TestMigrateResourcesV1AutocrudEquipmentMigrateTestPostResponse = zo
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryParams = zod.object({
@@ -12626,7 +12844,7 @@ export const ExecuteMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryPa
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -12677,7 +12895,9 @@ export const ExecuteMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryPa
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudEquipmentMigrateExecutePostQueryOffsetDefault)
@@ -12816,8 +13036,9 @@ export const MigrateSingleResourceV1AutocrudEquipmentMigrateSingleResourceIdPost
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -12830,7 +13051,7 @@ export const MigrateSingleResourceV1AutocrudEquipmentMigrateSingleResourceIdPost
 - Direct access to resource content only
 
 **Examples:**
-- `GET /pet/data` - Get first 10 resources (data only)
+- `GET /pet/data` - Get the default first page of resources (data only)
 - `GET /pet/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /pet/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /pet/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -12841,7 +13062,7 @@ export const MigrateSingleResourceV1AutocrudEquipmentMigrateSingleResourceIdPost
  * @summary List pet Data Only
  */
 export const listResourcesDataV1AutocrudPetDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudPetDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudPetDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudPetDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudPetDataGetQueryParams = zod.object({
@@ -12849,7 +13070,7 @@ export const ListResourcesDataV1AutocrudPetDataGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -12900,7 +13121,9 @@ export const ListResourcesDataV1AutocrudPetDataGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudPetDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudPetDataGetQueryOffsetDefault)
@@ -12998,8 +13221,9 @@ export const ListResourcesDataV1AutocrudPetDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -13008,7 +13232,7 @@ export const ListResourcesDataV1AutocrudPetDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /pet/meta` - Get metadata for first 10 resources
+- `GET /pet/meta` - Get metadata for the default first page of resources
 - `GET /pet/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /pet/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -13018,7 +13242,7 @@ export const ListResourcesDataV1AutocrudPetDataGetResponse = zod.array(
  * @summary List pet Metadata Only
  */
 export const listResourcesMetaV1AutocrudPetMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudPetMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudPetMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudPetMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudPetMetaGetQueryParams = zod.object({
@@ -13026,7 +13250,7 @@ export const ListResourcesMetaV1AutocrudPetMetaGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13077,7 +13301,9 @@ export const ListResourcesMetaV1AutocrudPetMetaGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudPetMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudPetMetaGetQueryOffsetDefault)
@@ -13156,8 +13382,9 @@ export const ListResourcesMetaV1AutocrudPetMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -13166,8 +13393,8 @@ export const ListResourcesMetaV1AutocrudPetMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /pet/revision-info` - Get current revision info for first 10 resources
-- `GET /pet/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /pet/revision-info` - Get current revision info for the default first page of resources
+- `GET /pet/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /pet/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -13176,7 +13403,7 @@ export const ListResourcesMetaV1AutocrudPetMetaGetResponse = zod.array(
  * @summary List pet Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryParams = zod.object({
@@ -13184,7 +13411,7 @@ export const ListResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryParams = 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13235,7 +13462,9 @@ export const ListResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryParams = 
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudPetRevisionInfoGetQueryOffsetDefault)
@@ -13285,7 +13514,7 @@ export const ListResourcesRevisionInfoV1AutocrudPetRevisionInfoGetResponse = zod
  * @summary List pet Complete Information
  */
 export const listResourcesFullV1AutocrudPetFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudPetFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudPetFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudPetFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudPetFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -13294,7 +13523,7 @@ export const ListResourcesFullV1AutocrudPetFullGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13345,7 +13574,9 @@ export const ListResourcesFullV1AutocrudPetFullGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudPetFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudPetFullGetQueryOffsetDefault)
@@ -13503,7 +13734,7 @@ export const ListResourcesFullV1AutocrudPetFullGetResponse = zod.array(
  * @summary Count pet Resources
  */
 export const getResourcesCountV1AutocrudPetCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudPetCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudPetCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudPetCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudPetCountGetQueryParams = zod.object({
@@ -13511,7 +13742,7 @@ export const GetResourcesCountV1AutocrudPetCountGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13562,7 +13793,9 @@ export const GetResourcesCountV1AutocrudPetCountGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudPetCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudPetCountGetQueryOffsetDefault)
@@ -13599,7 +13832,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List pet resources
  */
 export const listResourcesV1AutocrudPetGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudPetGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudPetGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudPetGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudPetGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -13608,7 +13841,7 @@ export const ListResourcesV1AutocrudPetGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13659,7 +13892,9 @@ export const ListResourcesV1AutocrudPetGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudPetGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudPetGetQueryOffsetDefault)
@@ -13869,7 +14104,7 @@ export const CreateResourceV1AutocrudPetPostResponse = zod
  * @summary Batch delete pet
  */
 export const batchDeleteV1AutocrudPetDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudPetDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudPetDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudPetDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudPetDeleteQueryParams = zod.object({
@@ -13877,7 +14112,7 @@ export const BatchDeleteV1AutocrudPetDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -13928,7 +14163,9 @@ export const BatchDeleteV1AutocrudPetDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudPetDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudPetDeleteQueryOffsetDefault)
@@ -13974,7 +14211,7 @@ which resources are included.
  * @summary Export pet data
  */
 export const exportModelV1AutocrudPetExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudPetExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudPetExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudPetExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudPetExportGetQueryParams = zod.object({
@@ -13982,7 +14219,7 @@ export const ExportModelV1AutocrudPetExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -14033,7 +14270,9 @@ export const ExportModelV1AutocrudPetExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudPetExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudPetExportGetQueryOffsetDefault)
@@ -15244,7 +15483,7 @@ export const RestoreResourceV1AutocrudPetResourceIdRestorePostResponse = zod
  * @summary Batch restore deleted pet
  */
 export const batchRestoreV1AutocrudPetRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudPetRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudPetRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudPetRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudPetRestorePostQueryParams = zod.object({
@@ -15252,7 +15491,7 @@ export const BatchRestoreV1AutocrudPetRestorePostQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -15303,7 +15542,9 @@ export const BatchRestoreV1AutocrudPetRestorePostQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudPetRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudPetRestorePostQueryOffsetDefault)
@@ -15351,7 +15592,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudPetMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudPetMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudPetMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudPetMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudPetMigrateTestPostQueryParams = zod.object({
@@ -15359,7 +15600,7 @@ export const TestMigrateResourcesV1AutocrudPetMigrateTestPostQueryParams = zod.o
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -15410,7 +15651,9 @@ export const TestMigrateResourcesV1AutocrudPetMigrateTestPostQueryParams = zod.o
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudPetMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudPetMigrateTestPostQueryOffsetDefault)
@@ -15440,7 +15683,7 @@ export const TestMigrateResourcesV1AutocrudPetMigrateTestPostResponse = zod.unkn
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudPetMigrateExecutePostQueryParams = zod.object({
@@ -15448,7 +15691,7 @@ export const ExecuteMigrateResourcesV1AutocrudPetMigrateExecutePostQueryParams =
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -15499,7 +15742,9 @@ export const ExecuteMigrateResourcesV1AutocrudPetMigrateExecutePostQueryParams =
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudPetMigrateExecutePostQueryOffsetDefault)
@@ -15629,8 +15874,9 @@ export const MigrateSingleResourceV1AutocrudPetMigrateSingleResourceIdPostRespon
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -15643,7 +15889,7 @@ export const MigrateSingleResourceV1AutocrudPetMigrateSingleResourceIdPostRespon
 - Direct access to resource content only
 
 **Examples:**
-- `GET /pet-job/data` - Get first 10 resources (data only)
+- `GET /pet-job/data` - Get the default first page of resources (data only)
 - `GET /pet-job/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /pet-job/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /pet-job/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -15654,7 +15900,7 @@ export const MigrateSingleResourceV1AutocrudPetMigrateSingleResourceIdPostRespon
  * @summary List pet-job Data Only
  */
 export const listResourcesDataV1AutocrudPetJobDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudPetJobDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudPetJobDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudPetJobDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudPetJobDataGetQueryParams = zod.object({
@@ -15662,7 +15908,7 @@ export const ListResourcesDataV1AutocrudPetJobDataGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -15713,7 +15959,9 @@ export const ListResourcesDataV1AutocrudPetJobDataGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudPetJobDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudPetJobDataGetQueryOffsetDefault)
@@ -15868,8 +16116,9 @@ export const ListResourcesDataV1AutocrudPetJobDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -15878,7 +16127,7 @@ export const ListResourcesDataV1AutocrudPetJobDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /pet-job/meta` - Get metadata for first 10 resources
+- `GET /pet-job/meta` - Get metadata for the default first page of resources
 - `GET /pet-job/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /pet-job/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -15888,7 +16137,7 @@ export const ListResourcesDataV1AutocrudPetJobDataGetResponse = zod.array(
  * @summary List pet-job Metadata Only
  */
 export const listResourcesMetaV1AutocrudPetJobMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudPetJobMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudPetJobMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudPetJobMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudPetJobMetaGetQueryParams = zod.object({
@@ -15896,7 +16145,7 @@ export const ListResourcesMetaV1AutocrudPetJobMetaGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -15947,7 +16196,9 @@ export const ListResourcesMetaV1AutocrudPetJobMetaGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudPetJobMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudPetJobMetaGetQueryOffsetDefault)
@@ -16026,8 +16277,9 @@ export const ListResourcesMetaV1AutocrudPetJobMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -16036,8 +16288,8 @@ export const ListResourcesMetaV1AutocrudPetJobMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /pet-job/revision-info` - Get current revision info for first 10 resources
-- `GET /pet-job/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /pet-job/revision-info` - Get current revision info for the default first page of resources
+- `GET /pet-job/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /pet-job/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -16046,7 +16298,7 @@ export const ListResourcesMetaV1AutocrudPetJobMetaGetResponse = zod.array(
  * @summary List pet-job Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryParams = zod.object({
@@ -16054,7 +16306,7 @@ export const ListResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -16105,7 +16357,9 @@ export const ListResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryParams
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetQueryOffsetDefault)
@@ -16157,7 +16411,7 @@ export const ListResourcesRevisionInfoV1AutocrudPetJobRevisionInfoGetResponse = 
  * @summary List pet-job Complete Information
  */
 export const listResourcesFullV1AutocrudPetJobFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudPetJobFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudPetJobFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudPetJobFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudPetJobFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -16166,7 +16420,7 @@ export const ListResourcesFullV1AutocrudPetJobFullGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -16217,7 +16471,9 @@ export const ListResourcesFullV1AutocrudPetJobFullGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudPetJobFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudPetJobFullGetQueryOffsetDefault)
@@ -16437,7 +16693,7 @@ export const ListResourcesFullV1AutocrudPetJobFullGetResponse = zod.array(
  * @summary Count pet-job Resources
  */
 export const getResourcesCountV1AutocrudPetJobCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudPetJobCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudPetJobCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudPetJobCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudPetJobCountGetQueryParams = zod.object({
@@ -16445,7 +16701,7 @@ export const GetResourcesCountV1AutocrudPetJobCountGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -16496,7 +16752,9 @@ export const GetResourcesCountV1AutocrudPetJobCountGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudPetJobCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudPetJobCountGetQueryOffsetDefault)
@@ -16533,7 +16791,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List pet-job resources
  */
 export const listResourcesV1AutocrudPetJobGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudPetJobGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudPetJobGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudPetJobGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudPetJobGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -16542,7 +16800,7 @@ export const ListResourcesV1AutocrudPetJobGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -16593,7 +16851,9 @@ export const ListResourcesV1AutocrudPetJobGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudPetJobGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudPetJobGetQueryOffsetDefault)
@@ -16906,7 +17166,7 @@ export const CreateResourceV1AutocrudPetJobPostResponse = zod
  * @summary Batch delete pet-job
  */
 export const batchDeleteV1AutocrudPetJobDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudPetJobDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudPetJobDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudPetJobDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudPetJobDeleteQueryParams = zod.object({
@@ -16914,7 +17174,7 @@ export const BatchDeleteV1AutocrudPetJobDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -16965,7 +17225,9 @@ export const BatchDeleteV1AutocrudPetJobDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudPetJobDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudPetJobDeleteQueryOffsetDefault)
@@ -17011,7 +17273,7 @@ which resources are included.
  * @summary Export pet-job data
  */
 export const exportModelV1AutocrudPetJobExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudPetJobExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudPetJobExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudPetJobExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudPetJobExportGetQueryParams = zod.object({
@@ -17019,7 +17281,7 @@ export const ExportModelV1AutocrudPetJobExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -17070,7 +17332,9 @@ export const ExportModelV1AutocrudPetJobExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudPetJobExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudPetJobExportGetQueryOffsetDefault)
@@ -18551,7 +18815,7 @@ export const RestoreResourceV1AutocrudPetJobResourceIdRestorePostResponse = zod
  * @summary Batch restore deleted pet-job
  */
 export const batchRestoreV1AutocrudPetJobRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudPetJobRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudPetJobRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudPetJobRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudPetJobRestorePostQueryParams = zod.object({
@@ -18559,7 +18823,7 @@ export const BatchRestoreV1AutocrudPetJobRestorePostQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -18610,7 +18874,9 @@ export const BatchRestoreV1AutocrudPetJobRestorePostQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudPetJobRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudPetJobRestorePostQueryOffsetDefault)
@@ -18660,7 +18926,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryParams = zod.object({
@@ -18668,7 +18934,7 @@ export const TestMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryParams = zo
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -18719,7 +18985,9 @@ export const TestMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryParams = zo
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudPetJobMigrateTestPostQueryOffsetDefault)
@@ -18749,7 +19017,7 @@ export const TestMigrateResourcesV1AutocrudPetJobMigrateTestPostResponse = zod.u
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryParams = zod.object({
@@ -18757,7 +19025,7 @@ export const ExecuteMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryParam
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -18808,7 +19076,9 @@ export const ExecuteMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryParam
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudPetJobMigrateExecutePostQueryOffsetDefault)
@@ -18945,8 +19215,9 @@ export const MigrateSingleResourceV1AutocrudPetJobMigrateSingleResourceIdPostRes
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -18959,7 +19230,7 @@ export const MigrateSingleResourceV1AutocrudPetJobMigrateSingleResourceIdPostRes
 - Direct access to resource content only
 
 **Examples:**
-- `GET /quest/data` - Get first 10 resources (data only)
+- `GET /quest/data` - Get the default first page of resources (data only)
 - `GET /quest/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /quest/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /quest/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -18970,7 +19241,7 @@ export const MigrateSingleResourceV1AutocrudPetJobMigrateSingleResourceIdPostRes
  * @summary List quest Data Only
  */
 export const listResourcesDataV1AutocrudQuestDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudQuestDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudQuestDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudQuestDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudQuestDataGetQueryParams = zod.object({
@@ -18978,7 +19249,7 @@ export const ListResourcesDataV1AutocrudQuestDataGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19029,7 +19300,9 @@ export const ListResourcesDataV1AutocrudQuestDataGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudQuestDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudQuestDataGetQueryOffsetDefault)
@@ -19174,8 +19447,9 @@ export const ListResourcesDataV1AutocrudQuestDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -19184,7 +19458,7 @@ export const ListResourcesDataV1AutocrudQuestDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /quest/meta` - Get metadata for first 10 resources
+- `GET /quest/meta` - Get metadata for the default first page of resources
 - `GET /quest/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /quest/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -19194,7 +19468,7 @@ export const ListResourcesDataV1AutocrudQuestDataGetResponse = zod.array(
  * @summary List quest Metadata Only
  */
 export const listResourcesMetaV1AutocrudQuestMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudQuestMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudQuestMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudQuestMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudQuestMetaGetQueryParams = zod.object({
@@ -19202,7 +19476,7 @@ export const ListResourcesMetaV1AutocrudQuestMetaGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19253,7 +19527,9 @@ export const ListResourcesMetaV1AutocrudQuestMetaGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudQuestMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudQuestMetaGetQueryOffsetDefault)
@@ -19332,8 +19608,9 @@ export const ListResourcesMetaV1AutocrudQuestMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -19342,8 +19619,8 @@ export const ListResourcesMetaV1AutocrudQuestMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /quest/revision-info` - Get current revision info for first 10 resources
-- `GET /quest/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /quest/revision-info` - Get current revision info for the default first page of resources
+- `GET /quest/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /quest/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -19352,7 +19629,7 @@ export const ListResourcesMetaV1AutocrudQuestMetaGetResponse = zod.array(
  * @summary List quest Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryParams = zod.object({
@@ -19360,7 +19637,7 @@ export const ListResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryParams 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19411,7 +19688,9 @@ export const ListResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryParams 
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetQueryOffsetDefault)
@@ -19461,7 +19740,7 @@ export const ListResourcesRevisionInfoV1AutocrudQuestRevisionInfoGetResponse = z
  * @summary List quest Complete Information
  */
 export const listResourcesFullV1AutocrudQuestFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudQuestFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudQuestFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudQuestFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudQuestFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -19470,7 +19749,7 @@ export const ListResourcesFullV1AutocrudQuestFullGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19521,7 +19800,9 @@ export const ListResourcesFullV1AutocrudQuestFullGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudQuestFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudQuestFullGetQueryOffsetDefault)
@@ -19720,7 +20001,7 @@ export const ListResourcesFullV1AutocrudQuestFullGetResponse = zod.array(
  * @summary Count quest Resources
  */
 export const getResourcesCountV1AutocrudQuestCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudQuestCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudQuestCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudQuestCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudQuestCountGetQueryParams = zod.object({
@@ -19728,7 +20009,7 @@ export const GetResourcesCountV1AutocrudQuestCountGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19779,7 +20060,9 @@ export const GetResourcesCountV1AutocrudQuestCountGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudQuestCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudQuestCountGetQueryOffsetDefault)
@@ -19816,7 +20099,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List quest resources
  */
 export const listResourcesV1AutocrudQuestGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudQuestGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudQuestGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudQuestGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudQuestGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -19825,7 +20108,7 @@ export const ListResourcesV1AutocrudQuestGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -19876,7 +20159,9 @@ export const ListResourcesV1AutocrudQuestGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudQuestGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudQuestGetQueryOffsetDefault)
@@ -20165,7 +20450,7 @@ export const CreateResourceV1AutocrudQuestPostResponse = zod
  * @summary Batch delete quest
  */
 export const batchDeleteV1AutocrudQuestDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudQuestDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudQuestDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudQuestDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudQuestDeleteQueryParams = zod.object({
@@ -20173,7 +20458,7 @@ export const BatchDeleteV1AutocrudQuestDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -20224,7 +20509,9 @@ export const BatchDeleteV1AutocrudQuestDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudQuestDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudQuestDeleteQueryOffsetDefault)
@@ -20270,7 +20557,7 @@ which resources are included.
  * @summary Export quest data
  */
 export const exportModelV1AutocrudQuestExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudQuestExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudQuestExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudQuestExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudQuestExportGetQueryParams = zod.object({
@@ -20278,7 +20565,7 @@ export const ExportModelV1AutocrudQuestExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -20329,7 +20616,9 @@ export const ExportModelV1AutocrudQuestExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudQuestExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudQuestExportGetQueryOffsetDefault)
@@ -21709,7 +21998,7 @@ export const RestoreResourceV1AutocrudQuestResourceIdRestorePostResponse = zod
  * @summary Batch restore deleted quest
  */
 export const batchRestoreV1AutocrudQuestRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudQuestRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudQuestRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudQuestRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudQuestRestorePostQueryParams = zod.object({
@@ -21717,7 +22006,7 @@ export const BatchRestoreV1AutocrudQuestRestorePostQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -21768,7 +22057,9 @@ export const BatchRestoreV1AutocrudQuestRestorePostQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudQuestRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudQuestRestorePostQueryOffsetDefault)
@@ -21818,7 +22109,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudQuestMigrateTestPostQueryParams = zod.object({
@@ -21826,7 +22117,7 @@ export const TestMigrateResourcesV1AutocrudQuestMigrateTestPostQueryParams = zod
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -21877,7 +22168,9 @@ export const TestMigrateResourcesV1AutocrudQuestMigrateTestPostQueryParams = zod
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudQuestMigrateTestPostQueryOffsetDefault)
@@ -21907,7 +22200,7 @@ export const TestMigrateResourcesV1AutocrudQuestMigrateTestPostResponse = zod.un
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryParams = zod.object({
@@ -21915,7 +22208,7 @@ export const ExecuteMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -21966,7 +22259,9 @@ export const ExecuteMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryParams
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudQuestMigrateExecutePostQueryOffsetDefault)
@@ -22099,8 +22394,9 @@ export const MigrateSingleResourceV1AutocrudQuestMigrateSingleResourceIdPostResp
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -22113,7 +22409,7 @@ export const MigrateSingleResourceV1AutocrudQuestMigrateSingleResourceIdPostResp
 - Direct access to resource content only
 
 **Examples:**
-- `GET /game-event/data` - Get first 10 resources (data only)
+- `GET /game-event/data` - Get the default first page of resources (data only)
 - `GET /game-event/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /game-event/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /game-event/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -22124,7 +22420,7 @@ export const MigrateSingleResourceV1AutocrudQuestMigrateSingleResourceIdPostResp
  * @summary List game-event Data Only
  */
 export const listResourcesDataV1AutocrudGameEventDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudGameEventDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudGameEventDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudGameEventDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudGameEventDataGetQueryParams = zod.object({
@@ -22132,7 +22428,7 @@ export const ListResourcesDataV1AutocrudGameEventDataGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -22183,7 +22479,9 @@ export const ListResourcesDataV1AutocrudGameEventDataGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudGameEventDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudGameEventDataGetQueryOffsetDefault)
@@ -22373,8 +22671,9 @@ export const ListResourcesDataV1AutocrudGameEventDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -22383,7 +22682,7 @@ export const ListResourcesDataV1AutocrudGameEventDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /game-event/meta` - Get metadata for first 10 resources
+- `GET /game-event/meta` - Get metadata for the default first page of resources
 - `GET /game-event/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /game-event/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -22393,7 +22692,7 @@ export const ListResourcesDataV1AutocrudGameEventDataGetResponse = zod.array(
  * @summary List game-event Metadata Only
  */
 export const listResourcesMetaV1AutocrudGameEventMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudGameEventMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudGameEventMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudGameEventMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudGameEventMetaGetQueryParams = zod.object({
@@ -22401,7 +22700,7 @@ export const ListResourcesMetaV1AutocrudGameEventMetaGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -22452,7 +22751,9 @@ export const ListResourcesMetaV1AutocrudGameEventMetaGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudGameEventMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudGameEventMetaGetQueryOffsetDefault)
@@ -22531,8 +22832,9 @@ export const ListResourcesMetaV1AutocrudGameEventMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -22541,8 +22843,8 @@ export const ListResourcesMetaV1AutocrudGameEventMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /game-event/revision-info` - Get current revision info for first 10 resources
-- `GET /game-event/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /game-event/revision-info` - Get current revision info for the default first page of resources
+- `GET /game-event/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /game-event/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -22551,7 +22853,7 @@ export const ListResourcesMetaV1AutocrudGameEventMetaGetResponse = zod.array(
  * @summary List game-event Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryParams = zod.object({
@@ -22559,7 +22861,7 @@ export const ListResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryPar
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -22610,7 +22912,9 @@ export const ListResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryPar
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetQueryOffsetDefault)
@@ -22662,7 +22966,7 @@ export const ListResourcesRevisionInfoV1AutocrudGameEventRevisionInfoGetResponse
  * @summary List game-event Complete Information
  */
 export const listResourcesFullV1AutocrudGameEventFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudGameEventFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudGameEventFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudGameEventFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudGameEventFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -22671,7 +22975,7 @@ export const ListResourcesFullV1AutocrudGameEventFullGetQueryParams = zod.object
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -22722,7 +23026,9 @@ export const ListResourcesFullV1AutocrudGameEventFullGetQueryParams = zod.object
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudGameEventFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudGameEventFullGetQueryOffsetDefault)
@@ -22978,7 +23284,7 @@ export const ListResourcesFullV1AutocrudGameEventFullGetResponse = zod.array(
  * @summary Count game-event Resources
  */
 export const getResourcesCountV1AutocrudGameEventCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudGameEventCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudGameEventCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudGameEventCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudGameEventCountGetQueryParams = zod.object({
@@ -22986,7 +23292,7 @@ export const GetResourcesCountV1AutocrudGameEventCountGetQueryParams = zod.objec
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -23037,7 +23343,9 @@ export const GetResourcesCountV1AutocrudGameEventCountGetQueryParams = zod.objec
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudGameEventCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudGameEventCountGetQueryOffsetDefault)
@@ -23074,7 +23382,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List game-event resources
  */
 export const listResourcesV1AutocrudGameEventGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudGameEventGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudGameEventGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudGameEventGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudGameEventGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -23083,7 +23391,7 @@ export const ListResourcesV1AutocrudGameEventGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -23134,7 +23442,9 @@ export const ListResourcesV1AutocrudGameEventGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudGameEventGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudGameEventGetQueryOffsetDefault)
@@ -23518,7 +23828,7 @@ export const CreateResourceV1AutocrudGameEventPostResponse = zod
  * @summary Batch delete game-event
  */
 export const batchDeleteV1AutocrudGameEventDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudGameEventDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudGameEventDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudGameEventDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudGameEventDeleteQueryParams = zod.object({
@@ -23526,7 +23836,7 @@ export const BatchDeleteV1AutocrudGameEventDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -23577,7 +23887,9 @@ export const BatchDeleteV1AutocrudGameEventDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudGameEventDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudGameEventDeleteQueryOffsetDefault)
@@ -23623,7 +23935,7 @@ which resources are included.
  * @summary Export game-event data
  */
 export const exportModelV1AutocrudGameEventExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudGameEventExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudGameEventExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudGameEventExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudGameEventExportGetQueryParams = zod.object({
@@ -23631,7 +23943,7 @@ export const ExportModelV1AutocrudGameEventExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -23682,7 +23994,9 @@ export const ExportModelV1AutocrudGameEventExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudGameEventExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudGameEventExportGetQueryOffsetDefault)
@@ -25366,7 +25680,7 @@ export const RestoreResourceV1AutocrudGameEventResourceIdRestorePostResponse = z
  * @summary Batch restore deleted game-event
  */
 export const batchRestoreV1AutocrudGameEventRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudGameEventRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudGameEventRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudGameEventRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudGameEventRestorePostQueryParams = zod.object({
@@ -25374,7 +25688,7 @@ export const BatchRestoreV1AutocrudGameEventRestorePostQueryParams = zod.object(
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -25425,7 +25739,9 @@ export const BatchRestoreV1AutocrudGameEventRestorePostQueryParams = zod.object(
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudGameEventRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudGameEventRestorePostQueryOffsetDefault)
@@ -25475,7 +25791,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryParams = zod.object({
@@ -25483,7 +25799,7 @@ export const TestMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryParams =
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -25534,7 +25850,9 @@ export const TestMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryParams =
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudGameEventMigrateTestPostQueryOffsetDefault)
@@ -25564,7 +25882,7 @@ export const TestMigrateResourcesV1AutocrudGameEventMigrateTestPostResponse = zo
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryParams = zod.object({
@@ -25572,7 +25890,7 @@ export const ExecuteMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryPa
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -25623,7 +25941,9 @@ export const ExecuteMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryPa
   limit: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(executeMigrateResourcesV1AutocrudGameEventMigrateExecutePostQueryOffsetDefault)
@@ -25762,8 +26082,9 @@ export const MigrateSingleResourceV1AutocrudGameEventMigrateSingleResourceIdPost
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -25776,7 +26097,7 @@ export const MigrateSingleResourceV1AutocrudGameEventMigrateSingleResourceIdPost
 - Direct access to resource content only
 
 **Examples:**
-- `GET /new-char1-job/data` - Get first 10 resources (data only)
+- `GET /new-char1-job/data` - Get the default first page of resources (data only)
 - `GET /new-char1-job/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /new-char1-job/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /new-char1-job/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -25787,7 +26108,7 @@ export const MigrateSingleResourceV1AutocrudGameEventMigrateSingleResourceIdPost
  * @summary List new-char1-job Data Only
  */
 export const listResourcesDataV1AutocrudNewChar1JobDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudNewChar1JobDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudNewChar1JobDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudNewChar1JobDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudNewChar1JobDataGetQueryParams = zod.object({
@@ -25795,7 +26116,7 @@ export const ListResourcesDataV1AutocrudNewChar1JobDataGetQueryParams = zod.obje
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -25846,7 +26167,9 @@ export const ListResourcesDataV1AutocrudNewChar1JobDataGetQueryParams = zod.obje
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudNewChar1JobDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudNewChar1JobDataGetQueryOffsetDefault)
@@ -25961,8 +26284,9 @@ export const ListResourcesDataV1AutocrudNewChar1JobDataGetResponse = zod.array(
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -25971,7 +26295,7 @@ export const ListResourcesDataV1AutocrudNewChar1JobDataGetResponse = zod.array(
 - System monitoring and statistics
 
 **Examples:**
-- `GET /new-char1-job/meta` - Get metadata for first 10 resources
+- `GET /new-char1-job/meta` - Get metadata for the default first page of resources
 - `GET /new-char1-job/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /new-char1-job/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -25981,7 +26305,7 @@ export const ListResourcesDataV1AutocrudNewChar1JobDataGetResponse = zod.array(
  * @summary List new-char1-job Metadata Only
  */
 export const listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetQueryParams = zod.object({
@@ -25989,7 +26313,7 @@ export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetQueryParams = zod.obje
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26040,7 +26364,9 @@ export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetQueryParams = zod.obje
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudNewChar1JobMetaGetQueryOffsetDefault)
@@ -26119,8 +26445,9 @@ export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetResponse = zod.array(
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -26129,8 +26456,8 @@ export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetResponse = zod.array(
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /new-char1-job/revision-info` - Get current revision info for first 10 resources
-- `GET /new-char1-job/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /new-char1-job/revision-info` - Get current revision info for the default first page of resources
+- `GET /new-char1-job/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /new-char1-job/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -26139,7 +26466,7 @@ export const ListResourcesMetaV1AutocrudNewChar1JobMetaGetResponse = zod.array(
  * @summary List new-char1-job Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryParams = zod.object({
@@ -26147,7 +26474,7 @@ export const ListResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryP
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26198,7 +26525,9 @@ export const ListResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryP
   limit: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetQueryOffsetDefault)
@@ -26250,7 +26579,7 @@ export const ListResourcesRevisionInfoV1AutocrudNewChar1JobRevisionInfoGetRespon
  * @summary List new-char1-job Complete Information
  */
 export const listResourcesFullV1AutocrudNewChar1JobFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudNewChar1JobFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudNewChar1JobFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudNewChar1JobFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudNewChar1JobFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -26259,7 +26588,7 @@ export const ListResourcesFullV1AutocrudNewChar1JobFullGetQueryParams = zod.obje
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26310,7 +26639,9 @@ export const ListResourcesFullV1AutocrudNewChar1JobFullGetQueryParams = zod.obje
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudNewChar1JobFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudNewChar1JobFullGetQueryOffsetDefault)
@@ -26482,7 +26813,7 @@ export const ListResourcesFullV1AutocrudNewChar1JobFullGetResponse = zod.array(
  * @summary Count new-char1-job Resources
  */
 export const getResourcesCountV1AutocrudNewChar1JobCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudNewChar1JobCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudNewChar1JobCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudNewChar1JobCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudNewChar1JobCountGetQueryParams = zod.object({
@@ -26490,7 +26821,7 @@ export const GetResourcesCountV1AutocrudNewChar1JobCountGetQueryParams = zod.obj
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26541,7 +26872,9 @@ export const GetResourcesCountV1AutocrudNewChar1JobCountGetQueryParams = zod.obj
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudNewChar1JobCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudNewChar1JobCountGetQueryOffsetDefault)
@@ -26578,7 +26911,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List new-char1-job resources
  */
 export const listResourcesV1AutocrudNewChar1JobGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudNewChar1JobGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudNewChar1JobGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudNewChar1JobGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudNewChar1JobGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -26587,7 +26920,7 @@ export const ListResourcesV1AutocrudNewChar1JobGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26638,7 +26971,9 @@ export const ListResourcesV1AutocrudNewChar1JobGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(listResourcesV1AutocrudNewChar1JobGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudNewChar1JobGetQueryOffsetDefault)
@@ -26878,7 +27213,7 @@ export const CreateResourceV1AutocrudNewChar1JobPostResponse = zod
  * @summary Batch delete new-char1-job
  */
 export const batchDeleteV1AutocrudNewChar1JobDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudNewChar1JobDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudNewChar1JobDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudNewChar1JobDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudNewChar1JobDeleteQueryParams = zod.object({
@@ -26886,7 +27221,7 @@ export const BatchDeleteV1AutocrudNewChar1JobDeleteQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -26937,7 +27272,9 @@ export const BatchDeleteV1AutocrudNewChar1JobDeleteQueryParams = zod.object({
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudNewChar1JobDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudNewChar1JobDeleteQueryOffsetDefault)
@@ -26985,7 +27322,7 @@ which resources are included.
  * @summary Export new-char1-job data
  */
 export const exportModelV1AutocrudNewChar1JobExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudNewChar1JobExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudNewChar1JobExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudNewChar1JobExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudNewChar1JobExportGetQueryParams = zod.object({
@@ -26993,7 +27330,7 @@ export const ExportModelV1AutocrudNewChar1JobExportGetQueryParams = zod.object({
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -27044,7 +27381,9 @@ export const ExportModelV1AutocrudNewChar1JobExportGetQueryParams = zod.object({
   limit: zod
     .number()
     .default(exportModelV1AutocrudNewChar1JobExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudNewChar1JobExportGetQueryOffsetDefault)
@@ -28398,7 +28737,7 @@ export const RestoreResourceV1AutocrudNewChar1JobResourceIdRestorePostResponse =
  * @summary Batch restore deleted new-char1-job
  */
 export const batchRestoreV1AutocrudNewChar1JobRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudNewChar1JobRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudNewChar1JobRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudNewChar1JobRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudNewChar1JobRestorePostQueryParams = zod.object({
@@ -28406,7 +28745,7 @@ export const BatchRestoreV1AutocrudNewChar1JobRestorePostQueryParams = zod.objec
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -28457,7 +28796,9 @@ export const BatchRestoreV1AutocrudNewChar1JobRestorePostQueryParams = zod.objec
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudNewChar1JobRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudNewChar1JobRestorePostQueryOffsetDefault)
@@ -28507,7 +28848,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryParams = zod.object({
@@ -28515,7 +28856,7 @@ export const TestMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -28566,7 +28907,9 @@ export const TestMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryParams
   limit: zod
     .number()
     .default(testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(testMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostQueryOffsetDefault)
@@ -28596,7 +28939,7 @@ export const TestMigrateResourcesV1AutocrudNewChar1JobMigrateTestPostResponse = 
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryParams = zod.object(
@@ -28605,7 +28948,7 @@ export const ExecuteMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQuery
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -28656,7 +28999,9 @@ export const ExecuteMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQuery
     limit: zod
       .number()
       .default(executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryLimitDefault)
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(executeMigrateResourcesV1AutocrudNewChar1JobMigrateExecutePostQueryOffsetDefault)
@@ -28795,8 +29140,9 @@ export const MigrateSingleResourceV1AutocrudNewChar1JobMigrateSingleResourceIdPo
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -28809,7 +29155,7 @@ export const MigrateSingleResourceV1AutocrudNewChar1JobMigrateSingleResourceIdPo
 - Direct access to resource content only
 
 **Examples:**
-- `GET /create-new-character2-job/data` - Get first 10 resources (data only)
+- `GET /create-new-character2-job/data` - Get the default first page of resources (data only)
 - `GET /create-new-character2-job/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /create-new-character2-job/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /create-new-character2-job/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -28820,7 +29166,7 @@ export const MigrateSingleResourceV1AutocrudNewChar1JobMigrateSingleResourceIdPo
  * @summary List create-new-character2-job Data Only
  */
 export const listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryParams = zod.object({
@@ -28828,7 +29174,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -28879,7 +29225,9 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryParams
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudCreateNewCharacter2JobDataGetQueryOffsetDefault)
@@ -29003,8 +29351,9 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetResponse = 
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -29013,7 +29362,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetResponse = 
 - System monitoring and statistics
 
 **Examples:**
-- `GET /create-new-character2-job/meta` - Get metadata for first 10 resources
+- `GET /create-new-character2-job/meta` - Get metadata for the default first page of resources
 - `GET /create-new-character2-job/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /create-new-character2-job/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -29023,7 +29372,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter2JobDataGetResponse = 
  * @summary List create-new-character2-job Metadata Only
  */
 export const listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryParams = zod.object({
@@ -29031,7 +29380,7 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -29082,7 +29431,9 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryParams
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetQueryOffsetDefault)
@@ -29164,8 +29515,9 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetResponse = 
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -29174,8 +29526,8 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetResponse = 
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /create-new-character2-job/revision-info` - Get current revision info for first 10 resources
-- `GET /create-new-character2-job/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /create-new-character2-job/revision-info` - Get current revision info for the default first page of resources
+- `GET /create-new-character2-job/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /create-new-character2-job/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -29184,7 +29536,7 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter2JobMetaGetResponse = 
  * @summary List create-new-character2-job Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryParams =
@@ -29193,7 +29545,7 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionIn
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -29248,7 +29600,9 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionIn
       .default(
         listResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionInfoGetQueryLimitDefault,
       )
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(
@@ -29302,7 +29656,7 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter2JobRevisionIn
  * @summary List create-new-character2-job Complete Information
  */
 export const listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -29311,7 +29665,7 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -29362,7 +29716,9 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryParams
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudCreateNewCharacter2JobFullGetQueryOffsetDefault)
@@ -29556,7 +29912,7 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter2JobFullGetResponse = 
  * @summary Count create-new-character2-job Resources
  */
 export const getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryParams = zod.object({
@@ -29564,7 +29920,7 @@ export const GetResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryParam
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -29615,7 +29971,9 @@ export const GetResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryParam
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudCreateNewCharacter2JobCountGetQueryOffsetDefault)
@@ -29652,7 +30010,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List create-new-character2-job resources
  */
 export const listResourcesV1AutocrudCreateNewCharacter2JobGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudCreateNewCharacter2JobGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudCreateNewCharacter2JobGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudCreateNewCharacter2JobGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudCreateNewCharacter2JobGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -29661,7 +30019,7 @@ export const ListResourcesV1AutocrudCreateNewCharacter2JobGetQueryParams = zod.o
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -29712,7 +30070,9 @@ export const ListResourcesV1AutocrudCreateNewCharacter2JobGetQueryParams = zod.o
   limit: zod
     .number()
     .default(listResourcesV1AutocrudCreateNewCharacter2JobGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudCreateNewCharacter2JobGetQueryOffsetDefault)
@@ -29974,7 +30334,7 @@ export const CreateResourceV1AutocrudCreateNewCharacter2JobPostResponse = zod
  * @summary Batch delete create-new-character2-job
  */
 export const batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryParams = zod.object({
@@ -29982,7 +30342,7 @@ export const BatchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryParams = zod.
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -30033,7 +30393,9 @@ export const BatchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryParams = zod.
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudCreateNewCharacter2JobDeleteQueryOffsetDefault)
@@ -30081,7 +30443,7 @@ which resources are included.
  * @summary Export create-new-character2-job data
  */
 export const exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudCreateNewCharacter2JobExportGetQueryParams = zod.object({
@@ -30089,7 +30451,7 @@ export const ExportModelV1AutocrudCreateNewCharacter2JobExportGetQueryParams = z
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -30140,7 +30502,9 @@ export const ExportModelV1AutocrudCreateNewCharacter2JobExportGetQueryParams = z
   limit: zod
     .number()
     .default(exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudCreateNewCharacter2JobExportGetQueryOffsetDefault)
@@ -31591,7 +31955,7 @@ export const RestoreResourceV1AutocrudCreateNewCharacter2JobResourceIdRestorePos
  * @summary Batch restore deleted create-new-character2-job
  */
 export const batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryParams = zod.object({
@@ -31599,7 +31963,7 @@ export const BatchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryParams 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -31650,7 +32014,9 @@ export const BatchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryParams 
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudCreateNewCharacter2JobRestorePostQueryOffsetDefault)
@@ -31701,7 +32067,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryParams =
@@ -31710,7 +32076,7 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPost
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -31763,7 +32129,9 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPost
     limit: zod
       .number()
       .default(testMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPostQueryLimitDefault)
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(
@@ -31796,7 +32164,7 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateTestPost
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryParams =
@@ -31805,7 +32173,7 @@ export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecu
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -31860,7 +32228,9 @@ export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecu
       .default(
         executeMigrateResourcesV1AutocrudCreateNewCharacter2JobMigrateExecutePostQueryLimitDefault,
       )
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(
@@ -32002,8 +32372,9 @@ export const MigrateSingleResourceV1AutocrudCreateNewCharacter2JobMigrateSingleR
 - Example: `[{"type": "meta", "key": "created_time", "direction": "+"}, {"type": "data", "field_path": "name", "direction": "-"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Partial Response:**
 - `partial`: List of fields to retrieve (e.g. '/field1', '/nested/field2')
@@ -32016,7 +32387,7 @@ export const MigrateSingleResourceV1AutocrudCreateNewCharacter2JobMigrateSingleR
 - Direct access to resource content only
 
 **Examples:**
-- `GET /create-new-character4-job/data` - Get first 10 resources (data only)
+- `GET /create-new-character4-job/data` - Get the default first page of resources (data only)
 - `GET /create-new-character4-job/data?limit=20&offset=40` - Get resources 41-60 (data only)
 - `GET /create-new-character4-job/data?is_deleted=false&limit=5` - Get 5 non-deleted resources (data only)
 - `GET /create-new-character4-job/data?partial=/name&partial=/email` - Get specific fields for all resources
@@ -32027,7 +32398,7 @@ export const MigrateSingleResourceV1AutocrudCreateNewCharacter2JobMigrateSingleR
  * @summary List create-new-character4-job Data Only
  */
 export const listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryIsDeletedDefault = false;
-export const listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryLimitDefault = 10;
+export const listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryLimitDefault = 4294967295;
 export const listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryOffsetDefault = 0;
 
 export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryParams = zod.object({
@@ -32035,7 +32406,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -32086,7 +32457,9 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryParams
   limit: zod
     .number()
     .default(listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesDataV1AutocrudCreateNewCharacter4JobDataGetQueryOffsetDefault)
@@ -32319,8 +32692,9 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetResponse = 
 - Example: `[{"type": "meta", "key": "updated_time", "direction": "-"}, {"type": "data", "field_path": "department", "direction": "+"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Resource management and administration
@@ -32329,7 +32703,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetResponse = 
 - System monitoring and statistics
 
 **Examples:**
-- `GET /create-new-character4-job/meta` - Get metadata for first 10 resources
+- `GET /create-new-character4-job/meta` - Get metadata for the default first page of resources
 - `GET /create-new-character4-job/meta?is_deleted=true` - Get metadata for deleted resources
 - `GET /create-new-character4-job/meta?created_bys=admin&limit=50` - Get metadata for admin-created resources
 
@@ -32339,7 +32713,7 @@ export const ListResourcesDataV1AutocrudCreateNewCharacter4JobDataGetResponse = 
  * @summary List create-new-character4-job Metadata Only
  */
 export const listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryIsDeletedDefault = false;
-export const listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryLimitDefault = 10;
+export const listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryLimitDefault = 4294967295;
 export const listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryOffsetDefault = 0;
 
 export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryParams = zod.object({
@@ -32347,7 +32721,7 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -32398,7 +32772,9 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryParams
   limit: zod
     .number()
     .default(listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetQueryOffsetDefault)
@@ -32480,8 +32856,9 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetResponse = 
 - Example: `[{"field_path": "status", "operator": "eq", "value": "active"}]`
 
 **Pagination:**
-- `limit`: Maximum number of results to return (default: 10)
+- `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
 - `offset`: Number of results to skip for pagination (default: 0)
+- If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
 **Use Cases:**
 - Version control system integration
@@ -32490,8 +32867,8 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetResponse = 
 - Change tracking and audit trails
 
 **Examples:**
-- `GET /create-new-character4-job/revision-info` - Get current revision info for first 10 resources
-- `GET /create-new-character4-job/revision-info?limit=100` - Get revision info for first 100 resources
+- `GET /create-new-character4-job/revision-info` - Get current revision info for the default first page of resources
+- `GET /create-new-character4-job/revision-info?limit=100` - Get revision info for the first 100 resources
 - `GET /create-new-character4-job/revision-info?updated_bys=editor` - Get revision info for editor-modified resources
 
 **Error Responses:**
@@ -32500,7 +32877,7 @@ export const ListResourcesMetaV1AutocrudCreateNewCharacter4JobMetaGetResponse = 
  * @summary List create-new-character4-job Current Revision Info
  */
 export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryIsDeletedDefault = false;
-export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryLimitDefault = 10;
+export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryLimitDefault = 4294967295;
 export const listResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryOffsetDefault = 0;
 
 export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryParams =
@@ -32509,7 +32886,7 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionIn
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -32564,7 +32941,9 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionIn
       .default(
         listResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionInfoGetQueryLimitDefault,
       )
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(
@@ -32618,7 +32997,7 @@ export const ListResourcesRevisionInfoV1AutocrudCreateNewCharacter4JobRevisionIn
  * @summary List create-new-character4-job Complete Information
  */
 export const listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryIsDeletedDefault = false;
-export const listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryLimitDefault = 10;
+export const listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryLimitDefault = 4294967295;
 export const listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryOffsetDefault = 0;
 export const listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -32627,7 +33006,7 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryParams
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -32678,7 +33057,9 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryParams
   limit: zod
     .number()
     .default(listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesFullV1AutocrudCreateNewCharacter4JobFullGetQueryOffsetDefault)
@@ -32981,7 +33362,7 @@ export const ListResourcesFullV1AutocrudCreateNewCharacter4JobFullGetResponse = 
  * @summary Count create-new-character4-job Resources
  */
 export const getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryIsDeletedDefault = false;
-export const getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryLimitDefault = 10;
+export const getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryLimitDefault = 4294967295;
 export const getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryOffsetDefault = 0;
 
 export const GetResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryParams = zod.object({
@@ -32989,7 +33370,7 @@ export const GetResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryParam
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -33040,7 +33421,9 @@ export const GetResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryParam
   limit: zod
     .number()
     .default(getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(getResourcesCountV1AutocrudCreateNewCharacter4JobCountGetQueryOffsetDefault)
@@ -33077,7 +33460,7 @@ By default all sections are returned: `data`, `revision_info`, `meta`.
  * @summary List create-new-character4-job resources
  */
 export const listResourcesV1AutocrudCreateNewCharacter4JobGetQueryIsDeletedDefault = false;
-export const listResourcesV1AutocrudCreateNewCharacter4JobGetQueryLimitDefault = 10;
+export const listResourcesV1AutocrudCreateNewCharacter4JobGetQueryLimitDefault = 4294967295;
 export const listResourcesV1AutocrudCreateNewCharacter4JobGetQueryOffsetDefault = 0;
 export const listResourcesV1AutocrudCreateNewCharacter4JobGetQueryReturnsDefault = `data,revision_info,meta`;
 
@@ -33086,7 +33469,7 @@ export const ListResourcesV1AutocrudCreateNewCharacter4JobGetQueryParams = zod.o
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -33137,7 +33520,9 @@ export const ListResourcesV1AutocrudCreateNewCharacter4JobGetQueryParams = zod.o
   limit: zod
     .number()
     .default(listResourcesV1AutocrudCreateNewCharacter4JobGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(listResourcesV1AutocrudCreateNewCharacter4JobGetQueryOffsetDefault)
@@ -33612,7 +33997,7 @@ export const CreateResourceV1AutocrudCreateNewCharacter4JobPostResponse = zod
  * @summary Batch delete create-new-character4-job
  */
 export const batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryIsDeletedDefault = false;
-export const batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryLimitDefault = 10;
+export const batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryLimitDefault = 4294967295;
 export const batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryOffsetDefault = 0;
 
 export const BatchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryParams = zod.object({
@@ -33620,7 +34005,7 @@ export const BatchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryParams = zod.
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -33671,7 +34056,9 @@ export const BatchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryParams = zod.
   limit: zod
     .number()
     .default(batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchDeleteV1AutocrudCreateNewCharacter4JobDeleteQueryOffsetDefault)
@@ -33719,7 +34106,7 @@ which resources are included.
  * @summary Export create-new-character4-job data
  */
 export const exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryIsDeletedDefault = false;
-export const exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryLimitDefault = 10;
+export const exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryLimitDefault = 4294967295;
 export const exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryOffsetDefault = 0;
 
 export const ExportModelV1AutocrudCreateNewCharacter4JobExportGetQueryParams = zod.object({
@@ -33727,7 +34114,7 @@ export const ExportModelV1AutocrudCreateNewCharacter4JobExportGetQueryParams = z
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -33778,7 +34165,9 @@ export const ExportModelV1AutocrudCreateNewCharacter4JobExportGetQueryParams = z
   limit: zod
     .number()
     .default(exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(exportModelV1AutocrudCreateNewCharacter4JobExportGetQueryOffsetDefault)
@@ -35665,7 +36054,7 @@ export const RestoreResourceV1AutocrudCreateNewCharacter4JobResourceIdRestorePos
  * @summary Batch restore deleted create-new-character4-job
  */
 export const batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryIsDeletedDefault = false;
-export const batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryLimitDefault = 10;
+export const batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryLimitDefault = 4294967295;
 export const batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryOffsetDefault = 0;
 
 export const BatchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryParams = zod.object({
@@ -35673,7 +36062,7 @@ export const BatchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryParams 
     .union([zod.string(), zod.null()])
     .optional()
     .describe(
-      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+      "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
     ),
   is_deleted: zod
     .union([zod.boolean(), zod.null()])
@@ -35724,7 +36113,9 @@ export const BatchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryParams 
   limit: zod
     .number()
     .default(batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryLimitDefault)
-    .describe('Maximum number of results'),
+    .describe(
+      'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+    ),
   offset: zod
     .number()
     .default(batchRestoreV1AutocrudCreateNewCharacter4JobRestorePostQueryOffsetDefault)
@@ -35775,7 +36166,7 @@ No data will be written back to storage - memory-only testing.
  * @summary Test Migrate Resources
  */
 export const testMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryIsDeletedDefault = false;
-export const testMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryLimitDefault = 10;
+export const testMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryLimitDefault = 4294967295;
 export const testMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryOffsetDefault = 0;
 
 export const TestMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryParams =
@@ -35784,7 +36175,7 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPost
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -35837,7 +36228,9 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPost
     limit: zod
       .number()
       .default(testMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPostQueryLimitDefault)
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(
@@ -35870,7 +36263,7 @@ export const TestMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateTestPost
  * @summary Execute Migrate Resources
  */
 export const executeMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryIsDeletedDefault = false;
-export const executeMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryLimitDefault = 10;
+export const executeMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryLimitDefault = 4294967295;
 export const executeMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryOffsetDefault = 0;
 
 export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryParams =
@@ -35879,7 +36272,7 @@ export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecu
       .union([zod.string(), zod.null()])
       .optional()
       .describe(
-        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\"",
+        "Query Builder expression. Example: \"QB['foo'] == 123\" or \"QB['age'].gt(18) & QB['status'].eq('active')\". When qb is used, do not combine it with data_conditions, conditions, or sorts; only limit, offset, and is_deleted may be used alongside qb.",
       ),
     is_deleted: zod
       .union([zod.boolean(), zod.null()])
@@ -35934,7 +36327,9 @@ export const ExecuteMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecu
       .default(
         executeMigrateResourcesV1AutocrudCreateNewCharacter4JobMigrateExecutePostQueryLimitDefault,
       )
-      .describe('Maximum number of results'),
+      .describe(
+        'Maximum number of results. Default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; set limit explicitly or use the \/count endpoint if you need the full total.',
+      ),
     offset: zod
       .number()
       .default(

--- a/web/app/src/autocrud/lib/components/field/CellFieldRenderer/CellFieldRenderer.test.ts
+++ b/web/app/src/autocrud/lib/components/field/CellFieldRenderer/CellFieldRenderer.test.ts
@@ -34,6 +34,7 @@ const ALL_FIELD_KINDS: FieldKind[] = [
   'itemFields',
   'union',
   'binary',
+  'binaryArray',
   'file',
   'json',
   'markdown',
@@ -67,7 +68,7 @@ describe('CELL_RENDERERS registry completeness', () => {
   });
 
   it('ALL_FIELD_KINDS contains every FieldKind value', () => {
-    expect(ALL_FIELD_KINDS.length).toBe(21);
+    expect(ALL_FIELD_KINDS.length).toBe(22);
   });
 });
 

--- a/web/app/src/autocrud/lib/components/field/CellFieldRenderer/index.tsx
+++ b/web/app/src/autocrud/lib/components/field/CellFieldRenderer/index.tsx
@@ -110,6 +110,13 @@ export const CELL_RENDERERS: Record<FieldKind, CellRenderer> = {
     return NA;
   },
 
+  binaryArray: ({ value }) => {
+    if (Array.isArray(value)) {
+      return `${value.length} file${value.length !== 1 ? 's' : ''}`;
+    }
+    return NA;
+  },
+
   /* ---- Text-like ---- */
 
   json: renderJson,

--- a/web/app/src/autocrud/lib/components/field/DetailFieldRenderer/index.tsx
+++ b/web/app/src/autocrud/lib/components/field/DetailFieldRenderer/index.tsx
@@ -172,6 +172,29 @@ const DETAIL_RENDERERS: Record<FieldKind, (ctx: DetailRenderContext) => React.Re
     return <Code block>{safeStringify(truncateForDetail(value), 2)}</Code>;
   },
 
+  binaryArray: ({ value }) => {
+    if (!Array.isArray(value) || value.length === 0) {
+      return (
+        <Text c="dimmed" size="sm">
+          No files
+        </Text>
+      );
+    }
+    return (
+      <Stack gap="xs">
+        {value.map((item: Record<string, unknown>, idx: number) =>
+          isBlobObject(item) ? (
+            <BinaryFieldDisplay key={idx} value={item} />
+          ) : (
+            <Code key={idx} block>
+              {safeStringify(item, 2)}
+            </Code>
+          ),
+        )}
+      </Stack>
+    );
+  },
+
   /* ---- Text-like ---- */
 
   json: ({ value }) => {

--- a/web/app/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.test.tsx
+++ b/web/app/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * BinaryArrayFieldRenderer — Tests for list-of-binary field rendering.
+ *
+ * Covers:
+ * - Empty state renders "No items" text
+ * - "Add" button inserts a new BinaryFieldEditor
+ * - Remove button removes item from list
+ * - onChange propagates correctly per-item
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import type { ResourceField } from '../../../resources';
+import { BinaryArrayFieldRenderer } from './BinaryArrayFieldRenderer';
+
+vi.mock('../../../client', () => ({
+  getBlobUrl: (id: string) => `http://test/blobs/${id}`,
+}));
+
+vi.mock('../../../hooks/useBlobUpload', () => ({
+  formatBytes: (bytes: number) => `${bytes} B`,
+}));
+
+afterEach(() => cleanup());
+
+function makeField(overrides: Partial<ResourceField> = {}): ResourceField {
+  return {
+    name: 'screenshots',
+    label: 'Screenshots',
+    type: 'binary',
+    isArray: true,
+    isRequired: false,
+    isNullable: false,
+    ...overrides,
+  };
+}
+
+function FormWrapper({
+  field,
+  initialValues,
+}: {
+  field: ResourceField;
+  initialValues: Record<string, any>;
+}) {
+  const form = useForm({ initialValues });
+  return (
+    <MantineProvider>
+      <BinaryArrayFieldRenderer field={field} form={form} />
+    </MantineProvider>
+  );
+}
+
+describe('BinaryArrayFieldRenderer', () => {
+  it('renders label and "No items" message when empty', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    expect(screen.getAllByText('Screenshots').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/no items/i)).toBeTruthy();
+  });
+
+  it('renders Add button', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    expect(screen.getAllByText('Add').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('adds a new binary editor when Add is clicked', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    // Before add, "No items yet" should be visible
+    expect(screen.getAllByText(/no items yet/i).length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(screen.getAllByText('Add')[0]);
+    // After adding, item #1 label should appear
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('removes item when remove button is clicked', () => {
+    render(
+      <FormWrapper
+        field={makeField()}
+        initialValues={{
+          screenshots: [{ _mode: 'empty' }, { _mode: 'empty' }],
+        }}
+      />,
+    );
+    // Two items initially
+    const itemsBefore = screen.queryAllByText(/^#\d+$/);
+    expect(itemsBefore.length).toBeGreaterThanOrEqual(2);
+
+    // Click the first ActionIcon (Remove button — contains an SVG trash icon, no text)
+    const allButtons = screen.getAllByRole('button');
+    // Filter to buttons that are NOT the "Add" button (which contains "Add" text)
+    const removeButtons = allButtons.filter((b) => !b.textContent?.toLowerCase().includes('add'));
+    expect(removeButtons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(removeButtons[0]);
+
+    // After removing one, one fewer item should be shown
+    const itemsAfter = screen.queryAllByText(/^#\d+$/);
+    expect(itemsAfter.length).toBeLessThan(itemsBefore.length);
+  });
+
+  it('renders existing items with file editors', () => {
+    render(
+      <FormWrapper
+        field={makeField()}
+        initialValues={{
+          screenshots: [
+            { _mode: 'existing', file_id: 'abc', content_type: 'image/png', size: 100 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders required indicator when isRequired is true', () => {
+    render(
+      <FormWrapper
+        field={makeField({ isRequired: true, isNullable: false })}
+        initialValues={{ screenshots: [{ _mode: 'empty' }] }}
+      />,
+    );
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/web/app/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.tsx
+++ b/web/app/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.tsx
@@ -1,0 +1,88 @@
+/**
+ * BinaryArrayFieldRenderer — Renders a list of binary fields for
+ * `isArray: true, type: 'binary'` fields (e.g. `List[bytes]` backend fields).
+ *
+ * Each array item is an independent `BinaryFieldEditor`. Files are NOT uploaded
+ * eagerly — the selected File objects are stored in form state and uploaded
+ * in bulk when the form is submitted.
+ */
+
+import { Stack, Group, Text, Button, ActionIcon, Paper } from '@mantine/core';
+import { IconTrash, IconPlus } from '@tabler/icons-react';
+import type { UseFormReturnType } from '@mantine/form';
+import type { ResourceField } from '../../../resources';
+import { BinaryFieldEditor } from './BinaryFieldEditor';
+import { getByPath, safeGetArrayItems, type BinaryFormValue } from '@/autocrud/lib/utils/formUtils';
+
+interface BinaryArrayFieldRendererProps {
+  field: ResourceField;
+  form: UseFormReturnType<any>;
+}
+
+const EMPTY_BINARY: BinaryFormValue = { _mode: 'empty' };
+
+export function BinaryArrayFieldRenderer({ field, form }: BinaryArrayFieldRendererProps) {
+  const { name, label, isRequired, isNullable } = field;
+  const rawItems = getByPath(form.getValues() as Record<string, any>, name);
+  const items = safeGetArrayItems(rawItems);
+
+  return (
+    <Stack gap="xs">
+      <Group justify="space-between" align="center">
+        <Text fw={500} size="sm">
+          {label}
+          {isRequired && !isNullable && (
+            <span style={{ color: 'var(--mantine-color-red-6)' }}> *</span>
+          )}
+        </Text>
+        <Button
+          size="compact-xs"
+          variant="light"
+          leftSection={<IconPlus size={14} />}
+          onClick={() => form.insertListItem(name, EMPTY_BINARY)}
+        >
+          Add
+        </Button>
+      </Group>
+
+      {items.length === 0 && (
+        <Text size="sm" c="dimmed" fs="italic">
+          No items yet
+        </Text>
+      )}
+
+      {items.map((_: any, index: number) => {
+        const itemPath = `${name}.${index}`;
+        const itemBv = getByPath(
+          form.getValues() as Record<string, any>,
+          itemPath,
+        ) as BinaryFormValue | null;
+
+        return (
+          <Paper key={index} withBorder p="sm" radius="sm">
+            <Group justify="space-between" mb="xs">
+              <Text size="xs" c="dimmed" fw={500}>
+                #{index + 1}
+              </Text>
+              <ActionIcon
+                aria-label="Remove"
+                size="sm"
+                color="red"
+                variant="subtle"
+                onClick={() => form.removeListItem(name, index)}
+              >
+                <IconTrash size={14} />
+              </ActionIcon>
+            </Group>
+            <BinaryFieldEditor
+              label={label}
+              required={isRequired && !isNullable}
+              value={itemBv}
+              onChange={(val) => form.setFieldValue(itemPath as any, val as any)}
+            />
+          </Paper>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/web/app/src/autocrud/lib/components/field/FormFieldRenderer/FieldRenderer.test.tsx
+++ b/web/app/src/autocrud/lib/components/field/FormFieldRenderer/FieldRenderer.test.tsx
@@ -93,6 +93,12 @@ vi.mock('./ArrayFieldRenderer', () => ({
   ArrayFieldRenderer: (props: any) => <div data-testid="array-renderer">{props.field.label}</div>,
 }));
 
+vi.mock('./BinaryArrayFieldRenderer', () => ({
+  BinaryArrayFieldRenderer: (props: any) => (
+    <div data-testid="binary-array-renderer">{props.field.label}</div>
+  ),
+}));
+
 beforeEach(() => {
   cleanup();
 });
@@ -370,6 +376,21 @@ describe('FieldRenderer', () => {
       />,
     );
     expect(screen.getByTestId('array-renderer')).toBeDefined();
+  });
+
+  it('renders BinaryArrayFieldRenderer for isArray binary field', () => {
+    render(
+      <TestFieldRenderer
+        field={makeField({
+          name: 'screenshots',
+          label: 'Screenshots',
+          type: 'binary',
+          isArray: true,
+        })}
+        initialValues={{ screenshots: [] }}
+      />,
+    );
+    expect(screen.getByTestId('binary-array-renderer')).toBeDefined();
   });
 
   it('renders NumberInput with slider variant', () => {

--- a/web/app/src/autocrud/lib/components/field/FormFieldRenderer/index.tsx
+++ b/web/app/src/autocrud/lib/components/field/FormFieldRenderer/index.tsx
@@ -22,6 +22,7 @@ import { RefSelect, RefMultiSelect, RefRevisionSelect, RefRevisionMultiSelect } 
 import { JsonEditor } from './JsonEditor';
 import { MarkdownEditor } from './MarkdownEditor';
 import { BinaryFieldEditor } from './BinaryFieldEditor';
+import { BinaryArrayFieldRenderer } from './BinaryArrayFieldRenderer';
 import { UnionFieldRenderer } from './UnionFieldRenderer';
 import { ArrayFieldRenderer } from './ArrayFieldRenderer';
 import { resolveFieldKind, type FieldKind } from '../resolveFieldKind';
@@ -73,6 +74,8 @@ const FIELD_RENDERERS: Record<FieldKind, (ctx: FieldRenderContext) => React.Reac
       />
     );
   },
+
+  binaryArray: ({ field, form }) => <BinaryArrayFieldRenderer field={field} form={form} />,
 
   file: ({ field, form }) => {
     const fileVariant = field.variant as Extract<FieldVariant, { type: 'file' }> | undefined;

--- a/web/app/src/autocrud/lib/components/field/resolveFieldKind.ts
+++ b/web/app/src/autocrud/lib/components/field/resolveFieldKind.ts
@@ -17,6 +17,7 @@ export type FieldKind =
   | 'itemFields'
   | 'union'
   | 'binary'
+  | 'binaryArray'
   | 'file'
   | 'json'
   | 'markdown'
@@ -60,6 +61,9 @@ export function resolveFieldKind(field: ResourceField): FieldKind {
   }
 
   // 3. Binary
+  if (field.type === 'binary' && field.isArray) {
+    return 'binaryArray';
+  }
   if (field.type === 'binary') {
     return 'binary';
   }

--- a/web/app/src/autocrud/lib/components/form/useResourceForm.ts
+++ b/web/app/src/autocrud/lib/components/form/useResourceForm.ts
@@ -339,6 +339,16 @@ export function useResourceForm<T extends Record<string, any>>({
           const bv = getByPath(values as Record<string, any>, field.name) as BinaryFormValue | null;
           binaryFieldValues.set(field.name, bv);
         }
+        if (field.type === 'binary' && field.isArray) {
+          // Array of binary items — preserve each element before JSON deep copy
+          const items = (values as Record<string, any>)[field.name];
+          if (Array.isArray(items)) {
+            for (let i = 0; i < items.length; i++) {
+              const bv = items[i] as BinaryFormValue | null;
+              arrayItemBinaryValues.set(`${field.name}.${i}`, bv);
+            }
+          }
+        }
         if (field.type === 'file') {
           const fv = getByPath(values as Record<string, any>, field.name) as File | null;
           fileFieldValues.set(field.name, fv);

--- a/web/app/src/autocrud/lib/utils/formUtils/transformers.test.ts
+++ b/web/app/src/autocrud/lib/utils/formUtils/transformers.test.ts
@@ -1901,4 +1901,105 @@ describe('processSubmitValues', () => {
     expect(Array.isArray(result.processed.equipments)).toBe(true);
     expect(result.processed.equipments).toHaveLength(0);
   });
+
+  // ── binary array (isArray: true, type: 'binary') ──
+
+  it('should report each binary array item key in binarySubFieldKeys', () => {
+    const fields = [
+      {
+        name: 'screenshots',
+        label: 'Screenshots',
+        type: 'binary' as const,
+        isArray: true,
+      },
+    ];
+    const values = {
+      screenshots: [
+        { _mode: 'file', file: new File(['a'], 'a.png', { type: 'image/png' }) },
+        { _mode: 'url', url: 'http://example.com/b.png' },
+        { _mode: 'empty' },
+      ],
+    };
+
+    const result = processSubmitValues(values, fields, [], []);
+    expect(result.binarySubFieldKeys).toEqual(['screenshots.0', 'screenshots.1', 'screenshots.2']);
+    expect(result.skippedBinaryFields).toEqual([]);
+  });
+
+  it('should default binary array to empty array in processSubmitValues when value is null', () => {
+    const fields = [
+      {
+        name: 'screenshots',
+        label: 'Screenshots',
+        type: 'binary' as const,
+        isArray: true,
+      },
+    ];
+    const values = { screenshots: null as any };
+
+    const result = processSubmitValues(values, fields, [], []);
+    expect(result.binarySubFieldKeys).toEqual([]);
+    expect(result.skippedBinaryFields).toEqual([]);
+  });
+});
+
+// ── processInitialValues — binary array ──
+
+describe('processInitialValues — binary array (isArray: true, type: binary)', () => {
+  const binaryArrayField = {
+    name: 'screenshots',
+    type: 'binary' as const,
+    isArray: true,
+  };
+
+  it('should convert each item to BinaryFormValue via binaryHandler.toFormValue', () => {
+    const result = processInitialValues(
+      {
+        screenshots: [
+          { file_id: 'f1', content_type: 'image/png', size: 512 },
+          { file_id: 'f2', content_type: 'image/jpeg', size: 1024 },
+        ],
+      },
+      [binaryArrayField],
+      [],
+      [],
+    );
+
+    expect(result.screenshots).toHaveLength(2);
+    expect(result.screenshots[0]).toEqual({
+      _mode: 'existing',
+      file_id: 'f1',
+      content_type: 'image/png',
+      size: 512,
+    });
+    expect(result.screenshots[1]).toEqual({
+      _mode: 'existing',
+      file_id: 'f2',
+      content_type: 'image/jpeg',
+      size: 1024,
+    });
+  });
+
+  it('should default to empty array when value is null', () => {
+    const result = processInitialValues({ screenshots: null }, [binaryArrayField], [], []);
+    expect(result.screenshots).toEqual([]);
+  });
+
+  it('should default to empty array when value is undefined', () => {
+    const result = processInitialValues({}, [binaryArrayField], [], []);
+    expect(result.screenshots).toEqual([]);
+  });
+
+  it('should convert items with no file_id to empty mode', () => {
+    const result = processInitialValues(
+      { screenshots: [null, undefined, {}] },
+      [binaryArrayField],
+      [],
+      [],
+    );
+    expect(result.screenshots).toHaveLength(3);
+    result.screenshots.forEach((item: any) => {
+      expect(item).toEqual({ _mode: 'empty' });
+    });
+  });
 });

--- a/web/app/src/autocrud/lib/utils/formUtils/transformers.ts
+++ b/web/app/src/autocrud/lib/utils/formUtils/transformers.ts
@@ -108,6 +108,15 @@ export function processInitialValues(
       } else {
         setByPath(processed, field.name, []);
       }
+    } else if (field.isArray && field.type === 'binary') {
+      // Array of binary items (e.g. List[bytes]) — convert each item via binaryHandler
+      if (Array.isArray(val)) {
+        const handler = getHandler('binary');
+        const processedItems = val.map((item: any) => handler.toFormValue(item, field));
+        setByPath(processed, field.name, processedItems);
+      } else {
+        setByPath(processed, field.name, []);
+      }
     } else if (field.isArray && field.ref && field.ref.type === 'resource_id') {
       // Array ref field — keep as array for MultiSelect, default to []
       setByPath(processed, field.name, Array.isArray(val) ? val : []);
@@ -372,6 +381,12 @@ export function processSubmitValues(
       const handler = getHandler('date');
       const submitFn = handler.submitValue ?? handler.toApiValue;
       setByPath(processed, field.name, submitFn(val, field));
+    } else if (field.type === 'binary' && field.isArray) {
+      // Array of binary items — each element is an independent BinaryFormValue
+      const items = Array.isArray(val) ? val : [];
+      for (let idx = 0; idx < items.length; idx++) {
+        binarySubFieldKeys.push(`${field.name}.${idx}`);
+      }
     } else if (field.type === 'binary') {
       skippedBinaryFields.push(field.name);
       continue;

--- a/web/generator/templates/base/src/autocrud/lib/components/field/CellFieldRenderer/CellFieldRenderer.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/CellFieldRenderer/CellFieldRenderer.test.ts
@@ -34,6 +34,7 @@ const ALL_FIELD_KINDS: FieldKind[] = [
   'itemFields',
   'union',
   'binary',
+  'binaryArray',
   'file',
   'json',
   'markdown',
@@ -67,7 +68,7 @@ describe('CELL_RENDERERS registry completeness', () => {
   });
 
   it('ALL_FIELD_KINDS contains every FieldKind value', () => {
-    expect(ALL_FIELD_KINDS.length).toBe(21);
+    expect(ALL_FIELD_KINDS.length).toBe(22);
   });
 });
 

--- a/web/generator/templates/base/src/autocrud/lib/components/field/CellFieldRenderer/index.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/CellFieldRenderer/index.tsx
@@ -110,6 +110,13 @@ export const CELL_RENDERERS: Record<FieldKind, CellRenderer> = {
     return NA;
   },
 
+  binaryArray: ({ value }) => {
+    if (Array.isArray(value)) {
+      return `${value.length} file${value.length !== 1 ? 's' : ''}`;
+    }
+    return NA;
+  },
+
   /* ---- Text-like ---- */
 
   json: renderJson,

--- a/web/generator/templates/base/src/autocrud/lib/components/field/DetailFieldRenderer/index.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/DetailFieldRenderer/index.tsx
@@ -172,6 +172,29 @@ const DETAIL_RENDERERS: Record<FieldKind, (ctx: DetailRenderContext) => React.Re
     return <Code block>{safeStringify(truncateForDetail(value), 2)}</Code>;
   },
 
+  binaryArray: ({ value }) => {
+    if (!Array.isArray(value) || value.length === 0) {
+      return (
+        <Text c="dimmed" size="sm">
+          No files
+        </Text>
+      );
+    }
+    return (
+      <Stack gap="xs">
+        {value.map((item: Record<string, unknown>, idx: number) =>
+          isBlobObject(item) ? (
+            <BinaryFieldDisplay key={idx} value={item} />
+          ) : (
+            <Code key={idx} block>
+              {safeStringify(item, 2)}
+            </Code>
+          ),
+        )}
+      </Stack>
+    );
+  },
+
   /* ---- Text-like ---- */
 
   json: ({ value }) => {

--- a/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.test.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * BinaryArrayFieldRenderer — Tests for list-of-binary field rendering.
+ *
+ * Covers:
+ * - Empty state renders "No items" text
+ * - "Add" button inserts a new BinaryFieldEditor
+ * - Remove button removes item from list
+ * - onChange propagates correctly per-item
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import type { ResourceField } from '../../../resources';
+import { BinaryArrayFieldRenderer } from './BinaryArrayFieldRenderer';
+
+vi.mock('../../../client', () => ({
+  getBlobUrl: (id: string) => `http://test/blobs/${id}`,
+}));
+
+vi.mock('../../../hooks/useBlobUpload', () => ({
+  formatBytes: (bytes: number) => `${bytes} B`,
+}));
+
+afterEach(() => cleanup());
+
+function makeField(overrides: Partial<ResourceField> = {}): ResourceField {
+  return {
+    name: 'screenshots',
+    label: 'Screenshots',
+    type: 'binary',
+    isArray: true,
+    isRequired: false,
+    isNullable: false,
+    ...overrides,
+  };
+}
+
+function FormWrapper({
+  field,
+  initialValues,
+}: {
+  field: ResourceField;
+  initialValues: Record<string, any>;
+}) {
+  const form = useForm({ initialValues });
+  return (
+    <MantineProvider>
+      <BinaryArrayFieldRenderer field={field} form={form} />
+    </MantineProvider>
+  );
+}
+
+describe('BinaryArrayFieldRenderer', () => {
+  it('renders label and "No items" message when empty', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    expect(screen.getAllByText('Screenshots').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/no items/i)).toBeTruthy();
+  });
+
+  it('renders Add button', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    expect(screen.getAllByText('Add').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('adds a new binary editor when Add is clicked', () => {
+    render(<FormWrapper field={makeField()} initialValues={{ screenshots: [] }} />);
+    // Before add, "No items yet" should be visible
+    expect(screen.getAllByText(/no items yet/i).length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(screen.getAllByText('Add')[0]);
+    // After adding, item #1 label should appear
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('removes item when remove button is clicked', () => {
+    render(
+      <FormWrapper
+        field={makeField()}
+        initialValues={{
+          screenshots: [{ _mode: 'empty' }, { _mode: 'empty' }],
+        }}
+      />,
+    );
+    // Two items initially
+    const itemsBefore = screen.queryAllByText(/^#\d+$/);
+    expect(itemsBefore.length).toBeGreaterThanOrEqual(2);
+
+    // Click the first ActionIcon (Remove button — contains an SVG trash icon, no text)
+    const allButtons = screen.getAllByRole('button');
+    // Filter to buttons that are NOT the "Add" button (which contains "Add" text)
+    const removeButtons = allButtons.filter((b) => !b.textContent?.toLowerCase().includes('add'));
+    expect(removeButtons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(removeButtons[0]);
+
+    // After removing one, one fewer item should be shown
+    const itemsAfter = screen.queryAllByText(/^#\d+$/);
+    expect(itemsAfter.length).toBeLessThan(itemsBefore.length);
+  });
+
+  it('renders existing items with file editors', () => {
+    render(
+      <FormWrapper
+        field={makeField()}
+        initialValues={{
+          screenshots: [
+            { _mode: 'existing', file_id: 'abc', content_type: 'image/png', size: 100 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders required indicator when isRequired is true', () => {
+    render(
+      <FormWrapper
+        field={makeField({ isRequired: true, isNullable: false })}
+        initialValues={{ screenshots: [{ _mode: 'empty' }] }}
+      />,
+    );
+    expect(screen.getAllByText('#1').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/BinaryArrayFieldRenderer.tsx
@@ -1,0 +1,88 @@
+/**
+ * BinaryArrayFieldRenderer — Renders a list of binary fields for
+ * `isArray: true, type: 'binary'` fields (e.g. `List[bytes]` backend fields).
+ *
+ * Each array item is an independent `BinaryFieldEditor`. Files are NOT uploaded
+ * eagerly — the selected File objects are stored in form state and uploaded
+ * in bulk when the form is submitted.
+ */
+
+import { Stack, Group, Text, Button, ActionIcon, Paper } from '@mantine/core';
+import { IconTrash, IconPlus } from '@tabler/icons-react';
+import type { UseFormReturnType } from '@mantine/form';
+import type { ResourceField } from '../../../resources';
+import { BinaryFieldEditor } from './BinaryFieldEditor';
+import { getByPath, safeGetArrayItems, type BinaryFormValue } from '@/autocrud/lib/utils/formUtils';
+
+interface BinaryArrayFieldRendererProps {
+  field: ResourceField;
+  form: UseFormReturnType<any>;
+}
+
+const EMPTY_BINARY: BinaryFormValue = { _mode: 'empty' };
+
+export function BinaryArrayFieldRenderer({ field, form }: BinaryArrayFieldRendererProps) {
+  const { name, label, isRequired, isNullable } = field;
+  const rawItems = getByPath(form.getValues() as Record<string, any>, name);
+  const items = safeGetArrayItems(rawItems);
+
+  return (
+    <Stack gap="xs">
+      <Group justify="space-between" align="center">
+        <Text fw={500} size="sm">
+          {label}
+          {isRequired && !isNullable && (
+            <span style={{ color: 'var(--mantine-color-red-6)' }}> *</span>
+          )}
+        </Text>
+        <Button
+          size="compact-xs"
+          variant="light"
+          leftSection={<IconPlus size={14} />}
+          onClick={() => form.insertListItem(name, EMPTY_BINARY)}
+        >
+          Add
+        </Button>
+      </Group>
+
+      {items.length === 0 && (
+        <Text size="sm" c="dimmed" fs="italic">
+          No items yet
+        </Text>
+      )}
+
+      {items.map((_: any, index: number) => {
+        const itemPath = `${name}.${index}`;
+        const itemBv = getByPath(
+          form.getValues() as Record<string, any>,
+          itemPath,
+        ) as BinaryFormValue | null;
+
+        return (
+          <Paper key={index} withBorder p="sm" radius="sm">
+            <Group justify="space-between" mb="xs">
+              <Text size="xs" c="dimmed" fw={500}>
+                #{index + 1}
+              </Text>
+              <ActionIcon
+                aria-label="Remove"
+                size="sm"
+                color="red"
+                variant="subtle"
+                onClick={() => form.removeListItem(name, index)}
+              >
+                <IconTrash size={14} />
+              </ActionIcon>
+            </Group>
+            <BinaryFieldEditor
+              label={label}
+              required={isRequired && !isNullable}
+              value={itemBv}
+              onChange={(val) => form.setFieldValue(itemPath as any, val as any)}
+            />
+          </Paper>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/FieldRenderer.test.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/FieldRenderer.test.tsx
@@ -93,6 +93,12 @@ vi.mock('./ArrayFieldRenderer', () => ({
   ArrayFieldRenderer: (props: any) => <div data-testid="array-renderer">{props.field.label}</div>,
 }));
 
+vi.mock('./BinaryArrayFieldRenderer', () => ({
+  BinaryArrayFieldRenderer: (props: any) => (
+    <div data-testid="binary-array-renderer">{props.field.label}</div>
+  ),
+}));
+
 beforeEach(() => {
   cleanup();
 });
@@ -370,6 +376,21 @@ describe('FieldRenderer', () => {
       />,
     );
     expect(screen.getByTestId('array-renderer')).toBeDefined();
+  });
+
+  it('renders BinaryArrayFieldRenderer for isArray binary field', () => {
+    render(
+      <TestFieldRenderer
+        field={makeField({
+          name: 'screenshots',
+          label: 'Screenshots',
+          type: 'binary',
+          isArray: true,
+        })}
+        initialValues={{ screenshots: [] }}
+      />,
+    );
+    expect(screen.getByTestId('binary-array-renderer')).toBeDefined();
   });
 
   it('renders NumberInput with slider variant', () => {

--- a/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/index.tsx
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/FormFieldRenderer/index.tsx
@@ -22,6 +22,7 @@ import { RefSelect, RefMultiSelect, RefRevisionSelect, RefRevisionMultiSelect } 
 import { JsonEditor } from './JsonEditor';
 import { MarkdownEditor } from './MarkdownEditor';
 import { BinaryFieldEditor } from './BinaryFieldEditor';
+import { BinaryArrayFieldRenderer } from './BinaryArrayFieldRenderer';
 import { UnionFieldRenderer } from './UnionFieldRenderer';
 import { ArrayFieldRenderer } from './ArrayFieldRenderer';
 import { resolveFieldKind, type FieldKind } from '../resolveFieldKind';
@@ -73,6 +74,8 @@ const FIELD_RENDERERS: Record<FieldKind, (ctx: FieldRenderContext) => React.Reac
       />
     );
   },
+
+  binaryArray: ({ field, form }) => <BinaryArrayFieldRenderer field={field} form={form} />,
 
   file: ({ field, form }) => {
     const fileVariant = field.variant as Extract<FieldVariant, { type: 'file' }> | undefined;

--- a/web/generator/templates/base/src/autocrud/lib/components/field/resolveFieldKind.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/field/resolveFieldKind.ts
@@ -17,6 +17,7 @@ export type FieldKind =
   | 'itemFields'
   | 'union'
   | 'binary'
+  | 'binaryArray'
   | 'file'
   | 'json'
   | 'markdown'
@@ -60,6 +61,9 @@ export function resolveFieldKind(field: ResourceField): FieldKind {
   }
 
   // 3. Binary
+  if (field.type === 'binary' && field.isArray) {
+    return 'binaryArray';
+  }
   if (field.type === 'binary') {
     return 'binary';
   }

--- a/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.ts
+++ b/web/generator/templates/base/src/autocrud/lib/components/form/useResourceForm.ts
@@ -339,6 +339,16 @@ export function useResourceForm<T extends Record<string, any>>({
           const bv = getByPath(values as Record<string, any>, field.name) as BinaryFormValue | null;
           binaryFieldValues.set(field.name, bv);
         }
+        if (field.type === 'binary' && field.isArray) {
+          // Array of binary items — preserve each element before JSON deep copy
+          const items = (values as Record<string, any>)[field.name];
+          if (Array.isArray(items)) {
+            for (let i = 0; i < items.length; i++) {
+              const bv = items[i] as BinaryFormValue | null;
+              arrayItemBinaryValues.set(`${field.name}.${i}`, bv);
+            }
+          }
+        }
         if (field.type === 'file') {
           const fv = getByPath(values as Record<string, any>, field.name) as File | null;
           fileFieldValues.set(field.name, fv);

--- a/web/generator/templates/base/src/autocrud/lib/utils/formUtils/transformers.test.ts
+++ b/web/generator/templates/base/src/autocrud/lib/utils/formUtils/transformers.test.ts
@@ -1901,4 +1901,105 @@ describe('processSubmitValues', () => {
     expect(Array.isArray(result.processed.equipments)).toBe(true);
     expect(result.processed.equipments).toHaveLength(0);
   });
+
+  // ── binary array (isArray: true, type: 'binary') ──
+
+  it('should report each binary array item key in binarySubFieldKeys', () => {
+    const fields = [
+      {
+        name: 'screenshots',
+        label: 'Screenshots',
+        type: 'binary' as const,
+        isArray: true,
+      },
+    ];
+    const values = {
+      screenshots: [
+        { _mode: 'file', file: new File(['a'], 'a.png', { type: 'image/png' }) },
+        { _mode: 'url', url: 'http://example.com/b.png' },
+        { _mode: 'empty' },
+      ],
+    };
+
+    const result = processSubmitValues(values, fields, [], []);
+    expect(result.binarySubFieldKeys).toEqual(['screenshots.0', 'screenshots.1', 'screenshots.2']);
+    expect(result.skippedBinaryFields).toEqual([]);
+  });
+
+  it('should default binary array to empty array in processSubmitValues when value is null', () => {
+    const fields = [
+      {
+        name: 'screenshots',
+        label: 'Screenshots',
+        type: 'binary' as const,
+        isArray: true,
+      },
+    ];
+    const values = { screenshots: null as any };
+
+    const result = processSubmitValues(values, fields, [], []);
+    expect(result.binarySubFieldKeys).toEqual([]);
+    expect(result.skippedBinaryFields).toEqual([]);
+  });
+});
+
+// ── processInitialValues — binary array ──
+
+describe('processInitialValues — binary array (isArray: true, type: binary)', () => {
+  const binaryArrayField = {
+    name: 'screenshots',
+    type: 'binary' as const,
+    isArray: true,
+  };
+
+  it('should convert each item to BinaryFormValue via binaryHandler.toFormValue', () => {
+    const result = processInitialValues(
+      {
+        screenshots: [
+          { file_id: 'f1', content_type: 'image/png', size: 512 },
+          { file_id: 'f2', content_type: 'image/jpeg', size: 1024 },
+        ],
+      },
+      [binaryArrayField],
+      [],
+      [],
+    );
+
+    expect(result.screenshots).toHaveLength(2);
+    expect(result.screenshots[0]).toEqual({
+      _mode: 'existing',
+      file_id: 'f1',
+      content_type: 'image/png',
+      size: 512,
+    });
+    expect(result.screenshots[1]).toEqual({
+      _mode: 'existing',
+      file_id: 'f2',
+      content_type: 'image/jpeg',
+      size: 1024,
+    });
+  });
+
+  it('should default to empty array when value is null', () => {
+    const result = processInitialValues({ screenshots: null }, [binaryArrayField], [], []);
+    expect(result.screenshots).toEqual([]);
+  });
+
+  it('should default to empty array when value is undefined', () => {
+    const result = processInitialValues({}, [binaryArrayField], [], []);
+    expect(result.screenshots).toEqual([]);
+  });
+
+  it('should convert items with no file_id to empty mode', () => {
+    const result = processInitialValues(
+      { screenshots: [null, undefined, {}] },
+      [binaryArrayField],
+      [],
+      [],
+    );
+    expect(result.screenshots).toHaveLength(3);
+    result.screenshots.forEach((item: any) => {
+      expect(item).toEqual({ _mode: 'empty' });
+    });
+  });
 });

--- a/web/generator/templates/base/src/autocrud/lib/utils/formUtils/transformers.ts
+++ b/web/generator/templates/base/src/autocrud/lib/utils/formUtils/transformers.ts
@@ -108,6 +108,15 @@ export function processInitialValues(
       } else {
         setByPath(processed, field.name, []);
       }
+    } else if (field.isArray && field.type === 'binary') {
+      // Array of binary items (e.g. List[bytes]) — convert each item via binaryHandler
+      if (Array.isArray(val)) {
+        const handler = getHandler('binary');
+        const processedItems = val.map((item: any) => handler.toFormValue(item, field));
+        setByPath(processed, field.name, processedItems);
+      } else {
+        setByPath(processed, field.name, []);
+      }
     } else if (field.isArray && field.ref && field.ref.type === 'resource_id') {
       // Array ref field — keep as array for MultiSelect, default to []
       setByPath(processed, field.name, Array.isArray(val) ? val : []);
@@ -372,6 +381,12 @@ export function processSubmitValues(
       const handler = getHandler('date');
       const submitFn = handler.submitValue ?? handler.toApiValue;
       setByPath(processed, field.name, submitFn(val, field));
+    } else if (field.type === 'binary' && field.isArray) {
+      // Array of binary items — each element is an independent BinaryFormValue
+      const items = Array.isArray(val) ? val : [];
+      for (let idx = 0; idx < items.length; idx++) {
+        binarySubFieldKeys.push(`${field.name}.${idx}`);
+      }
     } else if (field.type === 'binary') {
       skippedBinaryFields.push(field.name);
       continue;


### PR DESCRIPTION

### Problem

當後端 model 定義 `list[Binary]`（或 `List[bytes]`）欄位時，OpenAPI IR 會產生 `{type: 'binary', isArray: true}`，但前端四個層次都未正確處理，導致：

1. **表單**：只渲染一個 `BinaryFieldEditor`，無法新增/刪除多個檔案
2. **初始值轉換**：將整個陣列當成單一 binary 物件，丟棄所有值（回傳 `{_mode: 'empty'}`）
3. **Submit 轉換**：只記錄欄位名稱本身，遺漏每個元素的索引路徑（`field.0`、`field.1`...）
4. **表單提交前備份**：只備份單一 binary 值，陣列中所有項目在 deep copy 時全數遺失

### Solution

新增 `'binaryArray'` FieldKind，並補完所有四個層次的處理：

| 層次 | 修改 |
|------|------|
| `resolveFieldKind.ts` | 在 `binary` 之前加 `binaryArray` 判斷（`isArray && type === 'binary'`） |
| `BinaryArrayFieldRenderer.tsx` | 新元件：Add 按鈕 + 每項有 Remove 按鈕的動態列表 |
| `FormFieldRenderer/index.tsx` | 註冊 `binaryArray` renderer |
| `CellFieldRenderer/index.tsx` | 顯示 `N files` |
| `DetailFieldRenderer/index.tsx` | 逐項渲染 `BinaryFieldDisplay` |
| `transformers.ts` — `processInitialValues` | 對 `isArray && type === 'binary'` 逐項呼叫 `binaryHandler.toFormValue` |
| `transformers.ts` — `processSubmitValues` | 對每個 index 推入 `field.name.${idx}` 至 `binarySubFieldKeys` |
| `useResourceForm.ts` — `handleSubmit` | 提交前逐項備份 `field.name.${i}` 到 `arrayItemBinaryValues` |

所有變更已同步至 base。

### Tests

- `BinaryArrayFieldRenderer.test.tsx`（6 tests）：空狀態、Add 按鈕、新增項目、刪除項目、既有項目渲染、必填標示
- `FieldRenderer.test.tsx`：新增 `binaryArray` 欄位觸發 `BinaryArrayFieldRenderer` 的測試
- `transformers.test.ts`：新增 `processSubmitValues` 和 `processInitialValues` 的 binary array 測試（6 tests）
- `CellFieldRenderer.test.ts`：更新 `ALL_FIELD_KINDS` 計數（21 → 22）

全部 **1970 tests pass**。