### PR TITLE
fix: struct as direct body no longer produces duplicate form fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AutoCRUD (v0.8.3) is a model-driven backend platform for FastAPI. Define a `msgspec.Struct` model once; the framework generates REST APIs, GraphQL, search, version history, permissions, background jobs, and an admin UI automatically.
+
+## Commands
+
+**Always use `uv run` to execute scripts in the project environment.**
+
+```bash
+make test          # lint + run tests (excluding benchmarks) + coverage report
+make style         # auto-format: ruff format + ruff check --fix (run before committing)
+make check         # lint only: ruff check + ruff format --check
+make dev           # quick dev cycle: style + test
+make coverage      # run tests + coverage report (target ≥90%)
+make ci            # CI gate: check + test + coverage
+make build         # uv build
+make docs          # build MkDocs docs
+make serve         # serve docs locally
+```
+
+**Run a single test:**
+```bash
+uv run pytest tests/test_autocrud.py::TestAutocrud::test_add_model_with_encoding -v
+uv run pytest tests/ -k "test_add_model" -v
+```
+
+## Architecture
+
+### Core Components
+
+- **`AutoCRUD`** (`autocrud/crud/core.py`): Entry point — model registration + route generation.
+  - **Global Instance** (recommended): `from autocrud import crud` → `crud.configure()` → `crud.add_model()`
+  - **Manual Instance**: `AutoCRUD()` constructor for multiple independent instances
+- **`ResourceManager`** (`autocrud/resource_manager/core.py`): Core business logic — CRUD, versioning, permissions, events, migration, unique constraints, data coercion.
+- **Route Templates** (`autocrud/crud/route_templates/`): Each template generates specific API endpoints.
+  - Basic: `create`, `read`, `update`, `delete`, `search`, `patch`, `switch`
+  - Advanced: `blob`, `graphql`, `migrate`, `backup`, `rerun`, `batch_delete`, `batch_restore`, `restore`, `permanently_delete`
+- **Schema API** (`autocrud/schema.py`): Unified migration + validation with fluent `.step()` / `.plus()` chain API. Uses BFS to find shortest migration path between versions.
+- **Query Builder** (`autocrud/query.py` + `autocrud/crud/qb_parser.py`): Django-like query API with operator overloading (`==`, `!=`, `>=`, `&`, `|`, `~`).
+- **Storage Abstraction** — three independent layers, each with multiple backends:
+  - `IMetaStore`: simple (memory), postgres, redis, sqlalchemy, sqlite3, df, fast_slow
+  - `IResourceStore`: simple (memory), s3, cache, cached_s3, etag_cached_s3, mq_cached_s3, postgres
+  - `IBlobStore`: simple (memory), s3
+  - `IStorageFactory` (`autocrud/resource_manager/storage_factory.py`) creates per-model storage instances.
+- **Permission System** (`autocrud/permission/`): ACL, RBAC, action-based, data-based, meta-based, composite.
+- **Message Queue** (`autocrud/message_queue/`): Simple, RabbitMQ, Celery backends + heartbeat.
+- **Pydantic Converter** (`autocrud/resource_manager/pydantic_converter.py`): Bidirectional `pydantic_to_struct()` / `struct_to_pydantic()`.
+
+### Key Architectural Patterns
+
+- **Versioning**: Every modification creates a new immutable revision. Status: `draft` (mutable) or `stable` (immutable). Parent-child chains enable full history.
+- **Data Coercion**: `_coerce_data()` accepts `dict`, `Struct`, or Pydantic `BaseModel` → **always outputs `msgspec.Struct` internally**. Never return Pydantic instances from `ResourceManager` methods — `MsgspecResponse.render()` only supports Struct.
+- **UNSET Pattern**: Use `msgspec.UNSET` / `UnsetType` to distinguish "not provided" from `None`.
+- **Soft Delete**: `DeleteRouteTemplate` is soft-delete; use `RestoreRouteTemplate` / `PermanentlyDeleteRouteTemplate` for recovery.
+- **Unique Constraints**: `Unique` annotation + `UniqueConstraintHandler` (`autocrud/resource_manager/unique_handler.py`).
+
+### Public API
+
+Only exports from `autocrud/__init__.py` are public: `AutoCRUD`, `crud`, `Schema`, `LoadStats`, `struct_to_pydantic`, `DisplayName`, `Unique`, `UniqueConstraintError`, `IConstraintChecker`, `IValidator`, `ValidationError`, `DuplicateResourceError`, `OnDelete`, `OnDuplicate`, `Ref`, `RefRevision`, `RefType`, `RevisionNotMigratedError`, `SearchedResource`, `ResourceOps`, `BackgroundTaskAccepted`, `BlobUploadSession`, `JobRedirectInfo`, `MissingOperationContextError`.
+
+## Coding Conventions
+
+### Data Models
+
+Use `msgspec.Struct` for all models. Pydantic models are accepted as input and auto-converted.
+
+```python
+from msgspec import Struct, UNSET, UnsetType
+
+class User(Struct):
+    name: str
+    age: int
+    email: str | None = None
+
+class PatchUser(Struct, kw_only=True):
+    name: str | UnsetType = UNSET   # distinguishes "not provided" from None
+```
+
+### Schema API
+
+```python
+from autocrud import Schema
+
+schema = Schema(UserV2, "v2").step("v1", migrate_v1_to_v2).plus(validator_fn)
+crud.add_model(User, schema=schema)
+```
+
+### General
+
+- Extensive type hints required — `typing_extensions.Literal`, `Generic[T]`, etc.
+- All FastAPI routes and storage operations are `async`.
+- Google-style docstrings; write `TODO` for unclear items rather than guessing.
+- Code and comments in English; always respond to the user in 台灣繁體中文.
+- All new features must update docstrings and documentation.
+
+## Testing
+
+- All new features must include tests targeting **≥90% coverage**.
+- Bug fixes follow TDD: write failing test → implement fix → verify → refactor.
+- Use `msgspec.Struct` for test models.
+- Only run your own tests — avoid running unrelated test suites.
+- Frontend tests: run `pnpm test` under `web/app/` and confirm they pass.
+- Key test directories: `tests/test_autocrud.py` (integration), `tests/test_schema.py`, `tests/routes/` (API), `tests/meta_store/` (storage), `tests/permission/`.
+
+## Component Skills
+
+Detailed implementation guides live in `.claude/skills/`. Consult the relevant skill before modifying or extending a component:
+
+| Component | Skill File |
+|-----------|-----------|
+| Full Stack routing | `.claude/skills/autocrud-fullstack/SKILL.md` |
+| AutoCRUD Core | `.claude/skills/autocrud-core/SKILL.md` |
+| ResourceManager | `.claude/skills/resource-manager/SKILL.md` |
+| Schema API | `.claude/skills/schema/SKILL.md` |
+| Query Builder | `.claude/skills/query-builder/SKILL.md` |
+| Route Templates | `.claude/skills/route-templates/SKILL.md` |
+| Storage Factory | `.claude/skills/storage-factory/SKILL.md` |
+| Permission | `.claude/skills/permission/SKILL.md` |
+| Web Generator | `.claude/skills/web-generator/SKILL.md` |
+| Web App | `.claude/skills/web-app/SKILL.md` |
+| Docs Maintenance | `.claude/skills/docs-maintenance/SKILL.md` |

--- a/autocrud/crud/core.py
+++ b/autocrud/crud/core.py
@@ -2101,12 +2101,23 @@ class AutoCRUD:
             # Fall back to multipart/form-data (when UploadFile is present)
             if not rb:
                 rb = content.get("multipart/form-data", {}).get("schema", {})
-            # Resolve $ref to components/schemas
+            # Resolve $ref to components/schemas.
+            # If the $ref points directly to the body schema struct, the entire
+            # request body IS that struct — skip expanding its properties as
+            # inline params to avoid duplicate fields in the frontend form.
+            _direct_body_ref = False
             if "$ref" in rb:
                 ref_name = rb["$ref"].split("/")[-1]
-                rb = schema.get("components", {}).get("schemas", {}).get(ref_name, {})
-            props: dict = rb.get("properties", {})
-            required_list: list = rb.get("required", [])
+                if body_schema and ref_name == body_schema:
+                    _direct_body_ref = True
+                else:
+                    rb = (
+                        schema.get("components", {})
+                        .get("schemas", {})
+                        .get(ref_name, {})
+                    )
+            props: dict = {} if _direct_body_ref else rb.get("properties", {})
+            required_list: list = [] if _direct_body_ref else rb.get("required", [])
             # When bodySchema is set, identify the property that IS the body
             # schema (via $ref or allOf.$ref) so we can exclude it from inline
             # params and avoid duplication.
@@ -2280,11 +2291,19 @@ class AutoCRUD:
             rb = content.get("application/json", {}).get("schema", {})
             if not rb:
                 rb = content.get("multipart/form-data", {}).get("schema", {})
+            _direct_body_ref = False
             if "$ref" in rb:
                 ref_name = rb["$ref"].split("/")[-1]
-                rb = schema.get("components", {}).get("schemas", {}).get(ref_name, {})
-            props: dict = rb.get("properties", {})
-            required_list: list = rb.get("required", [])
+                if body_schema and ref_name == body_schema:
+                    _direct_body_ref = True
+                else:
+                    rb = (
+                        schema.get("components", {})
+                        .get("schemas", {})
+                        .get(ref_name, {})
+                    )
+            props: dict = {} if _direct_body_ref else rb.get("properties", {})
+            required_list: list = [] if _direct_body_ref else rb.get("required", [])
             body_schema_prop_names: set[str] = set()
             if body_schema:
                 for pname, pschema in props.items():

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
+    },
+    "tdd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "ad055544599481182d0079c4198e85da26677cb408a677be2da04915375f0427"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "2db47f0db7e6975486cd28bc6744f1358b47a434fb98df5b6ad507b6c3685b6a"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "8351452ad372ea4f839d3f7b951927b417851ffa49e7e6af28ea0f0ae111dca8"
+    }
+  }
+}

--- a/tests/test_create_action.py
+++ b/tests/test_create_action.py
@@ -1488,3 +1488,53 @@ class TestCreateActionWithRouterPrefix:
         assert action["path"] == "/item/create-from-query", (
             f"Expected '/item/create-from-query' but got '{action['path']}'"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: struct as direct body must not produce duplicate inlineBodyParams
+# ---------------------------------------------------------------------------
+
+
+class TestCreateActionStructBodyNoDuplicate:
+    """When a struct is used directly as the body, its fields must appear only
+    once in the action's fields (via bodySchema), not also as inlineBodyParams."""
+
+    def _build_app(self):
+        class Character(Struct):
+            name: str
+            level: int = 1
+
+        class SkillInput(Struct):
+            skill_name: str
+            power: int
+
+        crud = AutoCRUD()
+        crud.add_model(Character, name="character")
+
+        @crud.create_action("character", label="Add Skill")
+        async def add_skill(body: SkillInput = Body(...)):
+            return Character(name=body.skill_name, level=body.power)
+
+        app = FastAPI()
+        crud.apply(app)
+        crud.openapi(app)
+        return app
+
+    def test_no_inline_body_params_when_body_is_struct(self):
+        """Struct-as-body must NOT produce inlineBodyParams (those fields are
+        already represented by bodySchema)."""
+        app = self._build_app()
+        schema = app.openapi_schema
+        action = schema["x-autocrud-custom-create-actions"]["character"][0]
+        assert "bodySchema" in action
+        assert "inlineBodyParams" not in action, (
+            f"inlineBodyParams must be absent when body is a pure struct; "
+            f"got: {action.get('inlineBodyParams')}"
+        )
+
+    def test_body_schema_name_is_correct(self):
+        """bodySchema should record the struct name."""
+        app = self._build_app()
+        schema = app.openapi_schema
+        action = schema["x-autocrud-custom-create-actions"]["character"][0]
+        assert action["bodySchema"] == "SkillInput"

--- a/tests/test_update_action.py
+++ b/tests/test_update_action.py
@@ -1078,3 +1078,45 @@ class TestUpdateActionInfoMetaInjection:
         rm = crud.resource_managers["character"]
         resource = rm.get(resource_id)
         assert resource.data.name == f"{revision_id}-1"
+
+
+# ---------------------------------------------------------------------------
+# Regression: struct as direct body must not produce duplicate inlineBodyParams
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateActionStructBodyNoDuplicate:
+    """When a struct is used directly as the update action body, its fields
+    must appear only once (via bodySchema), not also as inlineBodyParams."""
+
+    def _build_app(self):
+        class Character(Struct):
+            name: str
+            level: int = 1
+
+        class RenameInput(Struct):
+            new_name: str
+            suffix: str = ""
+
+        crud = AutoCRUD()
+        crud.add_model(Character, name="character")
+
+        @crud.update_action("character", label="Rename")
+        def rename(existing: Character, body: RenameInput = Body(...)):
+            return Character(name=body.new_name + body.suffix, level=existing.level)
+
+        app = FastAPI()
+        crud.apply(app)
+        crud.openapi(app)
+        return app
+
+    def test_no_inline_body_params_when_body_is_struct(self):
+        """Struct-as-body must NOT produce inlineBodyParams for update actions."""
+        app = self._build_app()
+        schema = app.openapi_schema
+        action = schema["x-autocrud-custom-update-actions"]["character"][0]
+        assert "bodySchema" in action
+        assert "inlineBodyParams" not in action, (
+            f"inlineBodyParams must be absent when body is a pure struct; "
+            f"got: {action.get('inlineBodyParams')}"
+        )


### PR DESCRIPTION
## Problem

When a `create_action` or `update_action` handler uses a `msgspec.Struct` directly as the request body (e.g. `body: SkillInput = Body(...)`), FastAPI generates the OpenAPI request body schema as a direct `$ref` to the struct:

```json
{ "$ref": "#/components/schemas/SkillInput" }
```

The OpenAPI extension builder resolved this `$ref` to the struct's own schema, then iterated over its properties — mistaking them for additional inline body parameters. The resulting extension contained **both** `bodySchema: "SkillInput"` and `inlineBodyParams: [{name: "skill_name", ...}, {name: "power", ...}]` simultaneously.

The frontend IR builder consumed both, expanding each source into form fields independently, so every field of the struct appeared **twice** in the generated form.

## Fix

Before resolving the `$ref`, check whether it points directly to the body schema struct. If it does, the entire request body *is* that struct — there are no additional inline params to extract, so `props` is set to `{}` and the expansion is skipped entirely.

The same fix is applied to both `_inject_custom_create_actions` and `_inject_custom_update_actions`.

## Test plan

- [x] `TestCreateActionStructBodyNoDuplicate::test_no_inline_body_params_when_body_is_struct` — create action with pure struct body produces no `inlineBodyParams`
- [x] `TestCreateActionStructBodyNoDuplicate::test_body_schema_name_is_correct` — `bodySchema` name is still recorded correctly
- [x] `TestUpdateActionStructBodyNoDuplicate::test_no_inline_body_params_when_body_is_struct` — same regression coverage for update actions
- [x] Full `test_create_action.py` + `test_update_action.py` pass (101 tests, 0 failures)

fix #310