### PR TITLE
rename: brand content (README logo, MIGRATION/CHANGELOG, env var rename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to SpecStar (formerly `autocrud`).
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [0.10.0] — 2026-05-01
+
+The package is renamed from `autocrud` to **`specstar`**. No public method
+signatures or behaviors changed; this is a brand and identifier rename.
+
+### Renamed
+
+- **PyPI distribution**: `autocrud` → **`specstar`**.
+- **Top-level Python package**: `autocrud` → **`specstar`**.
+- **Class**: `AutoCRUD` → **`SpecStar`**. Importable as
+  `from specstar.crud.core import SpecStar` or `from specstar import SpecStar`.
+- **Global instance**: the singleton exported from the top-level package was
+  renamed `crud` → **`spec`**. Use `from specstar import spec`.
+- **Warning class**: `AutoCRUDWarning` → **`SpecStarWarning`**.
+- **Environment variable**: `AUTOCRUD_DEFAULT_QUERY_LIMIT` →
+  **`SPECSTAR_DEFAULT_QUERY_LIMIT`**. The legacy name still works during
+  the migration window with a one-shot `DeprecationWarning`.
+- **Repository / docs URL**: `github.com/HYChou0515/autocrud` →
+  `github.com/HYChou0515/specstar`. The old URL redirects.
+
+### Added
+
+- **Deprecation shim**: a new `autocrud==0.10.0` is published on PyPI as a
+  thin wrapper around `specstar==0.10.0`. It installs an `importlib`
+  meta-path finder that redirects every `autocrud[.X]` import to the
+  matching `specstar[.X]` module at runtime, emitting a `DeprecationWarning`
+  once per import path. This is the last release of `autocrud`; future
+  releases ship as `specstar` only.
+- **Migration guide**: see [MIGRATION.md](MIGRATION.md) for the find /
+  replace table and shim details.
+- **Logo**: text and mark variants in `branding/`.
+
+### Fixed
+
+- **GraphQL resolvers** silently swallowed exceptions when `ResourceMeta`
+  carried newly-added `rev_*` fields, when `indexed_data` was `UNSET`, or
+  when `RevisionInfo.uid` (a `UUID`) was passed to a `str`-typed strawberry
+  field. Resolvers now project only the fields the GraphQL type declares,
+  map `UNSET → None`, and stringify UUIDs.
+- **`SpecStar.apply()`** returned `app.router` (the FastAPI internal
+  `APIRouter`) instead of the documented "supplied `router` if any, else
+  `app`". The return value now matches the docstring.
+
+### Pre-existing on `autocrud<=0.9.0`
+
+The two `Fixed` items above were latent bugs on the 0.9.0 line. If you're
+upgrading directly from `autocrud==0.9.0` you'll get the fixes
+transparently — no code change required.
+
+---
+
+## [0.9.0] — 2026-04-29
+
+Last release under the `autocrud` name. Breaking changes are documented in
+detail in [docs/en/guides/upgrade-0.9.md](docs/en/guides/upgrade-0.9.md).
+
+### Removed
+
+- `PostgreSQLStorageFactory` and `PostgreSQLDiskS3StorageFactory` (deprecated
+  with a runtime warning since 0.8). Replace with `PostgreSQLS3StorageFactory`
+  or compose the meta / resource / blob stores directly.
+- `specstar.permission.basic` (deprecated since 0.8). Use the unified APIs
+  in `specstar.permission`.
+
+### Changed
+
+- `IResourceStore` now requires `save_many()` and `dump_all_revisions()` on
+  every backend. Custom stores must implement both.
+- `dump()` returns a generator of `(meta, revisions)` tuples rather than a
+  flat record stream. Callers that built a list need to flatten or pivot.
+- `IResourceManager` subclasses must implement `load_records_bulk()`.
+- `start_consume(block=False)` returns the worker handle instead of `None`.
+
+### Added
+
+- **`ResourceMeta` carries the current-revision fields** (`rev_status`,
+  `rev_created_by`, `rev_updated_by`, `rev_created_time`, `rev_updated_time`).
+  Run `ResourceManager.backfill_revision_meta()` once after deploying to
+  populate them on resources created on earlier versions; until you do, the
+  fields are `UNSET`. (#274)
+
+---
+
+## Earlier releases
+
+For releases before 0.9.0, see the
+[GitHub Releases page](https://github.com/HYChou0515/specstar/releases) and
+the per-version notes embedded in
+[docs/en/guides/](docs/en/guides/).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,155 @@
+# Migrating from `autocrud` to `specstar`
+
+`autocrud` was renamed to **`specstar`** in v0.10.0. Source code, types,
+behavior, and the FastAPI surface area are unchanged — only the package name
+and a handful of public identifiers were renamed.
+
+This guide covers everything you need to update.
+
+> **TL;DR** — `pip install -U specstar`, then run the [find / replace
+> table](#3-find--replace-table) and you're done. If you can't change code
+> right away, install `autocrud==0.10.0` instead and you'll get a
+> deprecation-warned shim that still works.
+
+---
+
+## 1. Why the rename
+
+`autocrud` started as "automatic CRUD for FastAPI", but the project grew well
+beyond that — versioning, GraphQL, search, permissions, background jobs, an
+admin UI generator. `SpecStar` better captures the actual scope: you write
+the **spec** (a `msgspec.Struct`) and SpecStar generates the **rest of the
+star**. The original name was also taken on PyPI in some ecosystems and
+confusable with unrelated projects.
+
+The rename is mechanical. No public method signatures or behaviors changed.
+
+---
+
+## 2. Pick a migration path
+
+You have two options. Pick whichever fits your team's risk appetite.
+
+### A. Migrate the imports (recommended)
+
+```bash
+pip install -U specstar
+pip uninstall autocrud   # optional — see "Keep both?" below
+```
+
+Then apply the [find / replace table](#3-find--replace-table) to your code.
+This is the path that gets you off the deprecation warnings and onto the
+canonical name.
+
+### B. Pin the shim (no code changes)
+
+```bash
+pip install -U "autocrud>=0.10.0"
+```
+
+`autocrud==0.10.0` no longer ships any code of its own — it's a thin shim
+that depends on `specstar==0.10.0` and uses an `importlib` meta-path finder
+to redirect every `autocrud[.X]` import to the matching `specstar[.X]`
+module at runtime. Your existing imports continue to work, but each one
+emits a `DeprecationWarning` once per process to remind you to migrate.
+
+The shim is a **migration runway, not a long-term home.** No further releases
+of `autocrud` will be published beyond 0.10.0; future fixes and features
+ship under `specstar` only.
+
+### Keep both installed?
+
+Don't. `autocrud==0.10.0` already depends on `specstar==0.10.0`, so installing
+the shim gives you both transitively. Installing `autocrud<0.10.0` *and*
+`specstar` side-by-side would give you two separate copies of the codebase
+that won't share state — confusing and pointless.
+
+---
+
+## 3. Find / replace table
+
+| Before                                                | After                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| `pip install autocrud`                                | `pip install specstar`                                 |
+| `from autocrud import ...`                            | `from specstar import ...`                             |
+| `from autocrud.crud.core import AutoCRUD`             | `from specstar.crud.core import SpecStar`              |
+| `from autocrud import crud`                           | `from specstar import spec`                            |
+| `AutoCRUD()`                                          | `SpecStar()`                                           |
+| `AutoCRUDWarning`                                     | `SpecStarWarning`                                      |
+| `crud.add_model(...)`, `crud.apply(...)`              | `spec.add_model(...)`, `spec.apply(...)`               |
+| `AUTOCRUD_DEFAULT_QUERY_LIMIT`                        | `SPECSTAR_DEFAULT_QUERY_LIMIT`                         |
+
+The `crud → spec` rename only applies to the **global instance** exported
+from `specstar/__init__.py`. Local variables you named `crud` in your own
+code can stay; they were never part of the public API. Submodule paths that
+contain `crud` (e.g. `specstar.crud.core`, `specstar.crud.route_templates`)
+are also unchanged — `crud` is a meaningful technical term in those paths,
+not a brand string.
+
+---
+
+## 4. Environment variables
+
+`AUTOCRUD_DEFAULT_QUERY_LIMIT` was renamed to **`SPECSTAR_DEFAULT_QUERY_LIMIT`**.
+The legacy name is still read at startup and emits a `DeprecationWarning`
+pointing at the new one. If both are set, `SPECSTAR_*` wins.
+
+```bash
+# Old
+export AUTOCRUD_DEFAULT_QUERY_LIMIT=1000
+
+# New
+export SPECSTAR_DEFAULT_QUERY_LIMIT=1000
+```
+
+---
+
+## 5. Generated code (Starter Wizard)
+
+Projects scaffolded by the [Starter Wizard](https://hychou0515.github.io/specstar/wizard/)
+prior to v0.10.0 emit `from autocrud import crud`. Re-running the wizard
+against the same configuration on v0.10.0 will produce `from specstar import
+spec` — there are no other content changes. If you'd rather hand-edit, the
+file you need to update is typically `main.py` and the import lines.
+
+---
+
+## 6. CI and pre-commit
+
+If you have CI greps or pre-commit hooks that block the string `autocrud`,
+update them. If you've pinned `autocrud<X.Y` in `requirements.txt`,
+`Pipfile`, `pyproject.toml`, or `uv.lock`, replace the dependency with
+`specstar` at the corresponding version.
+
+---
+
+## 7. Verifying the migration
+
+After updating, this should run cleanly with **no deprecation warnings**:
+
+```python
+import warnings
+warnings.simplefilter("error", DeprecationWarning)
+
+from specstar import SpecStar, spec  # noqa: F401
+```
+
+If a warning fires, the message names the import path that still goes
+through the shim — fix that import and re-run.
+
+---
+
+## 8. Schema migrations are unrelated
+
+If you arrived here looking for *data* migration (i.e. evolving the
+`msgspec.Struct` shape across versions of your application), see the
+[Schema Migration guide](https://hychou0515.github.io/specstar/howto/migrations/)
+instead. This document only covers the package-name rename.
+
+---
+
+## 9. Reporting issues
+
+Please file rename-related issues at
+<https://github.com/HYChou0515/specstar/issues>. Include the import path
+that broke and the deprecation warning text if there is one.

--- a/Makefile
+++ b/Makefile
@@ -167,15 +167,27 @@ clean-dev:
 	find . -type f -name "*.pyc" -delete
 	find . -type f -name "*.pyo" -delete
 
-# 建置套件
+# 建置 specstar 套件
 .PHONY: build
 build: clean-dev
-	@echo "建置套件..."
+	@echo "建置 specstar..."
 	uv build
+
+# 建置 autocrud-shim（autocrud 0.10.0 deprecation 套件）
+.PHONY: build-shim
+build-shim:
+	@echo "建置 autocrud-shim..."
+	cd autocrud-shim && uv build
+
+# 同時建置 specstar 與 autocrud-shim 兩個 wheel
+.PHONY: build-all
+build-all: build build-shim
+	@echo "兩個 wheel 都建置完成："
+	@ls -1 dist/*.whl autocrud-shim/dist/*.whl
 
 # 發布套件到 PyPI
 .PHONY: publish
-publish: build 
+publish: build
 	@echo "發布套件到 PyPI..."
 	uv run python scripts/publish.py
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -79,7 +79,7 @@ https://hychou0515.github.io/specstar/
 列表型端點預設會分頁。若想調整啟動時的預設上限，可設定環境變數：
 
 ```bash
-export AUTOCRUD_DEFAULT_QUERY_LIMIT=1000
+export SPECSTAR_DEFAULT_QUERY_LIMIT=1000
 ```
 
 - 若未設定，系統會使用非常大的 fallback
@@ -132,13 +132,13 @@ class TodoList(Struct):
     notes: str
 
 # 創建 SpecStar
-crud = SpecStar()
-crud.add_model(TodoItem)
-crud.add_model(TodoList)
+spec = SpecStar()
+spec.add_model(TodoItem)
+spec.add_model(TodoList)
 
 app = FastAPI()
-crud.apply(app)
-crud.openapi(app)
+spec.apply(app)
+spec.openapi(app)
 
 uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")
 ```
@@ -182,12 +182,12 @@ class TodoList(Struct):
     notes: str
 
 # 創建 CRUD API
-crud = SpecStar()
-crud.add_model(TodoItem)
-crud.add_model(TodoList)
+spec = SpecStar()
+spec.add_model(TodoItem)
+spec.add_model(TodoList)
 
 app = FastAPI()
-crud.apply(app)
+spec.apply(app)
 
 # 測試
 client = TestClient(app)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# SpecStar
+<p align="center">
+  <img src="branding/logo-text.svg" alt="SpecStar" height="120">
+</p>
 
-**Model-driven backend platform for FastAPI**
+<p align="center">
+  <strong>Model-driven backend platform for FastAPI</strong><br>
+  Generate REST APIs, GraphQL, search, version history, and an admin UI from a single Python model.
+</p>
 
-SpecStar automatically generates **REST APIs, GraphQL APIs, search, version history, and admin UI** from Python models.
+<p align="center">
+  <a href="https://pypi.org/project/specstar/"><img alt="PyPI" src="https://img.shields.io/pypi/v/specstar"></a>
+  <a href="https://github.com/HYChou0515/specstar/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/pypi/l/specstar"></a>
+  <a href="https://hychou0515.github.io/specstar/"><img alt="Docs" src="https://img.shields.io/badge/docs-mkdocs-blue"></a>
+</p>
+
+> **Renamed from `autocrud` to `specstar` (v0.10.0).** The old name still installs as a deprecation shim that redirects every `autocrud[.X]` import to `specstar[.X]`. New projects should `pip install specstar`. See the [migration guide](MIGRATION.md).
 
 Focus on **business logic**, not infrastructure.
 
@@ -46,12 +57,12 @@ Register the model:
 
 ```python
 from fastapi import FastAPI
-from specstar import crud
+from specstar import spec
 
 app = FastAPI()
 
-crud.add_model(User)
-crud.apply(app)
+spec.add_model(User)
+spec.apply(app)
 ```
 
 Start the server:
@@ -63,7 +74,7 @@ uvicorn main:app
 Optional startup tuning:
 
 ```bash
-export AUTOCRUD_DEFAULT_QUERY_LIMIT=1000
+export SPECSTAR_DEFAULT_QUERY_LIMIT=1000
 ```
 
 This controls the default page size for list endpoints. Per-request `limit`

--- a/autocrud-shim/LICENSE
+++ b/autocrud-shim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HYChou0515
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/autocrud-shim/pyproject.toml
+++ b/autocrud-shim/pyproject.toml
@@ -3,7 +3,7 @@ name = "autocrud"
 version = "0.10.0"
 description = "Deprecated alias for specstar. See https://github.com/HYChou0515/specstar"
 readme = "README.md"
-license = {file = "../LICENSE"}
+license = {file = "LICENSE"}
 requires-python = ">=3.11"
 authors = [
     {name = "HYChou0515", email = "hychou.svm@example.com"}

--- a/docs/en/concepts/query-system.md
+++ b/docs/en/concepts/query-system.md
@@ -219,7 +219,7 @@ You can still pass `limit` and `offset` in the URL:
 GET /users?qb=QB["age"].gt(18)&limit=20&offset=40
 ```
 
-List-style endpoints are paginated by default. The startup default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable, and you can still override it per request with an explicit limit.
+List-style endpoints are paginated by default. The startup default comes from the SPECSTAR_DEFAULT_QUERY_LIMIT environment variable, and you can still override it per request with an explicit limit.
 
 If both are present, the URL values override any `.limit()`, `.offset()`, or `.page()` settings defined inside the QB expression.
 

--- a/docs/en/guides/upgrade-0.10.md
+++ b/docs/en/guides/upgrade-0.10.md
@@ -1,0 +1,40 @@
+# Upgrading to 0.10 (`autocrud` → `specstar`)
+
+Version 0.10.0 renames the package from `autocrud` to **`specstar`**. No
+public method signatures or behaviors changed; this is a brand and
+identifier rename.
+
+The full migration walkthrough — including a find / replace table, the
+deprecation-shim path, and verification steps — lives in the
+[MIGRATION.md](https://github.com/HYChou0515/specstar/blob/master/MIGRATION.md)
+guide at the repository root.
+
+## Quick checklist
+
+- [ ] `pip install -U specstar` (or pin `autocrud>=0.10.0` for the shim)
+- [ ] Replace `from autocrud` → `from specstar` everywhere
+- [ ] Replace `AutoCRUD` → `SpecStar` and `AutoCRUDWarning` → `SpecStarWarning`
+- [ ] Rename the global instance reference `crud` → `spec`
+- [ ] Replace env var `AUTOCRUD_DEFAULT_QUERY_LIMIT` →
+      `SPECSTAR_DEFAULT_QUERY_LIMIT`
+- [ ] Re-run any Starter Wizard projects to regenerate `main.py` (or
+      hand-edit the import line)
+
+## Backward compatibility
+
+- `autocrud==0.10.0` ships as a **deprecation shim** that redirects every
+  `autocrud[.X]` import to `specstar[.X]` at runtime, with a
+  `DeprecationWarning` per import path. Existing code keeps working without
+  edits.
+- The legacy `AUTOCRUD_DEFAULT_QUERY_LIMIT` env var is still read with a
+  `DeprecationWarning` if `SPECSTAR_DEFAULT_QUERY_LIMIT` is unset.
+
+The shim is a migration runway, not a long-term home — `autocrud==0.10.0`
+is the **last release** under that name.
+
+## See also
+
+- [MIGRATION.md](https://github.com/HYChou0515/specstar/blob/master/MIGRATION.md)
+  — the full guide
+- [Schema migration](../howto/migrations.md) — for *data* migrations
+  (evolving your `msgspec.Struct` shapes); unrelated to the package rename

--- a/docs/en/howto/query-builder.md
+++ b/docs/en/howto/query-builder.md
@@ -49,7 +49,7 @@ GET /tasks?qb=QB["owner"].one_of(["alice", "bob"])
 GET /tasks?qb=QB.created_time().last_n_days(7)
 ```
 
-List endpoints are paginated by default. The startup default comes from the AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable, and you can still pass a different limit per request.
+List endpoints are paginated by default. The startup default comes from the SPECSTAR_DEFAULT_QUERY_LIMIT environment variable, and you can still pass a different limit per request.
 
 The server parses the expression with a safe AST parser.
 

--- a/docs/en/howto/troubleshooting.md
+++ b/docs/en/howto/troubleshooting.md
@@ -83,7 +83,7 @@ See also:
 - confirm the target field is indexed
 - confirm the operator matches the expected value type
 - test with a simpler query first, then add more conditions gradually
-- if results look truncated rather than missing, pass an explicit `limit` or set `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup
+- if results look truncated rather than missing, pass an explicit `limit` or set `SPECSTAR_DEFAULT_QUERY_LIMIT` at startup
 - use the `/count` endpoint when you need the exact total number of matches
 
 See also:

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -86,12 +86,12 @@ If that command prints a version string, the installation is ready.
 ## Configure the default list limit
 
 List-style endpoints are paginated by default. You can control the startup default
-with the `AUTOCRUD_DEFAULT_QUERY_LIMIT` environment variable.
+with the `SPECSTAR_DEFAULT_QUERY_LIMIT` environment variable.
 
 Example:
 
 ```bash
-export AUTOCRUD_DEFAULT_QUERY_LIMIT=1000
+export SPECSTAR_DEFAULT_QUERY_LIMIT=1000
 uvicorn main:app --reload
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,6 +204,7 @@ plugins:
                 - guides/performance.md
                 - guides/from-demo-to-production.md
                 - guides/upgrade-0.9.md
+                - guides/upgrade-0.10.md
 
             - Contributing:
                 - contributing/docs.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "specstar"
 dynamic = ["version"]
-description = "自動產生 CRUD API 的 Python 函式庫"
+description = "Model-driven backend platform for FastAPI: REST + GraphQL + search + version history + admin UI from a single msgspec.Struct"
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.11"

--- a/specstar/crud/route_templates/query_inputs.py
+++ b/specstar/crud/route_templates/query_inputs.py
@@ -109,7 +109,7 @@ class QueryInputs(BaseModel):
         DEFAULT_QUERY_LIMIT,
         description=(
             "Maximum number of results. Default comes from the "
-            "AUTOCRUD_DEFAULT_QUERY_LIMIT environment variable at startup; "
+            "SPECSTAR_DEFAULT_QUERY_LIMIT environment variable at startup; "
             "set limit explicitly or use the /count endpoint if you need the full total."
         ),
     )

--- a/specstar/crud/route_templates/search.py
+++ b/specstar/crud/route_templates/search.py
@@ -98,7 +98,7 @@ class ListRouteTemplate(BaseRouteTemplate):
                 - Example: `[{{"type": "meta", "key": "created_time", "direction": "+"}}, {{"type": "data", "field_path": "name", "direction": "-"}}]`
 
                 **Pagination:**
-                - `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
+                - `limit`: Maximum number of results to return (default comes from `SPECSTAR_DEFAULT_QUERY_LIMIT` at startup)
                 - `offset`: Number of results to skip for pagination (default: 0)
                 - If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
@@ -199,7 +199,7 @@ class ListRouteTemplate(BaseRouteTemplate):
                 - Example: `[{{"type": "meta", "key": "updated_time", "direction": "-"}}, {{"type": "data", "field_path": "department", "direction": "+"}}]`
 
                 **Pagination:**
-                - `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
+                - `limit`: Maximum number of results to return (default comes from `SPECSTAR_DEFAULT_QUERY_LIMIT` at startup)
                 - `offset`: Number of results to skip for pagination (default: 0)
                 - If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 
@@ -296,7 +296,7 @@ class ListRouteTemplate(BaseRouteTemplate):
                 - Example: `[{{"field_path": "status", "operator": "eq", "value": "active"}}]`
 
                 **Pagination:**
-                - `limit`: Maximum number of results to return (default comes from `AUTOCRUD_DEFAULT_QUERY_LIMIT` at startup)
+                - `limit`: Maximum number of results to return (default comes from `SPECSTAR_DEFAULT_QUERY_LIMIT` at startup)
                 - `offset`: Number of results to skip for pagination (default: 0)
                 - If you need an exact full total, use the `/count` endpoint or pass an explicit `limit`.
 

--- a/specstar/query_types.py
+++ b/specstar/query_types.py
@@ -85,12 +85,17 @@ class ResourceMetaSearchSort(Struct, kw_only=True, tag=True):
     key: ResourceMetaSortKey
 
 
-DEFAULT_QUERY_LIMIT_ENV_VAR = "AUTOCRUD_DEFAULT_QUERY_LIMIT"
+DEFAULT_QUERY_LIMIT_ENV_VAR = "SPECSTAR_DEFAULT_QUERY_LIMIT"
+DEFAULT_QUERY_LIMIT_LEGACY_ENV_VAR = "AUTOCRUD_DEFAULT_QUERY_LIMIT"
 DEFAULT_QUERY_LIMIT_FALLBACK = 2**32 - 1
 
 
 def _read_default_query_limit() -> int:
     """Read the startup default query limit from the environment.
+
+    Prefers ``SPECSTAR_DEFAULT_QUERY_LIMIT``; falls back to the legacy
+    ``AUTOCRUD_DEFAULT_QUERY_LIMIT`` (with a one-shot DeprecationWarning) for
+    deployments that have not yet migrated their environment.
 
     The value is intentionally configurable so operators can decide whether
     list endpoints should behave more like a small page or an effectively
@@ -98,15 +103,29 @@ def _read_default_query_limit() -> int:
     """
 
     raw = os.getenv(DEFAULT_QUERY_LIMIT_ENV_VAR)
+    source = DEFAULT_QUERY_LIMIT_ENV_VAR
     if raw is None or raw.strip() == "":
-        return DEFAULT_QUERY_LIMIT_FALLBACK
+        legacy = os.getenv(DEFAULT_QUERY_LIMIT_LEGACY_ENV_VAR)
+        if legacy is not None and legacy.strip() != "":
+            warnings.warn(
+                (
+                    f"{DEFAULT_QUERY_LIMIT_LEGACY_ENV_VAR} is deprecated; "
+                    f"set {DEFAULT_QUERY_LIMIT_ENV_VAR} instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            raw = legacy
+            source = DEFAULT_QUERY_LIMIT_LEGACY_ENV_VAR
+        else:
+            return DEFAULT_QUERY_LIMIT_FALLBACK
 
     try:
         value = int(raw)
     except ValueError:
         warnings.warn(
             (
-                f"Invalid {DEFAULT_QUERY_LIMIT_ENV_VAR}={raw!r}; "
+                f"Invalid {source}={raw!r}; "
                 f"falling back to {DEFAULT_QUERY_LIMIT_FALLBACK}."
             ),
             RuntimeWarning,
@@ -117,7 +136,7 @@ def _read_default_query_limit() -> int:
     if value < 1:
         warnings.warn(
             (
-                f"{DEFAULT_QUERY_LIMIT_ENV_VAR} must be >= 1, got {value}; "
+                f"{source} must be >= 1, got {value}; "
                 f"falling back to {DEFAULT_QUERY_LIMIT_FALLBACK}."
             ),
             RuntimeWarning,
@@ -131,9 +150,11 @@ def _read_default_query_limit() -> int:
 DEFAULT_QUERY_LIMIT = _read_default_query_limit()
 """Default page size for list-style search endpoints.
 
-Configurable at process startup through the AUTOCRUD_DEFAULT_QUERY_LIMIT
-environment variable. Falls back to a very large first-page limit so users do
-not easily mistake pagination for missing data.
+Configurable at process startup through the ``SPECSTAR_DEFAULT_QUERY_LIMIT``
+environment variable (legacy ``AUTOCRUD_DEFAULT_QUERY_LIMIT`` is still read
+with a DeprecationWarning during the migration window). Falls back to a very
+large first-page limit so users do not easily mistake pagination for missing
+data.
 """
 
 

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -2742,7 +2742,9 @@ class TestQueryLimitConfiguration:
     """
 
     @staticmethod
-    def _run_with_env(env_value: str | None) -> dict:
+    def _run_with_env(
+        env_value: str | None, *, var_name: str = "SPECSTAR_DEFAULT_QUERY_LIMIT"
+    ) -> dict:
         """Spawn a subprocess that imports query_types and reports the result.
 
         Returns a dict with ``limit``, ``fallback`` and ``warnings`` keys.
@@ -2772,9 +2774,10 @@ class TestQueryLimitConfiguration:
             "}))"
         )
         env = dict(os.environ)
+        env.pop("SPECSTAR_DEFAULT_QUERY_LIMIT", None)
         env.pop("AUTOCRUD_DEFAULT_QUERY_LIMIT", None)
         if env_value is not None:
-            env["AUTOCRUD_DEFAULT_QUERY_LIMIT"] = env_value
+            env[var_name] = env_value
         result = subprocess.run(
             [sys.executable, "-c", snippet],
             env=env,
@@ -2803,7 +2806,7 @@ class TestQueryLimitConfiguration:
         out = self._run_with_env("not-a-number")
         assert out["limit"] == out["fallback"]
         assert any(
-            cat == "RuntimeWarning" and "AUTOCRUD_DEFAULT_QUERY_LIMIT" in msg
+            cat == "RuntimeWarning" and "SPECSTAR_DEFAULT_QUERY_LIMIT" in msg
             for cat, msg in out["warnings"]
         )
 
@@ -2811,7 +2814,7 @@ class TestQueryLimitConfiguration:
         out = self._run_with_env("0")
         assert out["limit"] == out["fallback"]
         assert any(
-            cat == "RuntimeWarning" and "AUTOCRUD_DEFAULT_QUERY_LIMIT" in msg
+            cat == "RuntimeWarning" and "SPECSTAR_DEFAULT_QUERY_LIMIT" in msg
             for cat, msg in out["warnings"]
         )
 
@@ -2819,6 +2822,58 @@ class TestQueryLimitConfiguration:
         out = self._run_with_env("-5")
         assert out["limit"] == out["fallback"]
         assert any(
-            cat == "RuntimeWarning" and "AUTOCRUD_DEFAULT_QUERY_LIMIT" in msg
+            cat == "RuntimeWarning" and "SPECSTAR_DEFAULT_QUERY_LIMIT" in msg
             for cat, msg in out["warnings"]
+        )
+
+    def test_legacy_env_var_warns_and_works(self):
+        """``AUTOCRUD_DEFAULT_QUERY_LIMIT`` is read for backward compatibility,
+        but emits a ``DeprecationWarning`` pointing at the new name."""
+        out = self._run_with_env(
+            "777", var_name="AUTOCRUD_DEFAULT_QUERY_LIMIT"
+        )
+        assert out["limit"] == 777
+        assert out["default_limit"] == 777
+        assert any(
+            cat == "DeprecationWarning"
+            and "AUTOCRUD_DEFAULT_QUERY_LIMIT" in msg
+            and "SPECSTAR_DEFAULT_QUERY_LIMIT" in msg
+            for cat, msg in out["warnings"]
+        )
+
+    def test_new_env_var_takes_precedence_over_legacy(self):
+        """If both env vars are set, the new ``SPECSTAR_*`` name wins and the
+        legacy var triggers no deprecation warning (it isn't read)."""
+        import json
+        import subprocess
+        import sys
+
+        env = dict(os.environ)
+        env["SPECSTAR_DEFAULT_QUERY_LIMIT"] = "100"
+        env["AUTOCRUD_DEFAULT_QUERY_LIMIT"] = "999"
+        snippet = (
+            "import json, warnings;"
+            "warnings.simplefilter('always');"
+            "captured = [];"
+            "warnings.showwarning = ("
+            "  lambda message, category, filename, lineno, file=None, line=None:"
+            "  captured.append((category.__name__, str(message)))"
+            ");"
+            "from specstar.query_types import DEFAULT_QUERY_LIMIT;"
+            "print(json.dumps({"
+            "  'limit': DEFAULT_QUERY_LIMIT,"
+            "  'warnings': captured,"
+            "}))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", snippet],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        out = json.loads(result.stdout)
+        assert out["limit"] == 100
+        assert not any(
+            cat == "DeprecationWarning" for cat, _ in out["warnings"]
         )


### PR DESCRIPTION
## Summary

Phase 2 of the two-PR rename plan. Builds on top of #326 (mechanical rename) — please merge that one first or stack reviews.

- **README** (English + 繁體中文): swap in the SpecStar logo header, add PyPI / License / Docs shields, drop a deprecation banner pointing at \`MIGRATION.md\`, and finish renaming the global instance \`crud\` → \`spec\` in code examples.
- **\`MIGRATION.md\`** at repo root: full \`autocrud\` → \`specstar\` walkthrough (find/replace table, two migration paths, shim caveats, env var change, verification snippet).
- **\`CHANGELOG.md\`** at repo root: 0.10.0 entry covering the rename plus the GraphQL/apply fixes that came along with PR1; brief 0.9.0 summary that links to the existing \`upgrade-0.9.md\` guide.
- **\`docs/en/guides/upgrade-0.10.md\`** + mkdocs nav entry: short doc-site pointer that defers to MIGRATION.md.
- **Env var rename** with backward compat:
  - \`AUTOCRUD_DEFAULT_QUERY_LIMIT\` → **\`SPECSTAR_DEFAULT_QUERY_LIMIT\`**.
  - Legacy name still read at startup, emits a one-shot DeprecationWarning. New name wins if both are set. Two new tests cover the legacy path and the precedence rule.
  - Updates docstrings (search.py, query_inputs.py) and docs (installation, query-system, query-builder, troubleshooting).
- **\`pyproject.toml\` description**: replace the legacy 中文 string with a brand-aligned English one for PyPI.

## Out of scope

- PyPI publish + GitHub repo rename (Phase B — tracked separately).
- Any further code-level rename beyond the env var: nothing else on the public API needed renaming.

## Test plan

- [ ] CI green
- [ ] \`tests/test_query_builder.py::TestQueryLimitConfiguration\` — 8/8 (covers new var, legacy var deprecation, both-set precedence).
- [ ] \`grep -rn 'autocrud\\|AutoCRUD' --include='*.py' --include='*.md'\` should return only the intentional references in \`RENAME_PLAN.md\`, \`MIGRATION.md\`, \`CHANGELOG.md\`, \`README.md\`, \`docs/en/guides/upgrade-0.10.md\`, and the \`autocrud-shim/\` directory.
- [ ] Reviewer can render the README on GitHub and confirm the logo, shields, and banner display correctly.