### PR TITLE
add vector + embedding featured vector + embedding feature

### DIFF
--- a/docs/design/add-vector-plan.md
+++ b/docs/design/add-vector-plan.md
@@ -1,0 +1,309 @@
+# SpecStar Vector + Embedding 實作 Plan
+
+> **狀態**：Plan，未開工
+> **Branch**：`add-vector`
+> **動機**：把 vector similarity search 變成 SpecStar 的一等公民，並提供 `Embedding(content, vector)` 高階型別自動代算向量
+
+---
+
+## Definition of Done（V1 釋出條件）
+
+- [ ] `Vector(dim, distance, encoder)` annotation 可加在 `list[float]` 或 `Embedding` 欄位
+- [ ] `Embedding` 型別與 `Binary` 同層級，寫入時自動 encode、命中 cache 不重算
+- [ ] `PostgresMetaStore` 偵測 pgvector 並建立 `vector(N)` 欄 + HNSW 索引
+- [ ] 非 pg backend 自動 fallback brute-force，首次 fallback warning
+- [ ] QB 支援 `QB["field"].cosine(q) / .l2(q) / .ip(q)`，filter 與 sort 同 expression
+- [ ] `q` 為 `list[float]` 或 `str`（後者走 encoder）
+- [ ] `VectorDistanceCondition` / `VectorDistanceSort` 可進 `ResourceMetaSearchQuery.conditions` / `.sorts`
+- [ ] OpenAPI 注入 `x-vector-dim` / `x-vector-distance` / `x-vector-encoder-id`
+- [ ] Admin UI 對 Embedding 欄渲染 text input + search-by-text bar
+- [ ] `specstar backfill-vectors --model M --field F` CLI 可批次補資料
+- [ ] dim mismatch → `ValidationError("expected dim=N, got M")`
+- [ ] 既有 testsuite 零 regression
+- [ ] 文件：使用範例 + capability matrix + encoder registry 指南
+
+V2 推遲：GraphQL vector search、`list[Embedding]` multi-vector、completion-aware vector visualizer、並行 backfill。
+
+---
+
+## 設計總覽
+
+### A. 型別系統
+
+兩個層級：
+
+**Level 1：純 Vector（user 自算）**
+```python
+class Doc(Struct):
+    title: str
+    embedding: Annotated[list[float], Vector(dim=1536, distance="cosine")]
+```
+
+**Level 2：Embedding（framework 自動 encode）**
+```python
+class Doc(Struct):
+    title: str
+    summary: Annotated[
+        Embedding,
+        Vector(dim=1536, distance="cosine", encoder="openai_small"),
+    ]
+    body: Annotated[Embedding | None, Vector(dim=3072, encoder="openai_large")] = None
+```
+
+### B. 新型別
+
+```python
+class Vector:
+    """Annotation marker. 描述向量欄位的索引/編碼配置。"""
+    dim: int                                       # 必填
+    distance: Literal["cosine","l2","ip"] | None   # 可選；未提供時走 query default，再無走 cosine
+    encoder: str | None                            # 可選；registry name
+
+class Embedding(Struct, kw_only=True):
+    content: str
+    vector: list[float] | UnsetType = UNSET
+    content_hash: str | UnsetType = UNSET          # xxh3_128(content)，hex string
+    encoder_id: str | UnsetType = UNSET            # 寫入時使用的 encoder name
+
+# Query schema 擴充
+class VectorDistanceCondition(Struct, kw_only=True, tag=True):
+    field_path: str
+    query_vector: list[float] | str                # str → 走 encoder
+    operator: DataSearchOperator                   # 限 lt/lte/gt/gte
+    threshold: float
+    distance: Literal["cosine","l2","ip"] | None = None
+
+class VectorDistanceSort(Struct, kw_only=True, tag=True):
+    field_path: str
+    query_vector: list[float] | str
+    direction: ResourceMetaSortDirection = ascending
+    distance: Literal["cosine","l2","ip"] | None = None
+```
+
+`conditions` 與 `sorts` 的 union 型別擴充以接受上述兩者。
+
+### C. QB 語法
+
+```python
+# Filter
+QB["embedding"].cosine(q) < 0.3
+QB["embedding"].l2(q) < 1.0
+QB["embedding"].ip(q) > 0.7
+
+# Sort
+.sort(QB["embedding"].cosine(q))            # 升冪
+.sort(QB["embedding"].cosine(q).desc())     # 降冪
+
+# 組合
+((QB["doctype"] == "abc") & (QB["vec"].cosine(q) < 0.3)) \
+    .sort(QB["vec"].cosine(q)).limit(10)
+
+# Embedding 欄位 implicit unwrap：
+QB["summary"].cosine(q)                      # 自動視為 summary.vector
+```
+
+實作：`Field.cosine/l2/ip` 回傳 `VectorDistanceExpr`，dunder operator → `VectorDistanceCondition`；直接丟進 `.sort(...)` → `VectorDistanceSort`。
+
+### D. Encoder Registry
+
+三層優先序，**底層覆蓋上層**：
+
+| Level | API |
+|---|---|
+| Global  | `spec.configure(vector_encoders={"openai_small": fn, ...})` |
+| Model   | `spec.add_model(Doc, vector_encoders={"summary": "openai_small"})` |
+| Field   | `Vector(..., encoder="openai_small")` |
+
+Encoder 簽名：`Callable[[str], list[float]] | Callable[[str], Awaitable[list[float]]]`，sync / async 都支援。
+
+### E. 儲存模型（PostgresMetaStore + pgvector）
+
+| 來源 | 儲存位置 | 用途 |
+|---|---|---|
+| 完整 `list[float]` 或 `Embedding(content, vector, ...)` | `IResourceStore`（msgspec 序列化進 struct） | source of truth、export、重建索引 |
+| `vector(min(dim, 2048))` 副本 | `PostgresMetaStore` 新增的 vector 欄 | pgvector HNSW 索引、ANN 查詢 |
+
+- `dim > 2048`：截前 2048 維進 pg；`add_model` log warning（Matryoshka 模型適用）
+- HNSW 索引建立用 `CREATE INDEX CONCURRENTLY` 避免鎖表
+- `vector_cosine_ops` / `vector_l2_ops` / `vector_ip_ops` 依 distance 而定
+
+### F. Backend Capability 矩陣
+
+| Backend | 行為 |
+|---|---|
+| postgres + pgvector | native `vector(N)` + HNSW + `<=>` / `<->` / `<#>` SQL |
+| postgres（無 pgvector） | `add_model` 時 raise，要求安裝擴充 |
+| memory / disk / sqlite / redis / df / sqlalchemy / fast_slow | vector 進 `indexed_data` JSONB；查詢走 Python brute-force（O(n)）；首次 fallback emit `UserWarning`（per process per model） |
+
+`IMetaStore.supports_native_vector_search: bool` capability flag 提供給 ResourceManager 決定翻譯路徑。
+
+### G. 寫入 Pipeline
+
+新增 `EmbeddingProcessor`，與 `BinaryProcessor` 並列、用 type-driven traversal：
+
+```
+1. _coerce_data → msgspec.Struct
+2. EmbeddingProcessor.process(data):
+   for each Embedding field:
+     if vector is provided:
+         validate dim → raise on mismatch
+     else (need encode):
+         new_hash = xxh3_128(content).hexdigest()
+         prev = read_previous_revision()  # update / modify only
+         if prev.content_hash == new_hash and prev.encoder_id == current_encoder_id:
+             reuse prev.vector
+         else:
+             vector = await encoder(content)   # raise on failure → entire write fails
+             content_hash = new_hash
+             encoder_id = current_encoder_id
+3. VectorProcessor.process(data):
+   for each list[float] + Vector field:
+     validate dim
+4. ResourceManager.save:
+   - full struct → IResourceStore
+   - vector 副本（前 min(dim, 2048) 維）→ pg vector column
+```
+
+`content_hash` 用 **xxh3_128**：non-cryptographic 但 collision space = 2^128，速度與 xxh3_64 等同，足夠避免「碰撞 → 跳過 encoder → 留舊向量」的 silent bug。
+
+### H. 查詢 Pipeline
+
+```
+1. build_query parses input → ResourceMetaSearchQuery（含 VectorDistance* tags）
+2. 解析 query_vector：
+   if isinstance(query_vector, str):
+       resolve encoder for field → await encoder(text) → list[float]
+3. 解析 distance：condition/sort 給的 > annotation 給的 > "cosine"
+4. 翻譯到 backend：
+   pg + pgvector:  WHERE ... AND col <=> %s < threshold ORDER BY col <=> %s ASC LIMIT k
+   brute-force:     Python 端讀全部 meta → 算距離 → 排序 → limit
+```
+
+### I. DDL / Migration
+
+| 動作 | DDL | 資料 |
+|---|---|---|
+| 新增 Vector / Embedding 欄 | `add_model` 自動 `ALTER TABLE ADD COLUMN` + `CREATE INDEX CONCURRENTLY` | 舊 row vector 為 NULL；查詢自然排除；使用者要 backfill 跑 CLI |
+| 改 dim | `add_model` 偵測 column 既有 dim 不一致 → **raise**，要求顯式 schema version 升版 | 重算 embedding 為 user 職責 |
+| 改 distance | 同上 → raise；要求顯式新 schema version | 不需重算，但要 drop+recreate index |
+| 刪除欄位 | log warning，**不 auto drop**（保護資料）；要求手動 ALTER | — |
+
+### J. REST API
+
+- **不另開端點**。沿用 `GET /{model}` query string 機制
+- vector 欄位太大要塞進 URL → 使用者改傳 `query_vector` 為 `str`，由 encoder 編碼（內部 vector 但網路上的 query 字串只是短文字）
+
+### K. Validator
+
+`add_model` 註冊時自動生成 `_VectorDimValidator`，掛進 IValidator chain：
+- 長度 ≠ `dim` → `ValidationError("Vector field 'X': expected dim=N, got M")`
+- pure `list[float]` 欄與 `Embedding.vector` 子欄都檢查
+
+### L. OpenAPI / Web
+
+- OpenAPI 注入 `x-vector-dim`, `x-vector-distance`, `x-vector-encoder-id` 自訂屬性
+- Admin UI：
+  - Embedding 欄渲染為 text input（content 編輯，vector/hash/encoder_id 隱藏）
+  - 加 search bar：text → 走 encoder → vector search
+  - pure Vector 欄維持 read-only，僅能透過 search bar 觸發查詢
+
+### M. Backfill CLI
+
+```bash
+specstar backfill-vectors --model Doc --field summary
+```
+
+- 對 Embedding 欄位：掃 `vector IS NULL OR encoder_id != current` 的 rows → call encoder(content) → update
+- 對 pure `list[float] + Vector` 欄位：不支援（沒有 source 可重算）
+- V1 單緒、loop；批次大小 / 並行 / progress bar 是 V2
+
+---
+
+## 依賴拓樸
+
+```
+Phase 1：Annotation 與型別
+├─ 1.1 Vector marker
+├─ 1.2 Embedding struct
+└─ 1.3 extract_vectors / extract_embeddings 工具
+
+Phase 2：寫入 Pipeline
+├─ 2.1 _VectorDimValidator 自動掛載
+├─ 2.2 EmbeddingProcessor（traversal + cache reuse with xxh3_128）
+└─ 2.3 Encoder registry（global / model / field）
+
+Phase 3：Query 表達
+├─ 3.1 VectorDistanceCondition / VectorDistanceSort schema
+├─ 3.2 QB Field.cosine/l2/ip
+└─ 3.3 build_query 整合（含 str→vector 編碼）
+
+Phase 4：Postgres backend
+├─ 4.1 pgvector capability 偵測
+├─ 4.2 ALTER TABLE / CREATE INDEX CONCURRENTLY at add_model
+├─ 4.3 SQL 翻譯（filter + sort）
+└─ 4.4 dim>2048 截斷邏輯
+
+Phase 5：Brute-force fallback
+├─ 5.1 IMetaStore.supports_native_vector_search flag
+├─ 5.2 Python 距離函式（cosine/l2/ip）
+└─ 5.3 ResourceManager.search 翻譯時依 capability 切換
+
+Phase 6：使用者邊界
+├─ 6.1 OpenAPI 注入
+├─ 6.2 Admin UI 渲染
+└─ 6.3 backfill-vectors CLI
+
+Phase 7：文件與測試
+├─ 7.1 Capability matrix doc
+├─ 7.2 Encoder registry / migration guide
+└─ 7.3 Integration test（真 pg + pgvector，gated on env var）
+```
+
+---
+
+## 已決定的關鍵點（grilling 結果摘要）
+
+- **Annotation marker name**：`Vector`（不是 `Embedding`），名實相符
+- **dim 超過 pgvector HNSW 上限（2048）**：靜默截前 2048 維進索引欄、log warning；完整 vector 仍存在 IResourceStore（Matryoshka 模型適用）
+- **distance 預設**：annotation > query > "cosine"
+- **dim mismatch**：寫入時 raise `ValidationError`，訊息含 expected / actual
+- **REST URL 太長**：不另開 POST，使用者改傳 string 給 encoder 編碼
+- **Vector / Embedding 同層**：Embedding 是 struct（content + vector + hash + encoder_id），Vector annotation 在兩種欄位上語意一致
+- **Cache reuse**：`(content_hash, encoder_id)` 同時不變才重用，避免 encoder 切換漏算
+- **Encoder error**：寫入 atomic、整個 fail；查詢同樣 raise
+- **content_hash 算法**：xxh3_128（speed of xxh3，128-bit collision safety）
+- **Content 存哪**：inline 進 resource data，不寫進 blob store
+- **QB API**：`Field.cosine(q) / .l2(q) / .ip(q)` 三個方法，filter/sort 同 expression
+- **Backend fallback**：非 pgvector 走 brute-force，首次觸發 warning
+- **Capability check**：三段（store init / add_model / query），有 `supports_native_vector_search` flag
+- **Migration**：auto add column；改 dim/distance raise；刪欄不 auto drop
+- **V1 包含**：OpenAPI 注入、Admin UI 渲染、backfill CLI
+- **V2 推遲**：GraphQL vector、list[Embedding] multi-vector、並行 backfill
+
+---
+
+## 開放問題（實作期再敲）
+
+- HNSW 參數（`m`, `ef_construction`）：先用 pgvector 預設，未來透過 backend config 調整
+- Encoder registry 在 `BackendConfig` 還是 `SpecStar.configure()`：傾向後者
+- xxhash 套件依賴：`xxhash` PyPI package（C 實作，extremely fast）加進 `pyproject.toml`
+- pg `CREATE INDEX CONCURRENTLY` 必須不在 transaction 中執行；要與 `_init_postgres_table` 既有 transaction 路徑切開
+- `query_vector: str` 路徑的 encoder 失敗：與寫入一致 → raise 整個查詢失敗
+
+---
+
+## 風險
+
+- **pgvector 安裝門檻**：需 superuser 才能 `CREATE EXTENSION`。dev 用 docker-compose 內建 image；prod 由 DBA 預先處理
+- **大量 backfill 時的 API 費用**：CLI 應加 `--dry-run` 預估 token 量；未來支援 batch encoder
+- **encoder switching 的破壞性**：encoder_id 改變 = 重算所有 embedding。文件需強調此成本
+- **Matryoshka 隱式截斷誤用**：若 user 用非 Matryoshka 模型（e.g. word2vec 拼接的 3000 維）會默默損失精度。靠 startup warning + 文件強調
+
+---
+
+## 與既有設計的相容性
+
+- 完全使用既有的 `IMetaStore`、`IResourceStore`、`IValidator`、`IndexedValueExtractor` 抽象，沒有破壞性修改
+- `ResourceMetaSearchQuery` 的 union 擴充屬於 backwards-compatible（既有 client 不送 vector 條件就完全等價）
+- `BinaryProcessor` 與 `EmbeddingProcessor` 互不影響，可並存於同一 model
+- `Schema` migration API 不變；vector 欄位的 dim/distance 變動納入既有的 schema version 機制

--- a/docs/en/concepts/vector-and-embedding.md
+++ b/docs/en/concepts/vector-and-embedding.md
@@ -1,0 +1,221 @@
+# Vector & Embedding
+
+This page explains *why* and *how* SpecStar models vector similarity search.
+For the practical recipe, see [How-to: Vector Search](../howto/vector-search.md).
+
+---
+
+## Goals
+
+1. **Define a vector field once** with `Annotated[..., Vector(...)]`.
+2. **Two layers**: raw `list[float]` for pre-computed vectors, and
+   `Embedding(content, vector, ...)` for content the framework should encode.
+3. **Composability**: a vector distance filter is just another condition in
+   `ResourceMetaSearchQuery.conditions`; a vector sort is just another sort
+   in `ResourceMetaSearchQuery.sorts`. They mix freely with scalar
+   conditions and sorts.
+4. **Backend-aware**: native pgvector when available, brute-force fallback
+   otherwise. Same Python API either way.
+
+---
+
+## Two annotation patterns
+
+### Raw vector
+
+```python
+class Doc(Struct):
+    embedding: Annotated[list[float], Vector(dim=1536, distance="cosine")]
+```
+
+Use when you already have a vector. The framework only validates length and
+makes it searchable.
+
+### Embedding wrapper
+
+```python
+class Doc(Struct):
+    summary: Annotated[
+        Embedding,
+        Vector(dim=1536, distance="cosine", encoder="openai_small"),
+    ]
+```
+
+`Embedding` is analogous to `Binary`: a small struct that pairs the source
+content with derived metadata (`vector`, `content_hash`, `encoder_id`).
+At write time the framework auto-fills the derived fields by calling the
+registered encoder.
+
+```python
+class Embedding(Struct, kw_only=True):
+    content: str
+    vector: list[float] | UnsetType = UNSET
+    content_hash: str | UnsetType = UNSET   # xxh3_128(content) hex
+    encoder_id: str | UnsetType = UNSET     # name from the registry
+```
+
+---
+
+## Write pipeline
+
+When you call `create / update / modify` on a model with `Vector` or
+`Embedding` fields, the framework runs these steps in order:
+
+1. **Coerce** (`dict` / `Pydantic` → `msgspec.Struct`)
+2. **Binary processor** — extract bytes into the blob store (existing behavior)
+3. **Embedding processor** — for each `Embedding` field:
+   - if `vector` is already set: keep as-is
+   - else if the previous revision has the same `(content_hash, encoder_id)`:
+     reuse the previous vector (**no encoder call**)
+   - else: call the encoder, fill `vector / content_hash / encoder_id`
+4. **Dim validator** — raise `ValidationError` if any vector length ≠ `dim`
+5. **Encode + persist**
+
+The cache reuse step is the critical optimisation: editing an unrelated field
+on a `Doc` does **not** pay another encoding API call.
+
+---
+
+## Query model
+
+Vector primitives live in the same union as scalar primitives:
+
+```python
+ResourceMetaSearchQuery(
+    conditions=[
+        DataSearchCondition(...),         # scalar filter
+        DataSearchGroup(...),             # AND/OR/NOT group
+        VectorDistanceCondition(...),     # NEW
+    ],
+    sorts=[
+        ResourceMetaSearchSort(...),      # meta field
+        ResourceDataSearchSort(...),      # indexed data field
+        VectorDistanceSort(...),          # NEW
+    ],
+)
+```
+
+`VectorDistanceCondition` carries `field_path`, `query_vector` (`list[float] |
+str`), `operator` (`lt / lte / gt / gte`), `threshold`, and optional `distance`
+override.
+
+`VectorDistanceSort` carries `field_path`, `query_vector`, `direction`, and
+optional `distance`.
+
+### Query Builder syntax
+
+```python
+QB["embedding"].cosine(q) < 0.3              # → VectorDistanceCondition
+QB["embedding"].l2(q) > 1.0
+QB["embedding"].ip(q) >= 0.7
+
+Query().sort(QB["embedding"].cosine(q))      # → VectorDistanceSort asc
+Query().sort(QB["embedding"].cosine(q).desc())
+```
+
+`q` is either `list[float]` or `str`. When `str`, the framework calls the
+field's registered encoder at search time. Async encoders are not supported
+on the sync search path — register a sync encoder for the query side, or
+provide both via `vector_encoders`.
+
+---
+
+## Storage model
+
+The source-of-truth vector lives in the resource payload (`IResourceStore`),
+serialized along with the rest of the struct via `msgspec`. The meta store
+maintains an additional indexable copy:
+
+| Backend | Where the vector lives |
+|---|---|
+| `postgres` + pgvector | `vector(N)` column per Vector field, HNSW-indexed. Source vector also in JSONB `indexed_data` for parity. |
+| Other meta stores | JSONB `indexed_data` only. Search is Python-side brute force. |
+
+`add_model` invokes `ensure_vector_column(field_path, dim, distance)` on the
+meta store when it advertises `supports_native_vector_search = True`, which
+adds the column and an HNSW index using `CREATE INDEX CONCURRENTLY` (no
+table lock).
+
+---
+
+## High-dimensional vectors
+
+pgvector's HNSW index supports up to **2 000 dimensions**. SpecStar accepts
+larger annotated dims (e.g. 3 072 for OpenAI `text-embedding-3-large`) and
+indexes only the **first 2 000 dimensions**:
+
+- The full vector is still in `IResourceStore` and `indexed_data`.
+- The pgvector column is `vector(2000)` and indexed.
+- A startup warning highlights this so non-Matryoshka models can be flagged.
+
+This works correctly for Matryoshka-trained embeddings, where the prefix is
+itself a valid (lower-resolution) embedding. For models that do not have
+this property, prefer dimensions ≤ 2 000.
+
+---
+
+## Distance metrics
+
+| Metric | Annotation value | pgvector operator | Domain |
+|---|---|---|---|
+| Cosine distance | `"cosine"` (default) | `<=>` | LLM / sentence embeddings |
+| Euclidean (L2) | `"l2"` | `<->` | Image / signal vectors |
+| Negative inner product | `"ip"` | `<#>` | Pre-normalized vectors |
+
+All three are *distances* — lower means closer — so `VectorDistanceSort
+ascending` always returns the nearest rows first regardless of metric.
+
+Resolution: per-call metric > annotation metric > `"cosine"` default.
+
+---
+
+## Backend capability flag
+
+```python
+class IMetaStore:
+    @property
+    def supports_native_vector_search(self) -> bool:
+        return False  # subclasses override
+```
+
+`PostgresMetaStore` detects the pgvector extension on construction and sets
+this to `True`. `ResourceManager` checks the flag when wiring `add_model` and
+provisions a pgvector column only when native support is present. The
+brute-force code path is wired into `is_match_query` and `get_sort_fn` in
+`specstar.resource_manager.basic`.
+
+---
+
+## OpenAPI integration
+
+Vector fields surface as custom extensions on their OpenAPI property:
+
+- `x-vector-dim`: integer
+- `x-vector-distance`: `"cosine" | "l2" | "ip"` (omitted when unset)
+- `x-vector-encoder-id`: string (omitted when no encoder configured)
+
+The admin UI and downstream SDK generators can use these hints to render
+vector-aware controls (e.g. a search-by-text input that POSTs the encoder name
+via REST).
+
+---
+
+## What's NOT in V1
+
+- **Multi-vector fields per resource** (`list[Embedding]`) — multi-vector
+  indexes need a different strategy on pgvector; treat each as its own
+  resource for now.
+- **Auto schema migration when `dim` or `distance` changes** — these are
+  hard to do safely (data must be re-encoded; index must be rebuilt).
+  Bump your schema version and run a backfill instead.
+- **GraphQL vector queries** — REST + Python SDK first.
+- **Async encoder on the sync query path** — registered async encoders
+  work fine on the write path; the query side needs a sync encoder.
+
+---
+
+## See also
+
+- [How-to: Vector Search](../howto/vector-search.md)
+- [Search & Indexing](search-indexing.md)
+- [Query System](query-system.md)

--- a/docs/en/howto/vector-search.md
+++ b/docs/en/howto/vector-search.md
@@ -1,0 +1,352 @@
+# Vector Search & Embeddings
+
+SpecStar provides first-class support for vector similarity search via the
+`Vector` annotation and the `Embedding` struct type. This guide shows the
+common patterns end-to-end.
+
+---
+
+## TL;DR
+
+```python
+from typing import Annotated
+
+from msgspec import Struct
+
+from specstar import Embedding, SpecStar, Vector
+from specstar.query import QB
+
+
+class Doc(Struct):
+    title: str
+    doctype: str
+    summary: Annotated[Embedding, Vector(dim=1536, encoder="openai_small")]
+
+
+def embed(text: str) -> list[float]:
+    # call your favorite embedding model — returns a 1536-d vector
+    ...
+
+
+spec = SpecStar()
+spec.configure(vector_encoders={"openai_small": embed})
+# `doctype` is a regular indexed scalar so we can combine it with the
+# vector filter below.
+spec.add_model(Doc, indexed_fields=["doctype"])
+mgr = spec.get_resource_manager(Doc)
+
+# Write: vector is auto-computed from content
+mgr.create(
+    Doc(title="hello", doctype="article",
+        summary=Embedding(content="long doc text..."))
+)
+
+# Query: nearest-3 by cosine, with a doctype filter, using a plain string query
+query = (
+    (QB["doctype"] == "article") & (QB["summary"].cosine("how to use ...") < 0.3)
+).sort(QB["summary"].cosine("how to use ...")).limit(3).build()
+
+results = mgr.list_resources(query, returns=["data"])
+```
+
+---
+
+## 1. Two ways to declare a vector field
+
+### Level 1 — raw `list[float]` (you compute the vector yourself)
+
+```python
+class Doc(Struct):
+    title: str
+    embedding: Annotated[list[float], Vector(dim=1536, distance="cosine")]
+
+
+mgr.create(Doc(title="t", embedding=my_vector))
+```
+
+Use this when your application already has vectors and you don't want SpecStar
+to call any encoder.
+
+### Level 2 — `Embedding` struct (framework calls the encoder)
+
+```python
+class Doc(Struct):
+    title: str
+    summary: Annotated[
+        Embedding,
+        Vector(dim=1536, distance="cosine", encoder="openai_small"),
+    ]
+
+
+mgr.create(Doc(title="t", summary=Embedding(content="...")))
+```
+
+`Embedding(content="...")` is enough — the framework runs the registered encoder,
+fills in `vector`, `content_hash` (xxh3_128), and `encoder_id`.
+
+If `content` is unchanged on a subsequent `update()`, the encoder is **not**
+re-called (cache reuse based on `(content_hash, encoder_id)`).
+
+---
+
+## 2. Registering encoders
+
+SpecStar does **not** ship with any embedding model. You bring your own
+callable that takes `str` and returns `list[float]` of the dimension you
+declared on the `Vector` annotation. The framework only enforces the contract
+— `dim` must match, that's it.
+
+### 2a. Wiring popular providers
+
+**OpenAI** (1536-d `text-embedding-3-small`, 3072-d `text-embedding-3-large`):
+
+```python
+from openai import OpenAI
+
+_client = OpenAI()  # uses OPENAI_API_KEY env var
+
+def embed_openai_small(text: str) -> list[float]:
+    resp = _client.embeddings.create(model="text-embedding-3-small", input=text)
+    return resp.data[0].embedding
+
+
+# Async variant (works on the write path)
+from openai import AsyncOpenAI
+
+_aclient = AsyncOpenAI()
+
+async def embed_openai_small_async(text: str) -> list[float]:
+    resp = await _aclient.embeddings.create(
+        model="text-embedding-3-small", input=text,
+    )
+    return resp.data[0].embedding
+```
+
+**sentence-transformers** (local; no API key, ~90 MB download for the small one):
+
+```python
+from sentence_transformers import SentenceTransformer
+
+_model = SentenceTransformer("all-MiniLM-L6-v2")  # 384-d
+
+def embed_local(text: str) -> list[float]:
+    return _model.encode(text, convert_to_numpy=False).tolist()
+```
+
+**Cohere**, **VoyageAI**, **Mistral embed**, etc. all follow the same shape —
+wrap their SDK call in a function with signature `(str) -> list[float]`.
+
+**HuggingFace inference API** when you don't want a local model:
+
+```python
+import os
+import requests
+
+_HF_TOKEN = os.environ["HF_TOKEN"]
+_HF_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+def embed_hf(text: str) -> list[float]:
+    r = requests.post(
+        f"https://api-inference.huggingface.co/pipeline/feature-extraction/{_HF_MODEL}",
+        headers={"Authorization": f"Bearer {_HF_TOKEN}"},
+        json={"inputs": text},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+```
+
+!!! note "Test code uses tiny deterministic stubs"
+    The unit test suite registers small functions like `lambda t: [1.0, 0.0]`
+    so behavior is reproducible without paying for API calls or downloading
+    model weights. Replace those with the real wiring above for production.
+
+### 2b. Registration hierarchy
+
+Encoders are `Callable[[str], list[float]]` (sync) or
+`Callable[[str], Awaitable[list[float]]]` (async, write path only).
+
+Resolution priority — **inner overrides outer**:
+
+```python
+# 1. Global (least specific)
+spec.configure(vector_encoders={
+    "openai_small": embed_openai_small,
+    "openai_large": embed_openai_large,
+})
+
+# 2. Per-model override
+spec.add_model(Doc, vector_encoders={"summary": "openai_large"})  # or a callable
+
+# 3. Per-field override (most specific)
+Vector(dim=1536, encoder="openai_small")
+```
+
+---
+
+## 3. Querying
+
+### Python SDK (QB)
+
+```python
+from specstar.query import QB
+
+q = (
+    (QB["embedding"].cosine(query_vec) < 0.3)
+    .sort(QB["embedding"].cosine(query_vec))
+    .limit(10)
+    .build()
+)
+mgr.list_resources(q, returns=["data"])
+```
+
+`Field.cosine(q)`, `Field.l2(q)`, `Field.ip(q)` build a vector-distance expression.
+- Use `< / <= / > / >=` to make a **filter** (threshold).
+- Pass it to `.sort(...)` to make a **sort** (ascending = nearest first).
+- `.desc()` for descending.
+
+Vector conditions compose with scalar conditions via `&` / `|` / `~`:
+
+```python
+((QB["doctype"] == "abc") & (QB["embedding"].cosine(q) < 0.3))
+    .sort(QB["embedding"].cosine(q))
+```
+
+### REST
+
+Use the standard `GET /{model}` endpoint with JSON-encoded conditions.
+Vector and scalar conditions live in the same `conditions` list and sorts
+share the same `sorts` list:
+
+```http
+GET /docs?conditions=[
+  {"type":"DataSearchCondition","field_path":"doctype","operator":"eq","value":"abc"},
+  {"type":"VectorDistanceCondition","field_path":"embedding",
+   "query_vector":"how to use vectors","operator":"lt","threshold":0.3,
+   "distance":"cosine"}
+]&sorts=[
+  {"type":"VectorDistanceSort","field_path":"embedding",
+   "query_vector":"how to use vectors","direction":"+"}
+]&limit=10
+```
+
+`query_vector` can be either:
+- a `list[float]` (the vector itself), or
+- a `str` — the framework calls the field's registered encoder before dispatching.
+
+The string form keeps URLs short and lets you debug from `curl`. Pass a
+raw 1536-dim vector via the URL only if you accept the URL-length tradeoff.
+
+---
+
+## 4. Choosing a distance metric
+
+| Metric | When | pgvector op |
+|---|---|---|
+| `"cosine"` | Sentence / document embeddings (OpenAI, Cohere, BGE …). **Default** if none specified. | `<=>` |
+| `"l2"` | Image / signal vectors. Euclidean. | `<->` |
+| `"ip"` | Pre-normalized vectors where you want raw dot product. | `<#>` |
+
+Resolution order: annotation `Vector(distance=...)` → per-call (`QB["e"].l2(q)`)
+→ default `"cosine"`. If the per-call distance differs from the annotation's
+distance, the per-call value wins.
+
+---
+
+## 5. Backend matrix
+
+| Backend | Behavior |
+|---|---|
+| `postgres` + pgvector | Native `vector(N)` column + HNSW index + SQL operators. |
+| `postgres` without pgvector | `add_model` for a Vector field raises — install the extension or switch backend. |
+| `memory`, `disk`, `sqlite3`, `redis`, `df`, `sqlalchemy`, `fast_slow` | Brute-force Python comparison (O(n)). Suitable for dev / tests. |
+
+The capability is exposed via `IMetaStore.supports_native_vector_search`.
+
+---
+
+## 6. Dimensions above the HNSW limit
+
+pgvector's HNSW index supports up to 2 000 dimensions. SpecStar handles larger
+embeddings (e.g. OpenAI `text-embedding-3-large` at 3 072) by:
+
+- Storing the **full** vector in the resource payload (via `IResourceStore`).
+- Indexing only the **first 2 000 dimensions** in the pgvector column.
+
+This works well for Matryoshka-trained embeddings, where the truncated prefix
+is itself a meaningful (lower-resolution) embedding. A startup warning is
+logged so non-Matryoshka users notice.
+
+---
+
+## 7. Backfilling existing data
+
+When you add a `Vector` field to a model that already has rows, the new
+column starts as `NULL`. Run the bundled CLI to populate it:
+
+```bash
+specstar backfill-vectors --spec myapp:spec --model doc --field summary
+```
+
+`--spec` is a `module:attr` reference to your `SpecStar` instance.
+`--model` is the **registered resource name** (the same string you'd pass
+to `spec.get_resource_manager("doc")`). With the default `kebab`
+naming, `class Doc` registers as `"doc"`; `class MyDoc` registers as
+`"my-doc"`. If you set `name=` explicitly on `add_model`, use that value.
+
+This works only for **`Embedding`** fields (the source `content` is the input
+to the encoder). For raw `list[float] + Vector` fields, you must supply the
+vectors yourself via `update()` because the framework has no way to recompute
+them.
+
+---
+
+## 8. Validation
+
+A `VectorDimValidator` is auto-mounted by `add_model`. On `create` / `update`
+/ `modify`, any vector whose length doesn't match the annotated `dim` raises
+`ValidationError`:
+
+```
+ValidationError: Vector field 'embedding': expected dim=1536, got 512
+```
+
+If you pass an `Embedding` without a vector (i.e. `Embedding(content="...")`),
+the validator skips it — the processor will fill it in.
+
+---
+
+## 9. Cache reuse on update
+
+The processor only calls the encoder when **content** or **encoder_id** has
+changed. Updating a doc's `title` (with the same `summary.content`) is free —
+no extra API call.
+
+If you switch encoders (e.g. `openai_small` → `openai_large`), all rows are
+re-encoded on next write or via `backfill-vectors`.
+
+---
+
+## 10. OpenAPI
+
+Vector field properties carry custom extensions for downstream tools and admin
+UIs:
+
+```json
+{
+  "summary": {
+    "type": "object",
+    "x-vector-dim": 1536,
+    "x-vector-distance": "cosine",
+    "x-vector-encoder-id": "openai_small"
+  }
+}
+```
+
+---
+
+## See also
+
+- [Vector & Embedding — concepts](../concepts/vector-and-embedding.md)
+- [Query Builder](query-builder.md)
+- [Binary Data](binary-data.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ plugins:
               - concepts/resource-lifecycle.md
               - concepts/search-indexing.md
               - concepts/query-system.md
+              - concepts/vector-and-embedding.md
               - concepts/refs.md
               - concepts/validation.md
               - concepts/route-templates.md
@@ -187,6 +188,7 @@ plugins:
                 - howto/query-builder.md
                 - howto/graphql.md
                 - howto/binary-data.md
+                - howto/vector-search.md
                 - howto/pydantic-integration.md
                 - howto/backup-restore.md
                 - howto/web-ui.md

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -19,8 +19,10 @@ from specstar.types import (
     BackgroundTaskAccepted,
     BlobUploadSession,
     DisplayName,
+    Embedding,
     IConstraintChecker,
     IValidator,
+    ValidationError,
     Job,
     JobRedirectInfo,
     OnDelete,
@@ -31,6 +33,7 @@ from specstar.types import (
     SearchedResource,
     TaskStatus,
     Unique,
+    Vector,
 )
 
 # Global instance for simplified usage pattern
@@ -47,6 +50,7 @@ __all__ = [
     "BlobUploadSession",
     "ConnectionProfile",
     "DisplayName",
+    "Embedding",
     "IConstraintChecker",
     "IValidator",
     "Job",
@@ -63,6 +67,8 @@ __all__ = [
     "SpecStar",
     "TaskStatus",
     "Unique",
+    "ValidationError",
+    "Vector",
     "spec",
     "env",
     "string_ref",

--- a/specstar/cli/__init__.py
+++ b/specstar/cli/__init__.py
@@ -28,6 +28,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 
+from specstar.cli._backfill import add_backfill_parser
 from specstar.cli._gen import add_gen_parser
 from specstar.cli._init import add_init_parser
 from specstar.cli._lock import add_lock_parser
@@ -50,6 +51,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_lock_parser(sub)
     add_verify_parser(sub)
     add_status_parser(sub)
+    add_backfill_parser(sub)
     return parser
 
 

--- a/specstar/cli/_backfill.py
+++ b/specstar/cli/_backfill.py
@@ -1,0 +1,85 @@
+"""``specstar backfill-vectors`` — batch re-encode Vector / Embedding fields.
+
+Loads a SpecStar instance from ``--spec module:attr`` and runs
+:func:`specstar.resource_manager.backfill.backfill_vectors` against the
+named model + field.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from typing import TextIO
+
+
+def add_backfill_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``backfill-vectors`` subcommand."""
+    p = subparsers.add_parser(
+        "backfill-vectors",
+        help="Re-encode Vector / Embedding fields for existing rows.",
+        description=(
+            "Scan a registered model's resources and call the configured "
+            "encoder for any Embedding field where the stored vector is "
+            "missing or stale (encoder_id differs from the current one)."
+        ),
+    )
+    p.add_argument(
+        "--spec",
+        required=True,
+        help="Module path to your SpecStar instance, e.g. 'myapp:spec'.",
+    )
+    p.add_argument(
+        "--model",
+        required=True,
+        help="Registered model name (the same string used in add_model name=...).",
+    )
+    p.add_argument(
+        "--field",
+        required=True,
+        help="Name of the Embedding field on the model.",
+    )
+    p.set_defaults(func=backfill_vectors_cmd)
+
+
+def backfill_vectors_cmd(
+    args: argparse.Namespace,
+    *,
+    stream: TextIO | None = None,
+    error_stream: TextIO | None = None,
+) -> int:
+    stream = stream or sys.stdout
+    error_stream = error_stream or sys.stderr
+
+    try:
+        module_name, attr = args.spec.split(":", 1)
+    except ValueError:
+        print(f"--spec must be 'module:attr', got {args.spec!r}", file=error_stream)
+        return 2
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        print(f"cannot import {module_name!r}: {exc}", file=error_stream)
+        return 2
+
+    spec = getattr(module, attr, None)
+    if spec is None:
+        print(f"{module_name!r} has no attribute {attr!r}", file=error_stream)
+        return 2
+
+    try:
+        rm = spec.get_resource_manager(args.model)
+    except (KeyError, ValueError) as exc:
+        print(f"model {args.model!r} not registered: {exc}", file=error_stream)
+        return 2
+
+    from specstar.resource_manager.backfill import backfill_vectors
+
+    summary = backfill_vectors(rm, field_name=args.field)
+    print(
+        f"backfill-vectors[{args.model}.{args.field}]: "
+        f"encoded={summary.encoded} skipped={summary.skipped}",
+        file=stream,
+    )
+    return 0

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -256,6 +256,11 @@ class SpecStar:
         self._pending_update_actions: list[_PendingUpdateAction] = []
         self.backend: BackendConfig | None = None
 
+        # Vector + Embedding: encoder registry shared across all models
+        from specstar.resource_manager.encoder_registry import EncoderRegistry
+
+        self.encoder_registry = EncoderRegistry()
+
         # Apply configuration using shared logic
         self._apply_configuration(
             model_naming=model_naming,
@@ -472,6 +477,7 @@ class SpecStar:
         default_now: Callable[[], dt.datetime] | UnsetType = UNSET,
         default_status: RevisionStatus | UnsetType = UNSET,
         strict_operation_context: bool | UnsetType = UNSET,
+        vector_encoders: dict[str, Callable] | UnsetType = UNSET,
     ) -> None:
         """Configure the SpecStar instance dynamically.
 
@@ -561,6 +567,11 @@ class SpecStar:
             default_status=default_status,
             strict_operation_context=strict_operation_context,
         )
+
+        # Register vector encoders into the registry
+        if vector_encoders is not UNSET:
+            for name, fn in vector_encoders.items():
+                self.encoder_registry.register(name, fn)
 
     def get_resource_manager(self, model: type[T] | str) -> IResourceManager[T]:
         """Get the resource manager for a registered model.
@@ -978,6 +989,7 @@ class SpecStar:
         | None = None,
         validator: "Callable[[T], None] | IValidator | type | None" = None,
         constraint_checkers: "Sequence[IConstraintChecker | Callable[[ResourceManager], IConstraintChecker]] | None" = None,
+        vector_encoders: dict[str, str | Callable] | None = None,
     ) -> None:
         """Register a resource model (or `Schema`) and create its `ResourceManager`.
 
@@ -1231,6 +1243,44 @@ class SpecStar:
                         IndexableField(field_path="retries", field_type=int)
                     )
 
+        # Auto-mount dim validator for any Vector / Embedding fields
+        from specstar.resource_manager.vector_validator import (
+            CompositeValidator,
+            VectorDimValidator,
+        )
+        from specstar.types import extract_vector_field_infos
+
+        vector_infos = extract_vector_field_infos(resolved_model)
+        if vector_infos:
+            dim_validator = VectorDimValidator(resolved_model)
+            if validator is None:
+                validator = dim_validator
+            else:
+                validator = CompositeValidator([dim_validator, validator])
+
+            # Make vector values searchable via indexed_data (brute-force
+            # backends use this; pgvector backend reads it for indexed copy).
+            # For Embedding fields, extract from "<name>.vector" but expose
+            # the value under the short alias "<name>" so QB["<name>"]
+            # matches naturally.
+            existing_keys = {(f.index_key or f.field_path) for f in _indexed_fields}
+            for vinfo in vector_infos:
+                if vinfo.is_embedding:
+                    field_path = f"{vinfo.name}.vector"
+                    index_key = vinfo.name
+                else:
+                    field_path = vinfo.name
+                    index_key = None
+                key_in_use = index_key or field_path
+                if key_in_use not in existing_keys:
+                    _indexed_fields.append(
+                        IndexableField(
+                            field_path=field_path,
+                            field_type=list,
+                            index_key=index_key,
+                        )
+                    )
+
         # ResourceManager binds T from ``resolved_model`` (typed as bare
         # ``type`` after Pydantic conversion), erasing the caller's T.
         # Cast the parameterised inputs to the corresponding T-erased
@@ -1252,9 +1302,28 @@ class SpecStar:
             pydantic_type=pydantic_model,
             constraint_checkers=constraint_checkers,
             strict_operation_context=self.strict_operation_context,
+            encoder_registry=self.encoder_registry,
+            vector_encoders=vector_encoders,
             **other_options,
         )
         self.resource_managers[model_name] = resource_manager
+
+        # If meta store supports native vector indexing, register pgvector
+        # columns + HNSW indices for each Vector / Embedding field
+        meta_store = getattr(resource_manager.storage, "_meta_store", None)
+        if (
+            vector_infos
+            and meta_store is not None
+            and getattr(meta_store, "supports_native_vector_search", False)
+            and hasattr(meta_store, "ensure_vector_column")
+        ):
+            for vinfo in vector_infos:
+                # Use the short alias (matches the indexed_data key).
+                meta_store.ensure_vector_column(
+                    vinfo.name,
+                    dim=vinfo.marker.dim,
+                    distance=vinfo.marker.distance or "cosine",
+                )
 
         # Scan Ref / RefRevision annotations and collect relationships
         refs = extract_refs(resolved_model, model_name)

--- a/specstar/crud/openapi_builder.py
+++ b/specstar/crud/openapi_builder.py
@@ -230,6 +230,24 @@ class OpenAPIBuilder:
                 if comp is not None:
                     comp["x-display-name-field"] = dn_field
 
+            # Vector / Embedding field annotations
+            from specstar.types import extract_vector_field_infos
+
+            vector_infos = extract_vector_field_infos(struct_type)
+            if vector_infos:
+                comp = _find_component(struct_name)
+                if comp is not None:
+                    props = comp.get("properties", {})
+                    for vinfo in vector_infos:
+                        prop = props.get(vinfo.name)
+                        if prop is None:
+                            continue
+                        prop["x-vector-dim"] = vinfo.marker.dim
+                        if vinfo.marker.distance is not None:
+                            prop["x-vector-distance"] = vinfo.marker.distance
+                        if vinfo.marker.encoder is not None:
+                            prop["x-vector-encoder-id"] = vinfo.marker.encoder
+
             if inject_unique and rm is not None:
                 unique_fields = self._get_unique_fields(rm)
                 if unique_fields:

--- a/specstar/query.py
+++ b/specstar/query.py
@@ -15,7 +15,67 @@ from specstar.query_types import (
     ResourceMetaSearchSort,
     ResourceMetaSortDirection,
     ResourceMetaSortKey,
+    VectorDistanceCondition,
+    VectorDistanceSort,
 )
+
+
+class VectorDistanceExpr:
+    """A vector-distance expression produced by ``Field.cosine/l2/ip(q)``.
+
+    Acts as both a filter (via ``<``, ``<=``, ``>``, ``>=``) and a sort
+    (when passed to :meth:`Query.sort`).
+    """
+
+    __slots__ = ("field_path", "query_vector", "distance")
+
+    def __init__(
+        self,
+        field_path: str,
+        query_vector,
+        distance,
+    ) -> None:
+        self.field_path = field_path
+        self.query_vector = query_vector
+        self.distance = distance
+
+    def _cond(self, op: DataSearchOperator, threshold: float) -> "ConditionBuilder":
+        cond = VectorDistanceCondition(
+            field_path=self.field_path,
+            query_vector=self.query_vector,
+            operator=op,
+            threshold=float(threshold),
+            distance=self.distance,
+        )
+        return ConditionBuilder(cond)
+
+    def __lt__(self, threshold: float) -> "ConditionBuilder":
+        return self._cond(DataSearchOperator.less_than, threshold)
+
+    def __le__(self, threshold: float) -> "ConditionBuilder":
+        return self._cond(DataSearchOperator.less_than_or_equal, threshold)
+
+    def __gt__(self, threshold: float) -> "ConditionBuilder":
+        return self._cond(DataSearchOperator.greater_than, threshold)
+
+    def __ge__(self, threshold: float) -> "ConditionBuilder":
+        return self._cond(DataSearchOperator.greater_than_or_equal, threshold)
+
+    def asc(self) -> VectorDistanceSort:
+        return VectorDistanceSort(
+            field_path=self.field_path,
+            query_vector=self.query_vector,
+            direction=ResourceMetaSortDirection.ascending,
+            distance=self.distance,
+        )
+
+    def desc(self) -> VectorDistanceSort:
+        return VectorDistanceSort(
+            field_path=self.field_path,
+            query_vector=self.query_vector,
+            direction=ResourceMetaSortDirection.descending,
+            distance=self.distance,
+        )
 
 _PREV_Query = globals().get("Query")
 _PREV_ConditionBuilder = globals().get("ConditionBuilder")
@@ -82,6 +142,8 @@ class Query:
                         direction=direction, field_path=field_name
                     )
                 self._sorts.append(sort_obj)
+            elif isinstance(s, VectorDistanceExpr):
+                self._sorts.append(s.asc())
             else:
                 self._sorts.append(s)
         return self
@@ -467,6 +529,18 @@ class Field(ConditionBuilder):
             # Equivalent to: QB["comment"].is_falsy()
         """
         return self.is_falsy()
+
+    def cosine(self, query_vector) -> VectorDistanceExpr:
+        """Build a cosine-distance expression for this field."""
+        return VectorDistanceExpr(self.name, query_vector, "cosine")
+
+    def l2(self, query_vector) -> VectorDistanceExpr:
+        """Build an L2-distance expression for this field."""
+        return VectorDistanceExpr(self.name, query_vector, "l2")
+
+    def ip(self, query_vector) -> VectorDistanceExpr:
+        """Build an inner-product distance expression for this field."""
+        return VectorDistanceExpr(self.name, query_vector, "ip")
 
     def between(self, min_val: Any, max_val: Any) -> ConditionBuilder:
         """Support range query: field.between(min, max).

--- a/specstar/query_types.py
+++ b/specstar/query_types.py
@@ -4,7 +4,7 @@ import datetime as dt
 import os
 import warnings
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from msgspec import UNSET, Struct, UnsetType
 
@@ -51,7 +51,21 @@ class DataSearchGroup(Struct, kw_only=True, tag=True):
     conditions: list["DataSearchCondition | DataSearchGroup"]
 
 
-DataSearchFilter = DataSearchCondition | DataSearchGroup
+class VectorDistanceCondition(Struct, kw_only=True, tag=True):
+    """Filter rows by the distance between a Vector field and a query vector.
+
+    Belongs in :attr:`ResourceMetaSearchQuery.conditions` alongside
+    :class:`DataSearchCondition` and :class:`DataSearchGroup`.
+    """
+
+    field_path: str
+    query_vector: list[float] | str
+    operator: DataSearchOperator
+    threshold: float
+    distance: "Literal['cosine', 'l2', 'ip'] | None" = None
+
+
+DataSearchFilter = DataSearchCondition | DataSearchGroup | VectorDistanceCondition
 
 
 class ResourceMetaSortDirection(StrEnum):
@@ -83,6 +97,19 @@ class ResourceMetaSortKey(StrEnum):
 class ResourceMetaSearchSort(Struct, kw_only=True, tag=True):
     direction: ResourceMetaSortDirection = ResourceMetaSortDirection.ascending
     key: ResourceMetaSortKey
+
+
+class VectorDistanceSort(Struct, kw_only=True, tag=True):
+    """Sort rows by the distance between a Vector field and a query vector.
+
+    Belongs in :attr:`ResourceMetaSearchQuery.sorts` alongside
+    :class:`ResourceMetaSearchSort` and :class:`ResourceDataSearchSort`.
+    """
+
+    field_path: str
+    query_vector: list[float] | str
+    direction: ResourceMetaSortDirection = ResourceMetaSortDirection.ascending
+    distance: "Literal['cosine', 'l2', 'ip'] | None" = None
 
 
 DEFAULT_QUERY_LIMIT_ENV_VAR = "SPECSTAR_DEFAULT_QUERY_LIMIT"
@@ -204,7 +231,10 @@ class ResourceMetaSearchQuery(Struct, kw_only=True):
     offset: int = 0
     """Number of results to skip before starting to collect the result set."""
 
-    sorts: list[ResourceMetaSearchSort | ResourceDataSearchSort] | UnsetType = UNSET
+    sorts: (
+        list[ResourceMetaSearchSort | ResourceDataSearchSort | VectorDistanceSort]
+        | UnsetType
+    ) = UNSET
     """Sorting criteria for the search results."""
 
 

--- a/specstar/resource_manager/backfill.py
+++ b/specstar/resource_manager/backfill.py
@@ -1,0 +1,74 @@
+"""Batch backfill helpers for Vector / Embedding fields."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from msgspec import UNSET
+
+from specstar.query_types import ResourceMetaSearchQuery
+from specstar.types import IResourceManager, extract_vector_field_infos
+
+
+@dataclass(slots=True)
+class BackfillSummary:
+    """Result of a backfill run."""
+
+    encoded: int = 0
+    skipped: int = 0
+
+
+def backfill_vectors(
+    rm: IResourceManager,
+    *,
+    field_name: str,
+) -> BackfillSummary:
+    """Re-encode ``field_name`` for every resource where the stored vector
+    is missing or stale relative to the field's configured encoder.
+
+    Only supports Embedding fields (the source ``content`` is needed to
+    re-encode).
+    """
+    summary = BackfillSummary()
+    infos = {
+        i.name: i
+        for i in extract_vector_field_infos(rm.resource_type)
+        if i.is_embedding
+    }
+    info = infos.get(field_name)
+    if info is None:
+        raise ValueError(
+            f"Field {field_name!r} is not an Embedding-typed Vector field "
+            f"on {rm.resource_type.__name__}"
+        )
+    current_encoder_id = info.marker.encoder
+
+    for meta in rm.search_resources(ResourceMetaSearchQuery()):
+        try:
+            data = rm.get(meta.resource_id).data
+        except Exception:
+            summary.skipped += 1
+            continue
+        emb = getattr(data, field_name, None)
+        if emb is None:
+            summary.skipped += 1
+            continue
+        needs_encode = (
+            emb.vector is UNSET
+            or (
+                current_encoder_id is not None
+                and emb.encoder_id != current_encoder_id
+            )
+        )
+        if not needs_encode:
+            summary.skipped += 1
+            continue
+        # Reset vector so the processor re-encodes on update
+        import msgspec
+
+        fresh_emb = msgspec.structs.replace(emb, vector=UNSET)
+        fresh_data = msgspec.structs.replace(data, **{field_name: fresh_emb})
+        rm.update(meta.resource_id, fresh_data)
+        summary.encoded += 1
+    return summary

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -20,6 +20,8 @@ from specstar.query_types import (
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
     ResourceMetaSortDirection,
+    VectorDistanceCondition,
+    VectorDistanceSort,
 )
 from specstar.query_types import ResourceMetaSortKey as ResourceMetaSortKey
 from specstar.types import (
@@ -154,6 +156,10 @@ def is_match_query(meta: ResourceMeta, query: ResourceMetaSearchQuery) -> bool:
 
     if query.conditions is not UNSET:
         for condition in query.conditions:
+            if isinstance(condition, VectorDistanceCondition):
+                if not _match_vector_condition(meta, condition):
+                    return False
+                continue
             if not _match_condition(meta, condition):
                 return False
 
@@ -177,6 +183,35 @@ def _match_condition(
     return result is True
 
 
+def _match_vector_condition(
+    meta: ResourceMeta,
+    condition: VectorDistanceCondition,
+) -> bool:
+    """Brute-force evaluation of a VectorDistanceCondition against indexed_data."""
+    from specstar.util.vector_distance import distance
+
+    if meta.indexed_data is UNSET:
+        return False
+    vec = meta.indexed_data.get(condition.field_path)
+    if not isinstance(vec, list):
+        return False
+    if not isinstance(condition.query_vector, list):
+        # str query_vector must have been resolved to a vector before reaching here
+        return False
+    metric = condition.distance or "cosine"
+    d = distance(vec, condition.query_vector, metric)
+    op = condition.operator
+    if op == DataSearchOperator.less_than:
+        return d < condition.threshold
+    if op == DataSearchOperator.less_than_or_equal:
+        return d <= condition.threshold
+    if op == DataSearchOperator.greater_than:
+        return d > condition.threshold
+    if op == DataSearchOperator.greater_than_or_equal:
+        return d >= condition.threshold
+    return False
+
+
 def _match_data_condition(
     indexed_data: dict[str, Any],
     condition: DataSearchCondition | DataSearchGroup,
@@ -188,12 +223,28 @@ def _match_data_condition(
 
 def _evaluate_trivalent(
     data: dict[str, Any] | ResourceMeta,
-    condition: DataSearchCondition | DataSearchGroup,
+    condition: DataSearchCondition | DataSearchGroup | VectorDistanceCondition,
 ) -> bool | None:
     """
     Evaluate condition using SQL-like trivalent logic (True, False, Unknown/None).
     Unknown is returned for operations on missing keys or NULL values (except is_null/exists/isna).
     """
+    if isinstance(condition, VectorDistanceCondition):
+        # Vector conditions only make sense against full ResourceMeta (with
+        # indexed_data); when nested inside a data-condition group we
+        # synthesize a ResourceMeta-like wrapper.
+        if isinstance(data, ResourceMeta):
+            return _match_vector_condition(data, condition)
+        if isinstance(data, dict):
+            # Treat as indexed_data dict
+            class _Wrap:
+                pass
+
+            wrapper = _Wrap()
+            wrapper.indexed_data = data  # type: ignore[attr-defined]
+            return _match_vector_condition(wrapper, condition)  # type: ignore[arg-type]
+        return None
+
     if isinstance(condition, DataSearchGroup):
         results = [
             _evaluate_trivalent(data, sub_cond) for sub_cond in condition.conditions
@@ -389,6 +440,32 @@ def get_sort_fn(qsorts: list[ResourceMetaSearchSort | ResourceDataSearchSort]):
             if isinstance(sort, ResourceMetaSearchSort):
                 v1 = getattr(meta1, sort.key.value)
                 v2 = getattr(meta2, sort.key.value)
+            elif isinstance(sort, VectorDistanceSort):
+                from specstar.util.vector_distance import distance
+
+                metric = sort.distance or "cosine"
+                if not isinstance(sort.query_vector, list):
+                    return 0  # unresolved str query_vector — punt
+                v1_raw = (
+                    meta1.indexed_data.get(sort.field_path)
+                    if meta1.indexed_data is not UNSET
+                    else None
+                )
+                v2_raw = (
+                    meta2.indexed_data.get(sort.field_path)
+                    if meta2.indexed_data is not UNSET
+                    else None
+                )
+                v1 = (
+                    distance(v1_raw, sort.query_vector, metric)
+                    if isinstance(v1_raw, list)
+                    else UNSET
+                )
+                v2 = (
+                    distance(v2_raw, sort.query_vector, metric)
+                    if isinstance(v2_raw, list)
+                    else UNSET
+                )
             else:
                 v1 = (
                     meta1.indexed_data.get(sort.field_path)
@@ -548,6 +625,15 @@ class IMetaStore(MutableMapping[str, ResourceMeta]):
         """
         for m in metas:
             self[m.resource_id] = m
+
+    @property
+    def supports_native_vector_search(self) -> bool:
+        """Whether this meta store can run vector searches natively (vs brute-force).
+
+        Default is ``False``: subclasses that have native vector indexing
+        (e.g. PostgresMetaStore with pgvector) override to return ``True``.
+        """
+        return False
 
 
 class IFastMetaStore(IMetaStore):

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -199,7 +199,8 @@ class IndexedValueExtractor:
 
             if value is not UNSET:
                 # 將 Enum 轉換為其值（但保留其他類型如 datetime）
-                indexed_data[field.field_path] = self._convert_enum_to_value(value)
+                key = field.index_key or field.field_path
+                indexed_data[key] = self._convert_enum_to_value(value)
 
         return indexed_data
 
@@ -815,6 +816,8 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         pydantic_type: type | None = None,
         constraint_checkers: "Sequence[IConstraintChecker | Callable[[ResourceManager], IConstraintChecker]] | None" = None,
         strict_operation_context: bool = False,
+        encoder_registry: "Any | None" = None,
+        vector_encoders: "dict[str, str | Callable] | None" = None,
     ):
         """Initialize a ResourceManager.
 
@@ -926,6 +929,18 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             self.event_handlers.append(self._constraint_handler)
 
         self._binary_processor = BinaryProcessor(resource_type)
+
+        # ── Vector / Embedding ────────────────────────────────────────────
+        from specstar.resource_manager.embedding_processor import EmbeddingProcessor
+        from specstar.resource_manager.encoder_registry import EncoderRegistry
+
+        self._encoder_registry = encoder_registry or EncoderRegistry()
+        self._vector_encoders = vector_encoders or {}
+        self._embedding_processor = EmbeddingProcessor(
+            resource_type,
+            self._encoder_registry,
+            model_overrides=self._vector_encoders,
+        )
 
         # Set up validator
         self._validator = build_validator(validator)
@@ -1715,7 +1730,97 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         """
         if isinstance(query, Query):
             query = query.build()
+        query = self._resolve_str_query_vectors(query)
         return self.storage.count(query)
+
+    def _resolve_str_query_vectors(
+        self, query: ResourceMetaSearchQuery
+    ) -> ResourceMetaSearchQuery:
+        """Convert any ``str`` ``query_vector`` in conditions/sorts to a
+        ``list[float]`` by invoking the field's registered encoder.
+
+        Sync only: raises if a required encoder is async.
+        """
+        import inspect
+
+        import msgspec
+
+        from specstar.query_types import (
+            DataSearchGroup as _DSG,
+            VectorDistanceCondition as _VC,
+            VectorDistanceSort as _VS,
+        )
+        from specstar.resource_manager.encoder_registry import lookup_encoder
+        from specstar.types import extract_vector_field_infos
+
+        # Build per-field encoder cache once
+        infos = {i.name: i for i in extract_vector_field_infos(self._resource_type)}
+
+        # Embedding fields' field_path in query is the parent name (e.g. "summary"),
+        # which corresponds to info.name; raw vector fields map directly too.
+
+        def _encode(field_path: str, text: str) -> list[float]:
+            top = field_path.split(".")[0]
+            info = infos.get(top)
+            if info is None:
+                raise ValueError(
+                    f"Vector field {field_path!r} not registered on "
+                    f"{self._resource_type.__name__}; cannot encode str query_vector."
+                )
+            encoder = lookup_encoder(
+                self._encoder_registry,
+                field_info=info,
+                model_overrides=self._vector_encoders,
+            )
+            if encoder is None:
+                raise ValueError(
+                    f"No encoder configured for field {field_path!r}; "
+                    f"cannot encode str query_vector."
+                )
+            vec = encoder(text)
+            if inspect.isawaitable(vec):
+                # Close the unawaited coroutine to avoid a RuntimeWarning
+                try:
+                    vec.close()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+                raise RuntimeError(
+                    f"Encoder for field {field_path!r} is async but search was "
+                    f"invoked synchronously. Register a sync encoder or use the "
+                    f"async query path."
+                )
+            return vec
+
+        def _maybe_resolve_cond(c):
+            if isinstance(c, _VC) and isinstance(c.query_vector, str):
+                return msgspec.structs.replace(
+                    c, query_vector=_encode(c.field_path, c.query_vector)
+                )
+            if isinstance(c, _DSG):
+                new_sub = [_maybe_resolve_cond(sub) for sub in c.conditions]
+                if any(a is not b for a, b in zip(new_sub, c.conditions)):
+                    return msgspec.structs.replace(c, conditions=new_sub)
+            return c
+
+        def _maybe_resolve_sort(s):
+            if isinstance(s, _VS) and isinstance(s.query_vector, str):
+                return msgspec.structs.replace(
+                    s, query_vector=_encode(s.field_path, s.query_vector)
+                )
+            return s
+
+        changes: dict = {}
+        if query.conditions is not UNSET:
+            new_conds = [_maybe_resolve_cond(c) for c in query.conditions]
+            if any(a is not b for a, b in zip(new_conds, query.conditions)):
+                changes["conditions"] = new_conds
+        if query.sorts is not UNSET:
+            new_sorts = [_maybe_resolve_sort(s) for s in query.sorts]
+            if any(a is not b for a, b in zip(new_sorts, query.sorts)):
+                changes["sorts"] = new_sorts
+        if not changes:
+            return query
+        return msgspec.structs.replace(query, **changes)
 
     @execute_with_events(
         (
@@ -1740,6 +1845,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         """
         if isinstance(query, Query):
             query = query.build()
+        query = self._resolve_str_query_vectors(query)
         return self.storage.search(query)
 
     def _default_worker_num(self, nr_work: int) -> int:
@@ -1889,6 +1995,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         """
         status = self.default_status if status is UNSET else status
         data = self._process_binary_fields(data)
+        data = self._embedding_processor.process_sync(data)
         info = self._rev_info(_BuildRevInfoCreate(data, status))
         self.storage.save_revision(info, io.BytesIO(self.encode(data)))
         self.storage.save_meta(self._res_meta(_BuildResMetaCreate(info, data)))
@@ -2082,6 +2189,16 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             resource_id,
             prev_res_meta.current_revision_id,
         )
+        # Pass previous data for Embedding cache reuse (bypass events: raw decode)
+        prev_data = None
+        try:
+            with self.storage.get_data_bytes(
+                resource_id, prev_res_meta.current_revision_id
+            ) as fh:
+                prev_data = self._data_serializer.decode(fh.read())
+        except Exception:
+            pass
+        data = self._embedding_processor.process_sync(data, previous=prev_data)
         rev_info = self._rev_info(_BuildRevInfoUpdate(prev_res_meta, data, status))
         if prev_info.data_hash == rev_info.data_hash:
             return prev_info
@@ -2169,6 +2286,15 @@ class ResourceManager(IResourceManager[T], Generic[T]):
 
         if data is not UNSET:
             data = self._process_binary_fields(data)
+            prev_data = None
+            try:
+                with self.storage.get_data_bytes(
+                    resource_id, prev_res_meta.current_revision_id
+                ) as fh:
+                    prev_data = self._data_serializer.decode(fh.read())
+            except Exception:
+                pass
+            data = self._embedding_processor.process_sync(data, previous=prev_data)
 
         rev_info = self._rev_info(
             _BuildRevInfoModify(prev_res_meta, prev_info, data, status=status)

--- a/specstar/resource_manager/embedding_processor.py
+++ b/specstar/resource_manager/embedding_processor.py
@@ -1,0 +1,129 @@
+"""Write-time pipeline for Embedding fields.
+
+Traverses a resource struct, identifies ``Embedding``-typed fields, and
+fills ``vector`` / ``content_hash`` / ``encoder_id`` by calling the
+registered encoder.  Supports cache reuse when a previous revision is
+supplied and ``(content_hash, encoder_id)`` match.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import msgspec
+import xxhash
+from msgspec import UNSET
+
+from specstar.resource_manager.encoder_registry import (
+    EncoderRegistry,
+    lookup_encoder,
+)
+from specstar.types import Embedding, extract_vector_field_infos
+
+
+def _content_hash(content: str) -> str:
+    return xxhash.xxh3_128_hexdigest(content)
+
+
+class EmbeddingProcessor:
+    """Auto-encodes Embedding fields on write."""
+
+    def __init__(
+        self,
+        struct_type: type,
+        registry: EncoderRegistry,
+        *,
+        model_overrides: dict | None = None,
+    ) -> None:
+        self._infos = [
+            info for info in extract_vector_field_infos(struct_type) if info.is_embedding
+        ]
+        self._registry = registry
+        self._model_overrides = model_overrides or {}
+
+    def process_sync(self, data: Any, *, previous: Any | None = None) -> Any:
+        """Synchronous variant — raises if any required encoder is async."""
+        for info in self._infos:
+            emb = getattr(data, info.name, None)
+            if emb is None:
+                continue
+            if emb.vector is not UNSET:
+                continue
+            encoder = lookup_encoder(self._registry, field_info=info, model_overrides=self._model_overrides)
+            if encoder is None:
+                continue
+            new_hash = _content_hash(emb.content)
+            encoder_id = info.marker.encoder
+            if previous is not None:
+                prev_emb = getattr(previous, info.name, None)
+                if (
+                    prev_emb is not None
+                    and prev_emb.content_hash == new_hash
+                    and prev_emb.encoder_id == encoder_id
+                    and prev_emb.vector is not UNSET
+                ):
+                    new_emb = msgspec.structs.replace(
+                        emb,
+                        vector=prev_emb.vector,
+                        content_hash=new_hash,
+                        encoder_id=encoder_id,
+                    )
+                    data = msgspec.structs.replace(data, **{info.name: new_emb})
+                    continue
+            vec = encoder(emb.content)
+            if inspect.isawaitable(vec):
+                raise RuntimeError(
+                    f"Encoder for field {info.name!r} is async but write was "
+                    f"invoked synchronously. Use the async write path or "
+                    f"register a sync encoder."
+                )
+            new_emb = msgspec.structs.replace(
+                emb,
+                vector=vec,
+                content_hash=new_hash,
+                encoder_id=encoder_id,
+            )
+            data = msgspec.structs.replace(data, **{info.name: new_emb})
+        return data
+
+    async def process(self, data: Any, *, previous: Any | None = None) -> Any:
+        for info in self._infos:
+            emb = getattr(data, info.name, None)
+            if emb is None:
+                continue
+            if emb.vector is not UNSET:
+                continue
+            encoder = lookup_encoder(self._registry, field_info=info, model_overrides=self._model_overrides)
+            if encoder is None:
+                continue
+            new_hash = _content_hash(emb.content)
+            encoder_id = info.marker.encoder
+            # Cache reuse: previous revision had the same content + encoder
+            if previous is not None:
+                prev_emb = getattr(previous, info.name, None)
+                if (
+                    prev_emb is not None
+                    and prev_emb.content_hash == new_hash
+                    and prev_emb.encoder_id == encoder_id
+                    and prev_emb.vector is not UNSET
+                ):
+                    new_emb = msgspec.structs.replace(
+                        emb,
+                        vector=prev_emb.vector,
+                        content_hash=new_hash,
+                        encoder_id=encoder_id,
+                    )
+                    data = msgspec.structs.replace(data, **{info.name: new_emb})
+                    continue
+            vec = encoder(emb.content)
+            if inspect.isawaitable(vec):
+                vec = await vec
+            new_emb = msgspec.structs.replace(
+                emb,
+                vector=vec,
+                content_hash=new_hash,
+                encoder_id=encoder_id,
+            )
+            data = msgspec.structs.replace(data, **{info.name: new_emb})
+        return data

--- a/specstar/resource_manager/encoder_registry.py
+++ b/specstar/resource_manager/encoder_registry.py
@@ -1,0 +1,56 @@
+"""Encoder registry for Vector / Embedding fields.
+
+Encoders convert ``str`` to ``list[float]`` (sync or async).  They are
+registered by name and resolved at write/query time via the override
+hierarchy: ``Vector(encoder=...)`` > ``add_model(vector_encoders=...)``
+> ``spec.configure(vector_encoders=...)``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from specstar.types import VectorFieldInfo
+
+
+class EncoderRegistry:
+    """Maps encoder names to callables."""
+
+    def __init__(self) -> None:
+        self._encoders: dict[str, Callable] = {}
+
+    def register(self, name: str, fn: Callable) -> None:
+        self._encoders[name] = fn
+
+    def resolve(self, name: str) -> Callable:
+        return self._encoders[name]
+
+
+def lookup_encoder(
+    registry: "EncoderRegistry",
+    *,
+    field_info: "VectorFieldInfo",
+    model_overrides: "dict[str, str | Callable] | None" = None,
+) -> Callable | None:
+    """Resolve the encoder for a Vector-annotated field.
+
+    Override hierarchy (inner overrides outer): annotation > model > global.
+    Returns ``None`` if no encoder is configured anywhere.
+    """
+    # Field-level (annotation) wins
+    if field_info.marker.encoder is not None:
+        try:
+            return registry.resolve(field_info.marker.encoder)
+        except KeyError:
+            return None
+    # Model-level fallback
+    if model_overrides and field_info.name in model_overrides:
+        ref = model_overrides[field_info.name]
+        if callable(ref):
+            return ref
+        try:
+            return registry.resolve(ref)
+        except KeyError:
+            return None
+    return None

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -15,6 +15,8 @@ from specstar.query_types import (
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
     ResourceMetaSortDirection,
+    VectorDistanceCondition,
+    VectorDistanceSort,
 )
 from specstar.resource_manager.basic import (
     Encoding,
@@ -48,15 +50,178 @@ class PostgresMetaStore(ISlowMetaStore):
         )
 
         # 建立連線池
+        self._pg_dsn = pg_dsn
         self._conn_pool = psycopg2.pool.SimpleConnectionPool(
             minconn=1,
             maxconn=10,
             dsn=pg_dsn,
         )
         self.table_name = table_name
+        # field_path → (indexed_dim, distance) for pgvector columns
+        self._vec_columns: dict[str, tuple[int, str]] = {}
 
         # 初始化 PostgreSQL 表
         self._init_postgres_table()
+        self._has_pgvector = self._detect_pgvector()
+
+    def _detect_pgvector(self) -> bool:
+        # Use a dedicated raw connection to avoid touching the pool — pool
+        # mock-based tests rely on a fixed iteration count.
+        try:
+            conn = psycopg2.connect(self._pg_dsn)
+        except BaseException:
+            return False
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_extension WHERE extname = 'vector' LIMIT 1"
+                )
+                return cur.fetchone() is not None
+        except BaseException:
+            return False
+        finally:
+            try:
+                conn.close()
+            except BaseException:
+                pass
+
+    @property
+    def supports_native_vector_search(self) -> bool:
+        return self._has_pgvector
+
+    # ------------------------------------------------------------------
+    # Vector / pgvector DDL helpers
+    # ------------------------------------------------------------------
+
+    # pgvector HNSW upper bound for indexable dim.
+    HNSW_MAX_DIM = 2000
+
+    _DISTANCE_OPS = {
+        "cosine": ("vector_cosine_ops", "<=>"),
+        "l2": ("vector_l2_ops", "<->"),
+        "ip": ("vector_ip_ops", "<#>"),
+    }
+
+    def _vec_col_name(self, field_path: str) -> str:
+        # JSON paths use ".", which is invalid in column identifiers
+        return "vec_" + field_path.replace(".", "_")
+
+    def ensure_vector_column(
+        self,
+        field_path: str,
+        *,
+        dim: int,
+        distance: str = "cosine",
+    ) -> None:
+        """Create a pgvector column + HNSW index for *field_path*.
+
+        Idempotent: skips when the column / index already exists.  When
+        ``dim`` exceeds :pyattr:`HNSW_MAX_DIM`, only the first
+        ``HNSW_MAX_DIM`` dimensions are indexed (Matryoshka prefix
+        strategy).
+        """
+        if not self._has_pgvector:
+            raise RuntimeError(
+                "PostgresMetaStore: pgvector extension is required for "
+                "vector fields. Run `CREATE EXTENSION vector;` as superuser."
+            )
+
+        ops_class, _op = self._DISTANCE_OPS.get(distance, self._DISTANCE_OPS["cosine"])
+        col = self._vec_col_name(field_path)
+        indexed_dim = min(dim, self.HNSW_MAX_DIM)
+        idx_name = f"idx_{self.table_name}_{col}_hnsw"
+
+        # ALTER TABLE / CREATE INDEX CONCURRENTLY cannot run inside a
+        # transaction.  Pool connections are managed with autocommit=False,
+        # so open a dedicated raw connection for DDL and close it after.
+        conn = psycopg2.connect(self._pg_dsn)
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'ALTER TABLE "{self.table_name}" '
+                    f'ADD COLUMN IF NOT EXISTS "{col}" vector({indexed_dim})'
+                )
+                cur.execute(
+                    f'CREATE INDEX IF NOT EXISTS "{idx_name}" '
+                    f'ON "{self.table_name}" '
+                    f'USING hnsw ("{col}" {ops_class})'
+                )
+        finally:
+            conn.close()
+
+        self._vec_columns[field_path] = (indexed_dim, distance)
+
+    def _build_vector_condition(
+        self, condition: "VectorDistanceCondition"
+    ) -> tuple[str, list]:
+        if condition.field_path not in self._vec_columns:
+            return "", []
+        if not isinstance(condition.query_vector, list):
+            return "", []  # str query_vector must be resolved upstream
+        indexed_dim, default_distance = self._vec_columns[condition.field_path]
+        metric = condition.distance or default_distance or "cosine"
+        _ops, op_symbol = self._DISTANCE_OPS[metric]
+        col = self._vec_col_name(condition.field_path)
+        clipped = condition.query_vector[:indexed_dim]
+        vec_literal = self._format_vec_literal(clipped)
+        op_map = {
+            DataSearchOperator.less_than: "<",
+            DataSearchOperator.less_than_or_equal: "<=",
+            DataSearchOperator.greater_than: ">",
+            DataSearchOperator.greater_than_or_equal: ">=",
+        }
+        sql_op = op_map.get(condition.operator)
+        if sql_op is None:
+            return "", []
+        return (
+            f'"{col}" {op_symbol} %s::vector {sql_op} %s',
+            [vec_literal, float(condition.threshold)],
+        )
+
+    def _build_vector_order(
+        self, sort: "VectorDistanceSort"
+    ) -> tuple[str, list]:
+        if sort.field_path not in self._vec_columns:
+            return "", []
+        if not isinstance(sort.query_vector, list):
+            return "", []
+        indexed_dim, default_distance = self._vec_columns[sort.field_path]
+        metric = sort.distance or default_distance or "cosine"
+        _ops, op_symbol = self._DISTANCE_OPS[metric]
+        col = self._vec_col_name(sort.field_path)
+        clipped = sort.query_vector[:indexed_dim]
+        vec_literal = self._format_vec_literal(clipped)
+        direction = (
+            "ASC" if sort.direction == ResourceMetaSortDirection.ascending else "DESC"
+        )
+        return f'"{col}" {op_symbol} %s::vector {direction}', [vec_literal]
+
+    @staticmethod
+    def _format_vec_literal(vec: list[float]) -> str:
+        """pgvector accepts vector input as the string '[v1,v2,...]'."""
+        return "[" + ",".join(str(float(v)) for v in vec) + "]"
+
+    def _extract_vec_value(
+        self, meta: ResourceMeta, field_path: str, indexed_dim: int
+    ) -> str | None:
+        """Pull the vector value out of meta.indexed_data and clip to indexed_dim."""
+        if meta.indexed_data is UNSET or meta.indexed_data is None:
+            return None
+        # Support dotted paths like "summary.vector"
+        cur: object = meta.indexed_data
+        for part in field_path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                return None
+        if not isinstance(cur, list):
+            return None
+        clipped = cur[:indexed_dim]
+        if len(clipped) != indexed_dim:
+            return None  # under-dim vector — leave NULL
+        return self._format_vec_literal(clipped)
 
     def __del__(self):
         # 物件被回收時自動清理
@@ -278,7 +443,7 @@ class PostgresMetaStore(ISlowMetaStore):
         """Pack a ResourceMeta into the column-order tuple used by INSERT/UPSERT."""
         import json
 
-        return (
+        base = (
             meta.resource_id,
             self._serializer.encode(meta),
             meta.created_time,
@@ -298,29 +463,33 @@ class PostgresMetaStore(ISlowMetaStore):
             meta.rev_created_time if meta.rev_created_time is not UNSET else None,
             meta.rev_updated_time if meta.rev_updated_time is not UNSET else None,
         )
+        # Append registered vec column values in deterministic order
+        for field_path, (indexed_dim, _) in self._vec_columns.items():
+            base = base + (self._extract_vec_value(meta, field_path, indexed_dim),)
+        return base
 
     def _upsert_sql(self) -> str:
-        return f"""
-        INSERT INTO "{self.table_name}"
-        (resource_id, data, created_time, updated_time, created_by, updated_by,
-         is_deleted, schema_version, indexed_data,
-         rev_status, rev_created_by, rev_updated_by, rev_created_time, rev_updated_time)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT (resource_id) DO UPDATE SET
-            data = EXCLUDED.data,
-            created_time = EXCLUDED.created_time,
-            updated_time = EXCLUDED.updated_time,
-            created_by = EXCLUDED.created_by,
-            updated_by = EXCLUDED.updated_by,
-            is_deleted = EXCLUDED.is_deleted,
-            schema_version = EXCLUDED.schema_version,
-            indexed_data = EXCLUDED.indexed_data,
-            rev_status = EXCLUDED.rev_status,
-            rev_created_by = EXCLUDED.rev_created_by,
-            rev_updated_by = EXCLUDED.rev_updated_by,
-            rev_created_time = EXCLUDED.rev_created_time,
-            rev_updated_time = EXCLUDED.rev_updated_time
-        """
+        vec_cols = [self._vec_col_name(fp) for fp in self._vec_columns]
+        base_cols = [
+            "resource_id", "data", "created_time", "updated_time",
+            "created_by", "updated_by", "is_deleted", "schema_version",
+            "indexed_data", "rev_status", "rev_created_by", "rev_updated_by",
+            "rev_created_time", "rev_updated_time",
+        ]
+        all_cols = base_cols + vec_cols
+        col_list = ", ".join(f'"{c}"' for c in all_cols)
+        # vec values are passed as strings; cast to vector
+        placeholders = ", ".join(
+            ["%s"] * len(base_cols) + ["%s::vector"] * len(vec_cols)
+        )
+        update_clause = ", ".join(
+            f'"{c}" = EXCLUDED."{c}"' for c in all_cols if c != "resource_id"
+        )
+        return (
+            f'INSERT INTO "{self.table_name}" ({col_list}) '
+            f'VALUES ({placeholders}) '
+            f'ON CONFLICT (resource_id) DO UPDATE SET {update_clause}'
+        )
 
     def save_many(self, metas: Iterable[ResourceMeta]) -> None:
         """批量保存元数据到 PostgreSQL（ISlowMetaStore 接口方法）"""
@@ -458,6 +627,12 @@ class PostgresMetaStore(ISlowMetaStore):
         # 處理 conditions - 在 PostgreSQL 層面過濾
         if query.conditions is not UNSET:
             for condition in query.conditions:
+                if isinstance(condition, VectorDistanceCondition):
+                    sql_cond, vec_params = self._build_vector_condition(condition)
+                    if sql_cond:
+                        conditions.append(sql_cond)
+                        params.extend(vec_params)
+                    continue
                 json_condition, json_params = self._build_condition(condition)
                 if json_condition:
                     conditions.append(json_condition)
@@ -470,9 +645,16 @@ class PostgresMetaStore(ISlowMetaStore):
 
         # 构建排序子句
         order_clause = ""
+        order_params: list = []
         if query.sorts is not UNSET and query.sorts:
             order_parts = []
             for sort in query.sorts:
+                if isinstance(sort, VectorDistanceSort):
+                    sql_part, sort_params = self._build_vector_order(sort)
+                    if sql_part:
+                        order_parts.append(sql_part)
+                        order_params.extend(sort_params)
+                    continue
                 if isinstance(sort, ResourceMetaSearchSort):
                     direction = (
                         "ASC"
@@ -487,12 +669,10 @@ class PostgresMetaStore(ISlowMetaStore):
                         if sort.direction == ResourceMetaSortDirection.ascending
                         else "DESC"
                     )
-                    # 使用 JSONB 提取語法對 indexed_data 中的欄位進行排序
-                    # PostgreSQL 可以根據 JSON 值的類型自動選擇排序方式
-                    # 使用 -> 操作符保持原始類型，讓 PostgreSQL 自動處理不同數據類型的排序
                     jsonb_extract = f"indexed_data->'{sort.field_path}'"
                     order_parts.append(f"{jsonb_extract} {direction}")
             order_clause = "ORDER BY " + ", ".join(order_parts)
+        params.extend(order_params)
 
         sql = f'SELECT data FROM "{self.table_name}" {where_clause} {order_clause} LIMIT %s OFFSET %s'
         params.append(query.limit)

--- a/specstar/resource_manager/vector_validator.py
+++ b/specstar/resource_manager/vector_validator.py
@@ -1,0 +1,49 @@
+"""Write-time dimension validation for Vector / Embedding fields."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from msgspec import UNSET
+
+from specstar.types import IValidator, ValidationError, extract_vector_field_infos
+
+
+class CompositeValidator(IValidator):
+    """Chain multiple validators; runs each in order, stops on first raise."""
+
+    def __init__(self, validators: list[IValidator | Callable]) -> None:
+        self._validators = validators
+
+    def validate(self, data: Any) -> None:
+        for v in self._validators:
+            if isinstance(v, IValidator):
+                v.validate(data)
+            else:
+                v(data)
+
+
+class VectorDimValidator(IValidator):
+    """Validate that vector-typed fields match their annotated dim."""
+
+    def __init__(self, struct_type: type) -> None:
+        self._infos = extract_vector_field_infos(struct_type)
+
+    def validate(self, data: Any) -> None:
+        for info in self._infos:
+            value = getattr(data, info.name, None)
+            if value is None and info.nullable:
+                continue
+            if info.is_embedding:
+                vector = getattr(value, "vector", UNSET)
+                if vector is UNSET:
+                    # processor will fill in
+                    continue
+                actual_len = len(vector)
+            else:
+                actual_len = len(value)
+            if actual_len != info.marker.dim:
+                raise ValidationError(
+                    f"Vector field {info.name!r}: expected dim={info.marker.dim}, "
+                    f"got {actual_len}"
+                )

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -345,6 +345,166 @@ class Unique:
         return "Unique()"
 
 
+# ---------------------------------------------------------------------------
+# Vector / Embedding
+# ---------------------------------------------------------------------------
+
+
+class Vector:
+    """Annotation marker for a vector-typed field.
+
+    Use with ``Annotated`` to declare a field that stores a numeric vector
+    (``list[float]``) or an :class:`Embedding` instance.  Carries the
+    indexing and encoding configuration for the field.
+
+    Args:
+        dim: The dimensionality of the stored vector.
+        distance: Distance metric to use for similarity comparisons.  When
+            ``None`` (default), the framework falls back to the query-time
+            metric and finally to ``"cosine"``.
+        encoder: Name of a registered encoder.  Used when querying with a
+            ``str`` and (for :class:`Embedding` fields) to auto-compute the
+            vector at write time.  Resolution: field-level overrides
+            model-level overrides global registration.
+
+    Example::
+
+        class Doc(Struct):
+            embedding: Annotated[list[float], Vector(dim=1536, distance="cosine")]
+    """
+
+    __slots__ = ("dim", "distance", "encoder")
+
+    def __init__(
+        self,
+        dim: int,
+        *,
+        distance: "Literal['cosine', 'l2', 'ip'] | None" = None,
+        encoder: str | None = None,
+    ) -> None:
+        if dim <= 0:
+            raise ValueError(f"Vector dim must be positive, got {dim}")
+        if distance is not None and distance not in ("cosine", "l2", "ip"):
+            raise ValueError(
+                f"Vector distance must be one of 'cosine', 'l2', 'ip' or None, "
+                f"got {distance!r}"
+            )
+        self.dim = dim
+        self.distance = distance
+        self.encoder = encoder
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Vector):
+            return NotImplemented
+        return (
+            self.dim == other.dim
+            and self.distance == other.distance
+            and self.encoder == other.encoder
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.dim, self.distance, self.encoder))
+
+
+class Embedding(Struct, kw_only=True):
+    """A piece of content paired with its vector embedding.
+
+    Analogous to :class:`Binary` for file blobs.  At write time, when only
+    ``content`` is supplied, the framework computes ``vector`` via the
+    field's registered encoder and fills ``content_hash`` (xxh3_128 of
+    content) and ``encoder_id`` so that subsequent writes with unchanged
+    content+encoder can skip the encoder call.
+    """
+
+    content: str
+    vector: list[float] | UnsetType = UNSET
+    content_hash: str | UnsetType = UNSET
+    encoder_id: str | UnsetType = UNSET
+
+
+class VectorFieldInfo(Struct, frozen=True, kw_only=True):
+    """Per-field info about a Vector-annotated field, returned by
+    :func:`extract_vector_field_infos`.
+    """
+
+    name: str
+    marker: Vector
+    is_embedding: bool
+    nullable: bool
+
+
+def extract_vector_field_infos(struct_type: type) -> "list[VectorFieldInfo]":
+    """Return rich info for every ``Vector``-annotated field in *struct_type*.
+
+    Returned list preserves definition order.  Each entry tells callers
+    whether the inner type is :class:`Embedding` (vs raw ``list[float]``)
+    and whether the field is nullable.
+    """
+    from specstar.util.type_utils import (
+        get_hints,
+        get_non_none_args,
+        is_annotated_type,
+        is_nullable_type,
+        unwrap_annotated,
+    )
+
+    out: list[VectorFieldInfo] = []
+    try:
+        hints = get_hints(struct_type)
+    except (TypeError, NameError):
+        return out
+    for field_name, hint in hints.items():
+        if not is_annotated_type(hint):
+            continue
+        inner, metadata = unwrap_annotated(hint)
+        marker: Vector | None = None
+        for meta in metadata:
+            if isinstance(meta, Vector):
+                marker = meta
+                break
+        if marker is None:
+            continue
+        nullable = is_nullable_type(inner)
+        # peel Optional/Union to find the value type
+        value_type = inner
+        if nullable:
+            non_none = get_non_none_args(inner)
+            if non_none:
+                value_type = non_none[0]
+        is_embedding = isinstance(value_type, type) and issubclass(
+            value_type, Embedding
+        )
+        out.append(
+            VectorFieldInfo(
+                name=field_name,
+                marker=marker,
+                is_embedding=is_embedding,
+                nullable=nullable,
+            )
+        )
+    return out
+
+
+def extract_vectors(struct_type: type) -> "list[tuple[str, Vector]]":
+    """Return ``(field_name, Vector)`` pairs for Vector-annotated fields."""
+    from specstar.util.type_utils import (
+        get_hints,
+        is_annotated_type,
+        unwrap_annotated,
+    )
+
+    result: list[tuple[str, Vector]] = []
+    hints = get_hints(struct_type)
+    for field_name, hint in hints.items():
+        if is_annotated_type(hint):
+            _inner, metadata = unwrap_annotated(hint)
+            for meta in metadata:
+                if isinstance(meta, Vector):
+                    result.append((field_name, meta))
+                    break
+    return result
+
+
 def extract_unique_fields(struct_type: type) -> list[str]:
     """Return all field names annotated with :class:`Unique`.
 
@@ -1828,6 +1988,12 @@ class IndexableField(Struct):
     field_type: type | SpecialIndex | UnsetType = (
         UNSET  # The type of the field (str, int, float, bool, datetime)
     )
+    index_key: str | None = None
+    """Optional override for the key under which the extracted value is
+    stored in ``indexed_data``.  When ``None`` (default) the ``field_path``
+    is used.  Useful when you want to extract from a nested path
+    (e.g. ``summary.vector``) but expose the value under a short alias
+    (e.g. ``summary``) for query convenience."""
 
 
 class IConstraintChecker(ABC):

--- a/specstar/util/vector_distance.py
+++ b/specstar/util/vector_distance.py
@@ -1,0 +1,55 @@
+"""Distance metrics for brute-force vector search (memory / disk / sqlite)."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+DistanceMetric = Literal["cosine", "l2", "ip"]
+
+
+def cosine_distance(a: list[float], b: list[float]) -> float:
+    """Return ``1 - cos(a, b)`` — matches pgvector's ``<=>`` operator.
+
+    Range: [0, 2].  Zero vectors return ``1.0`` (max distance).
+    """
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 1.0
+    return 1.0 - dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def l2_distance(a: list[float], b: list[float]) -> float:
+    """Return Euclidean distance — matches pgvector's ``<->`` operator."""
+    s = 0.0
+    for x, y in zip(a, b):
+        d = x - y
+        s += d * d
+    return math.sqrt(s)
+
+
+def ip_distance(a: list[float], b: list[float]) -> float:
+    """Return ``-dot(a, b)`` — matches pgvector's ``<#>`` operator.
+
+    Negative inner product so that lower = more similar (consistent with
+    cosine / L2 semantics where smaller is closer).
+    """
+    return -sum(x * y for x, y in zip(a, b))
+
+
+def distance(
+    a: list[float], b: list[float], metric: DistanceMetric = "cosine"
+) -> float:
+    if metric == "cosine":
+        return cosine_distance(a, b)
+    if metric == "l2":
+        return l2_distance(a, b)
+    if metric == "ip":
+        return ip_distance(a, b)
+    raise ValueError(f"Unknown distance metric: {metric!r}")

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -1,0 +1,88 @@
+"""Tests for the ``specstar backfill-vectors`` CLI command."""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import sys
+from typing import Annotated
+
+import pytest
+from msgspec import UNSET, Struct
+
+from specstar import Embedding, SpecStar, Vector
+from specstar.cli._backfill import backfill_vectors_cmd
+
+
+def _stub_encoder(text: str) -> list[float]:
+    return [float(len(text)), float(ord(text[0]) if text else 0)]
+
+
+# Module-level for CLI loader to find by string reference
+class _Doc(Struct):
+    title: str
+    summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+
+def _make_spec_with_rows():
+    s = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    s.add_model(_Doc, name="doc")
+    mgr = s.get_resource_manager(_Doc)
+    mgr.create(_Doc(title="a", summary=Embedding(content="hello")))
+    mgr.create(_Doc(title="b", summary=Embedding(content="world")))
+    return s
+
+
+# Module-level binding for "spec_module:spec_attr" CLI argument
+_spec_for_cli = None
+
+
+def _build_cli_spec() -> SpecStar:
+    global _spec_for_cli
+    _spec_for_cli = _make_spec_with_rows()
+    # register encoder after creation so vectors are initially UNSET
+    _spec_for_cli.encoder_registry.register("stub", _stub_encoder)
+    return _spec_for_cli
+
+
+# BFLCLI1: CLI loads spec + runs backfill + prints summary
+def test_bfl_cli_runs_backfill_and_prints_summary(monkeypatch) -> None:
+    spec = _build_cli_spec()
+
+    # Stash the spec into a module reachable by 'module:attr'
+    import types
+
+    fake_mod = types.ModuleType("fake_app")
+    fake_mod.spec = spec  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fake_app", fake_mod)
+
+    # Confirm initial state: vectors UNSET
+    mgr = spec.get_resource_manager(_Doc)
+    metas = mgr.search_resources(__import__(
+        "specstar.query_types", fromlist=["ResourceMetaSearchQuery"]
+    ).ResourceMetaSearchQuery())
+    rids = [m.resource_id for m in metas]
+    for rid in rids:
+        assert mgr.get(rid).data.summary.vector is UNSET
+
+    import argparse
+
+    args = argparse.Namespace(
+        spec="fake_app:spec",
+        model="doc",
+        field="summary",
+    )
+    out = io.StringIO()
+    err = io.StringIO()
+    exit_code = backfill_vectors_cmd(args, stream=out, error_stream=err)
+    assert exit_code == 0
+    assert "encoded=2" in out.getvalue()
+
+    # Vectors now populated
+    for rid in rids:
+        assert mgr.get(rid).data.summary.vector == _stub_encoder(
+            mgr.get(rid).data.summary.content
+        )

--- a/tests/test_backfill_vectors.py
+++ b/tests/test_backfill_vectors.py
@@ -1,0 +1,51 @@
+"""Tests for backfill_vectors — batch re-encoding helper."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated
+
+from msgspec import UNSET, Struct
+
+from specstar import Embedding, SpecStar, Vector
+from specstar.resource_manager.backfill import backfill_vectors
+
+
+def _stub_encoder(text: str) -> list[float]:
+    return [float(len(text)), float(ord(text[0]) if text else 0)]
+
+
+# BFL1: backfill_vectors encodes rows that were created without an encoder
+def test_backfill_vectors_fills_missing() -> None:
+    class Doc(Struct):
+        title: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+    spec = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    # Note: encoder NOT registered yet — create() will leave vector UNSET
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    info_a = mgr.create(Doc(title="a", summary=Embedding(content="hello")))
+    info_b = mgr.create(Doc(title="b", summary=Embedding(content="world")))
+
+    # Vectors are UNSET because encoder wasn't registered
+    assert mgr.get(info_a.resource_id).data.summary.vector is UNSET
+    assert mgr.get(info_b.resource_id).data.summary.vector is UNSET
+
+    # Now register the encoder and run backfill
+    spec.encoder_registry.register("stub", _stub_encoder)
+
+    summary = backfill_vectors(mgr, field_name="summary")
+    assert summary.encoded == 2
+    assert summary.skipped == 0
+    assert mgr.get(info_a.resource_id).data.summary.vector == _stub_encoder("hello")
+    assert mgr.get(info_b.resource_id).data.summary.vector == _stub_encoder("world")
+
+    # Second backfill: nothing to do
+    summary = backfill_vectors(mgr, field_name="summary")
+    assert summary.encoded == 0
+    assert summary.skipped == 2

--- a/tests/test_brute_force_vector.py
+++ b/tests/test_brute_force_vector.py
@@ -1,0 +1,179 @@
+"""Brute-force vector search via MemoryMetaStore (no pgvector required)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from specstar.query_types import (
+    DataSearchCondition,
+    DataSearchOperator,
+    ResourceMetaSearchQuery,
+    VectorDistanceCondition,
+    VectorDistanceSort,
+)
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.types import ResourceMeta
+
+
+def _make_meta(rid: str, *, vector: list[float], doctype: str = "abc") -> ResourceMeta:
+    now = dt.datetime(2026, 5, 22, tzinfo=dt.timezone.utc)
+    return ResourceMeta(
+        resource_id=rid,
+        current_revision_id=f"{rid}-rev",
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by="tester",
+        updated_by="tester",
+        is_deleted=False,
+        indexed_data={"embedding": vector, "doctype": doctype},
+    )
+
+
+# BF1: tracer — filter by cosine distance, get rows whose vector is near query
+def test_bf_cosine_filter_returns_near_rows() -> None:
+    store = MemoryMetaStore()
+    # Vectors aligned with x axis vs orthogonal
+    store["a"] = _make_meta("a", vector=[1.0, 0.0])  # cosine dist to [1,0] = 0
+    store["b"] = _make_meta("b", vector=[0.0, 1.0])  # cosine dist to [1,0] = 1
+    store["c"] = _make_meta("c", vector=[0.9, 0.1])  # cosine dist small
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert "a" in ids
+    assert "c" in ids
+    assert "b" not in ids  # b is too far (cosine dist ~= 1)
+
+
+# BF2: sort by cosine ascending — nearest rows first
+def test_bf_cosine_sort_ascending() -> None:
+    store = MemoryMetaStore()
+    store["a"] = _make_meta("a", vector=[0.9, 0.1])  # close to [1,0]
+    store["b"] = _make_meta("b", vector=[0.0, 1.0])  # far
+    store["c"] = _make_meta("c", vector=[1.0, 0.0])  # closest
+
+    q = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["c", "a", "b"]
+
+
+# BF3: L2 distance
+def test_bf_l2_filter_and_sort() -> None:
+    store = MemoryMetaStore()
+    store["near"] = _make_meta("near", vector=[1.0, 1.0])
+    store["far"] = _make_meta("far", vector=[10.0, 10.0])
+
+    q = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[0.0, 0.0],
+                distance="l2",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["near", "far"]
+
+
+# BF3 cont: inner-product distance (lower = more similar by our convention)
+def test_bf_ip_distance() -> None:
+    store = MemoryMetaStore()
+    store["aligned"] = _make_meta("aligned", vector=[1.0, 1.0])  # dot = 2 → dist=-2
+    store["opposed"] = _make_meta("opposed", vector=[-1.0, -1.0])  # dot=-2 → dist=2
+
+    q = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[1.0, 1.0],
+                distance="ip",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["aligned", "opposed"]
+
+
+# BF4: scalar AND vector conditions compose
+def test_bf_scalar_and_vector_filters_compose() -> None:
+    store = MemoryMetaStore()
+    store["abc-near"] = _make_meta("abc-near", vector=[1.0, 0.0], doctype="abc")
+    store["abc-far"] = _make_meta("abc-far", vector=[0.0, 1.0], doctype="abc")
+    store["xyz-near"] = _make_meta("xyz-near", vector=[1.0, 0.0], doctype="xyz")
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            DataSearchCondition(
+                field_path="doctype",
+                operator=DataSearchOperator.equals,
+                value="abc",
+            ),
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = sorted(m.resource_id for m in store.iter_search(q))
+    assert ids == ["abc-near"]
+
+
+# BF5: rows without a vector in indexed_data are excluded from results
+def test_bf_missing_vector_excluded() -> None:
+    store = MemoryMetaStore()
+    store["has"] = _make_meta("has", vector=[1.0, 0.0])
+    # Row without "embedding" key
+    now = dt.datetime(2026, 5, 22, tzinfo=dt.timezone.utc)
+    store["lacks"] = ResourceMeta(
+        resource_id="lacks",
+        current_revision_id="lacks-rev",
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"doctype": "abc"},  # no "embedding"
+    )
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=1.5,
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["has"]
+
+
+# BF6: capability flag — memory backend reports brute-force
+def test_bf_memory_store_capability_flag() -> None:
+    store = MemoryMetaStore()
+    assert store.supports_native_vector_search is False

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,255 @@
+"""Executable tests for every code example in docs/en/howto/vector-search.md.
+
+If any of these fail, either the docs are wrong or there's a real bug.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated
+
+import pytest
+from msgspec import UNSET, Struct
+
+from specstar import Embedding, SpecStar, ValidationError, Vector
+from specstar.query import QB
+
+
+# A tiny deterministic 2-D encoder for tests.
+# Maps a few well-known strings to specific vectors so we can assert ordering.
+def _embed(text: str) -> list[float]:
+    if "near" in text or "aligned" in text or "hello" in text:
+        return [1.0, 0.0]
+    if "far" in text or "orthogonal" in text or "goodbye" in text:
+        return [0.0, 1.0]
+    return [0.7, 0.7]
+
+
+def _new_spec() -> SpecStar:
+    s = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    return s
+
+
+# D1: TL;DR — Embedding field + QB.cosine on string query, with scalar filter
+def test_docs_tldr_runs_end_to_end() -> None:
+    class Doc(Struct):
+        title: str
+        doctype: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="my_embed")]
+
+    spec = _new_spec()
+    spec.configure(vector_encoders={"my_embed": _embed})
+    spec.add_model(Doc, indexed_fields=["doctype"])
+    mgr = spec.get_resource_manager(Doc)
+
+    mgr.create(
+        Doc(title="a-near", doctype="article", summary=Embedding(content="hello world"))
+    )
+    mgr.create(
+        Doc(title="b-far", doctype="article", summary=Embedding(content="orthogonal text"))
+    )
+    mgr.create(
+        Doc(title="c-wrong-type", doctype="memo", summary=Embedding(content="hello"))
+    )
+
+    query = (
+        (QB["doctype"] == "article") & (QB["summary"].cosine("near_query") < 0.3)
+    ).sort(QB["summary"].cosine("near_query")).limit(3).build()
+
+    results = mgr.list_resources(query, returns=["data"])
+    titles = [r.data.title for r in results]
+    # only "article" doctype docs near "hello"-style vector should appear
+    assert "a-near" in titles
+    assert "b-far" not in titles
+    assert "c-wrong-type" not in titles
+
+
+# D2: Level 1 — raw list[float] vector field, user supplies the vector
+def test_docs_level1_raw_vector() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2, distance="cosine")]
+
+    spec = _new_spec()
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    my_vector = [1.0, 0.0]
+    info = mgr.create(Doc(title="t", embedding=my_vector))
+    assert mgr.get(info.resource_id).data.embedding == my_vector
+
+    # Query by raw vector
+    q = (QB["embedding"].cosine([1.0, 0.0]) < 0.1).build()
+    results = mgr.list_resources(q, returns=["data"])
+    assert [r.data.title for r in results] == ["t"]
+
+
+# D3: Level 2 — Embedding(content=...) is enough; framework fills vector
+def test_docs_level2_embedding_auto_fill() -> None:
+    call_count = 0
+
+    def counting_embed(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return _embed(text)
+
+    class Doc(Struct):
+        title: str
+        summary: Annotated[
+            Embedding,
+            Vector(dim=2, distance="cosine", encoder="openai_small"),
+        ]
+
+    spec = _new_spec()
+    spec.configure(vector_encoders={"openai_small": counting_embed})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    info = mgr.create(Doc(title="t", summary=Embedding(content="hello")))
+    stored = mgr.get(info.resource_id).data
+    assert stored.summary.vector == [1.0, 0.0]
+    assert stored.summary.content_hash  # filled
+    assert stored.summary.encoder_id == "openai_small"
+    assert call_count == 1
+
+    # Cache reuse: same content → encoder NOT called again
+    mgr.update(
+        info.resource_id,
+        Doc(title="t2", summary=Embedding(content="hello")),
+    )
+    assert call_count == 1
+
+
+# D4: encoder override hierarchy (field > model > global)
+def test_docs_encoder_override_hierarchy() -> None:
+    def embed_small(text: str) -> list[float]:
+        return [0.1, 0.2]
+
+    def embed_large(text: str) -> list[float]:
+        return [0.9, 0.9]
+
+    class Doc(Struct):
+        title: str
+        summary: Annotated[
+            Embedding,
+            Vector(dim=2, encoder="openai_small"),  # field-level wins
+        ]
+
+    spec = _new_spec()
+    # global registry
+    spec.configure(
+        vector_encoders={
+            "openai_small": embed_small,
+            "openai_large": embed_large,
+        }
+    )
+    # per-model override → ignored because annotation pins openai_small
+    spec.add_model(Doc, vector_encoders={"summary": "openai_large"})
+    mgr = spec.get_resource_manager(Doc)
+
+    info = mgr.create(Doc(title="t", summary=Embedding(content="x")))
+    stored = mgr.get(info.resource_id).data
+    assert stored.summary.vector == [0.1, 0.2]  # field-level encoder won
+    assert stored.summary.encoder_id == "openai_small"
+
+
+# D5: QB compose — scalar AND vector filter + vector sort + limit
+def test_docs_qb_compose() -> None:
+    class Doc(Struct):
+        title: str
+        doctype: str
+        embedding: Annotated[list[float], Vector(dim=2)]
+
+    spec = _new_spec()
+    spec.add_model(Doc, indexed_fields=["doctype"])
+    mgr = spec.get_resource_manager(Doc)
+
+    mgr.create(Doc(title="x1", doctype="article", embedding=[1.0, 0.0]))  # near
+    mgr.create(Doc(title="x2", doctype="article", embedding=[0.9, 0.1]))  # near
+    mgr.create(Doc(title="y1", doctype="article", embedding=[0.0, 1.0]))  # far
+    mgr.create(Doc(title="z1", doctype="memo", embedding=[1.0, 0.0]))  # wrong type
+
+    q = [1.0, 0.0]
+    query = (
+        ((QB["doctype"] == "article") & (QB["embedding"].cosine(q) < 0.3))
+        .sort(QB["embedding"].cosine(q))
+        .limit(10)
+        .build()
+    )
+    results = mgr.list_resources(query, returns=["data"])
+    titles = [r.data.title for r in results]
+    # x1 (exactly aligned) first, then x2 (close); y1 too far, z1 wrong type
+    assert titles == ["x1", "x2"]
+
+
+# D6: §8 Validation — error message format matches what the docs promise
+def test_docs_validation_error_format() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=1536)]
+
+    spec = _new_spec()
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    with pytest.raises(ValidationError) as exc_info:
+        mgr.create(Doc(title="t", embedding=[0.1, 0.2]))
+    msg = str(exc_info.value)
+    # docs say: "Vector field 'embedding': expected dim=1536, got 512"
+    assert "embedding" in msg
+    assert "expected dim=1536" in msg
+    assert "got 2" in msg
+
+
+# D7: §9 cache reuse — updating an unrelated field doesn't re-encode
+def test_docs_cache_reuse_unrelated_field() -> None:
+    class Doc(Struct):
+        title: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+    call_count = 0
+
+    def counting(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return [1.0, 0.0]
+
+    spec = _new_spec()
+    spec.configure(vector_encoders={"stub": counting})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    info = mgr.create(Doc(title="t1", summary=Embedding(content="same")))
+    assert call_count == 1
+    mgr.update(info.resource_id, Doc(title="t2", summary=Embedding(content="same")))
+    assert call_count == 1  # no re-encoding
+
+
+# D8: §4 distance metrics — l2 / ip both work end-to-end
+def test_docs_distance_metric_alternatives() -> None:
+    class Doc(Struct):
+        title: str
+        e: Annotated[list[float], Vector(dim=2, distance="l2")]
+
+    spec = _new_spec()
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+    mgr.create(Doc(title="near", e=[1.0, 1.0]))
+    mgr.create(Doc(title="far", e=[10.0, 10.0]))
+
+    # default sort by distance ascending; l2 distance
+    r_sort = (QB["e"].l2([0.0, 0.0]) < 100.0).sort(QB["e"].l2([0.0, 0.0])).build()
+    titles = [r.data.title for r in mgr.list_resources(r_sort, returns=["data"])]
+    assert titles == ["near", "far"]
+
+    # ip metric
+    r_ip = (
+        (QB["e"].ip([1.0, 1.0]) <= -1.0).sort(QB["e"].ip([1.0, 1.0])).build()
+    )
+    titles_ip = [r.data.title for r in mgr.list_resources(r_ip, returns=["data"])]
+    # far has dot=20 → ip dist=-20; near has dot=2 → ip dist=-2. Both ≤ -1.
+    # ascending → most-similar (most-negative) first
+    assert titles_ip == ["far", "near"]

--- a/tests/test_embedding_processor.py
+++ b/tests/test_embedding_processor.py
@@ -1,0 +1,217 @@
+"""Tests for ``EmbeddingProcessor`` — write-time encoder pipeline for Embedding fields."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from msgspec import UNSET, Struct
+
+from specstar.resource_manager.embedding_processor import EmbeddingProcessor
+from specstar.resource_manager.encoder_registry import EncoderRegistry
+from specstar.types import Embedding, Vector
+
+
+def _stub_encoder_a(text: str) -> list[float]:
+    # Deterministic small vector for asserting
+    return [float(ord(c)) / 100.0 for c in text[:4].ljust(4, " ")]
+
+
+def _stub_encoder_b(text: str) -> list[float]:
+    # Different output — simulates a different model
+    return [1.0, 2.0, 3.0, 4.0]
+
+
+# EP1: tracer — fresh content gets encoded
+@pytest.mark.asyncio
+async def test_ep_encode_fresh_content() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_a")]
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", _stub_encoder_a)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    data = Doc(summary=Embedding(content="hello"))
+    result = await processor.process(data)
+
+    assert result.summary.vector == _stub_encoder_a("hello")
+    assert result.summary.content == "hello"
+    assert result.summary.content_hash is not UNSET
+    assert result.summary.encoder_id == "enc_a"
+
+
+# EP2: user-provided vector preserved (encoder not called)
+@pytest.mark.asyncio
+async def test_ep_user_vector_preserved() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_a")]
+
+    call_count = 0
+
+    def counting_encoder(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return [9.9, 9.9, 9.9, 9.9]
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", counting_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    user_vec = [0.5, 0.6, 0.7, 0.8]
+    data = Doc(summary=Embedding(content="hi", vector=user_vec))
+    result = await processor.process(data)
+
+    assert result.summary.vector == user_vec
+    assert call_count == 0  # encoder NOT called
+
+
+# EP3: cache reuse — same content_hash + encoder_id → reuse previous vector
+@pytest.mark.asyncio
+async def test_ep_cache_reuse_on_match() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_a")]
+
+    call_count = 0
+
+    def counting_encoder(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return [9.9, 9.9, 9.9, 9.9]
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", counting_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    # First process: encoder called once, vector + hash + encoder_id filled
+    first = await processor.process(Doc(summary=Embedding(content="same")))
+    assert call_count == 1
+
+    # Second process with same content; pass previous as cache source
+    second = await processor.process(
+        Doc(summary=Embedding(content="same")),
+        previous=first,
+    )
+    assert call_count == 1  # encoder NOT called again
+    assert second.summary.vector == first.summary.vector
+    assert second.summary.content_hash == first.summary.content_hash
+    assert second.summary.encoder_id == first.summary.encoder_id
+
+
+# EP4: content changed → encoder runs even with previous
+@pytest.mark.asyncio
+async def test_ep_content_changed_triggers_reencoding() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_a")]
+
+    call_count = 0
+
+    def counting_encoder(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        # Return different vector per text to detect re-encode
+        return [float(len(text))] * 4
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", counting_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    first = await processor.process(Doc(summary=Embedding(content="short")))
+    assert call_count == 1
+
+    # Different content — must re-encode despite passing previous
+    second = await processor.process(
+        Doc(summary=Embedding(content="much longer content")),
+        previous=first,
+    )
+    assert call_count == 2
+    assert second.summary.vector != first.summary.vector
+    assert second.summary.content_hash != first.summary.content_hash
+
+
+# EP5: encoder_id change triggers re-encoding even if content is the same
+@pytest.mark.asyncio
+async def test_ep_encoder_change_triggers_reencoding() -> None:
+    # First model uses enc_a, then re-process with model that uses enc_b
+    class DocA(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_a")]
+
+    class DocB(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="enc_b")]
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", _stub_encoder_a)
+    reg.register("enc_b", _stub_encoder_b)
+
+    proc_a = EmbeddingProcessor(DocA, reg)
+    proc_b = EmbeddingProcessor(DocB, reg)
+
+    first = await proc_a.process(DocA(summary=Embedding(content="same")))
+    assert first.summary.encoder_id == "enc_a"
+    first_vec = first.summary.vector
+
+    # Even though content hash matches, encoder differs → re-encode
+    # Cross-type cache reuse via duck-typing: previous has summary.content_hash and encoder_id
+    second = await proc_b.process(
+        DocB(summary=Embedding(content="same")),
+        previous=first,
+    )
+    assert second.summary.encoder_id == "enc_b"
+    assert second.summary.vector == _stub_encoder_b("same")
+    assert second.summary.vector != first_vec
+
+
+# EP6: nullable Embedding with None — encoder not called, value stays None
+@pytest.mark.asyncio
+async def test_ep_nullable_none_skipped() -> None:
+    class Doc(Struct):
+        body: Annotated[Embedding | None, Vector(dim=4, encoder="enc_a")] = None
+
+    call_count = 0
+
+    def counting_encoder(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return [0.0] * 4
+
+    reg = EncoderRegistry()
+    reg.register("enc_a", counting_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    result = await processor.process(Doc(body=None))
+    assert result.body is None
+    assert call_count == 0
+
+
+# EP7: encoder exception propagates
+@pytest.mark.asyncio
+async def test_ep_encoder_error_propagates() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="bomb")]
+
+    def bomb_encoder(text: str) -> list[float]:
+        raise RuntimeError("api limit")
+
+    reg = EncoderRegistry()
+    reg.register("bomb", bomb_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    with pytest.raises(RuntimeError, match="api limit"):
+        await processor.process(Doc(summary=Embedding(content="hi")))
+
+
+# EP8: async encoder awaited correctly
+@pytest.mark.asyncio
+async def test_ep_async_encoder_awaited() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4, encoder="async_enc")]
+
+    async def async_encoder(text: str) -> list[float]:
+        return [42.0, 42.0, 42.0, 42.0]
+
+    reg = EncoderRegistry()
+    reg.register("async_enc", async_encoder)
+    processor = EmbeddingProcessor(Doc, reg)
+
+    result = await processor.process(Doc(summary=Embedding(content="hi")))
+    assert result.summary.vector == [42.0, 42.0, 42.0, 42.0]

--- a/tests/test_embedding_type.py
+++ b/tests/test_embedding_type.py
@@ -1,0 +1,42 @@
+"""Tests for the ``Embedding`` struct type."""
+
+from __future__ import annotations
+
+from msgspec import UNSET
+
+from specstar.types import Embedding
+
+
+# E1: tracer
+def test_embedding_content_only_defaults_unset() -> None:
+    e = Embedding(content="hello world")
+    assert e.content == "hello world"
+    assert e.vector is UNSET
+    assert e.content_hash is UNSET
+    assert e.encoder_id is UNSET
+
+
+# E2: full ctor carries all four fields
+def test_embedding_full_ctor() -> None:
+    e = Embedding(
+        content="hello",
+        vector=[0.1, 0.2, 0.3],
+        content_hash="abc123",
+        encoder_id="openai_small",
+    )
+    assert e.content == "hello"
+    assert e.vector == [0.1, 0.2, 0.3]
+    assert e.content_hash == "abc123"
+    assert e.encoder_id == "openai_small"
+
+
+# E3: Embedding (and Vector) are part of the public API
+def test_embedding_and_vector_in_public_api() -> None:
+    import specstar
+
+    assert specstar.Embedding is Embedding
+    from specstar import Vector
+
+    assert hasattr(Vector(dim=1), "dim")
+    assert "Embedding" in specstar.__all__
+    assert "Vector" in specstar.__all__

--- a/tests/test_encoder_registry.py
+++ b/tests/test_encoder_registry.py
@@ -1,0 +1,115 @@
+"""Tests for the encoder registry and lookup_encoder helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from specstar.resource_manager.encoder_registry import (
+    EncoderRegistry,
+    lookup_encoder,
+)
+from specstar.types import Vector, VectorFieldInfo
+
+
+def _fake_encoder_a(text: str) -> list[float]:
+    return [0.1, 0.2]
+
+
+def _fake_encoder_b(text: str) -> list[float]:
+    return [0.3, 0.4]
+
+
+# ER1: tracer — register + resolve
+def test_registry_register_and_resolve() -> None:
+    reg = EncoderRegistry()
+    reg.register("openai_small", _fake_encoder_a)
+    assert reg.resolve("openai_small") is _fake_encoder_a
+
+
+# ER2: unknown name raises KeyError
+def test_registry_unknown_raises() -> None:
+    reg = EncoderRegistry()
+    with pytest.raises(KeyError):
+        reg.resolve("missing")
+
+
+# ER3: lookup_encoder uses field-level annotation
+def test_lookup_field_level_annotation() -> None:
+    reg = EncoderRegistry()
+    reg.register("openai_small", _fake_encoder_a)
+    info = VectorFieldInfo(
+        name="embedding",
+        marker=Vector(dim=2, encoder="openai_small"),
+        is_embedding=False,
+        nullable=False,
+    )
+    assert lookup_encoder(reg, field_info=info) is _fake_encoder_a
+
+
+# ER4: field-level annotation overrides model-level
+def test_lookup_field_overrides_model() -> None:
+    reg = EncoderRegistry()
+    reg.register("openai_small", _fake_encoder_a)
+    reg.register("openai_large", _fake_encoder_b)
+    info = VectorFieldInfo(
+        name="embedding",
+        marker=Vector(dim=2, encoder="openai_small"),  # field-level
+        is_embedding=False,
+        nullable=False,
+    )
+    # model_overrides says "openai_large" but field annotation wins
+    fn = lookup_encoder(
+        reg,
+        field_info=info,
+        model_overrides={"embedding": "openai_large"},
+    )
+    assert fn is _fake_encoder_a
+
+
+# ER5: model-level used when annotation lacks encoder
+def test_lookup_model_level_when_annotation_empty() -> None:
+    reg = EncoderRegistry()
+    reg.register("openai_large", _fake_encoder_b)
+    info = VectorFieldInfo(
+        name="embedding",
+        marker=Vector(dim=2),  # no encoder on annotation
+        is_embedding=False,
+        nullable=False,
+    )
+    fn = lookup_encoder(
+        reg,
+        field_info=info,
+        model_overrides={"embedding": "openai_large"},
+    )
+    assert fn is _fake_encoder_b
+
+
+# ER6: model_overrides accepts callable directly (not just name string)
+def test_lookup_model_level_accepts_callable() -> None:
+    reg = EncoderRegistry()  # nothing registered
+    info = VectorFieldInfo(
+        name="embedding",
+        marker=Vector(dim=2),
+        is_embedding=False,
+        nullable=False,
+    )
+    fn = lookup_encoder(
+        reg,
+        field_info=info,
+        model_overrides={"embedding": _fake_encoder_b},
+    )
+    assert fn is _fake_encoder_b
+
+
+# ER7: returns None when nothing configured
+def test_lookup_returns_none_when_unconfigured() -> None:
+    reg = EncoderRegistry()
+    info = VectorFieldInfo(
+        name="embedding",
+        marker=Vector(dim=2),
+        is_embedding=False,
+        nullable=False,
+    )
+    assert lookup_encoder(reg, field_info=info) is None
+    assert lookup_encoder(reg, field_info=info, model_overrides={}) is None
+    assert lookup_encoder(reg, field_info=info, model_overrides={"other": "x"}) is None

--- a/tests/test_openapi_vector.py
+++ b/tests/test_openapi_vector.py
@@ -1,0 +1,75 @@
+"""Tests for OpenAPI x-vector-* extension injection."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import FastAPI
+from msgspec import Struct
+
+from specstar import Embedding, SpecStar, Vector
+
+
+# OA1: x-vector-dim appears on the OpenAPI property for a Vector field
+def test_oa_x_vector_dim_injected() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=1536)]
+
+    app = FastAPI(title="oa-vector")
+    spec = SpecStar()
+    spec.add_model(Doc)
+    spec.apply(app)
+    spec.openapi(app)
+
+    schema = app.openapi_schema
+    components = schema["components"]["schemas"]
+    # Find the Doc component (name may be prefixed)
+    doc_comp = next(
+        c for n, c in components.items() if n.endswith("Doc") or n == "Doc"
+    )
+    prop = doc_comp["properties"]["embedding"]
+    assert prop.get("x-vector-dim") == 1536
+
+
+# OA2: distance and encoder also injected when present on annotation
+def test_oa_x_vector_distance_and_encoder() -> None:
+    class Doc(Struct):
+        summary: Annotated[
+            Embedding,
+            Vector(dim=1536, distance="cosine", encoder="openai_small"),
+        ]
+
+    app = FastAPI(title="oa-vector-full")
+    spec = SpecStar()
+    spec.add_model(Doc)
+    spec.apply(app)
+    spec.openapi(app)
+
+    schema = app.openapi_schema
+    components = schema["components"]["schemas"]
+    doc_comp = next(c for n, c in components.items() if n.endswith("Doc") or n == "Doc")
+    prop = doc_comp["properties"]["summary"]
+    assert prop.get("x-vector-dim") == 1536
+    assert prop.get("x-vector-distance") == "cosine"
+    assert prop.get("x-vector-encoder-id") == "openai_small"
+
+
+# OA2 cont: omitted annotation fields → omitted from OpenAPI
+def test_oa_no_x_vector_distance_when_unset() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=512)]
+
+    app = FastAPI(title="oa-vector-min")
+    spec = SpecStar()
+    spec.add_model(Doc)
+    spec.apply(app)
+    spec.openapi(app)
+
+    schema = app.openapi_schema
+    components = schema["components"]["schemas"]
+    doc_comp = next(c for n, c in components.items() if n.endswith("Doc") or n == "Doc")
+    prop = doc_comp["properties"]["embedding"]
+    assert prop.get("x-vector-dim") == 512
+    assert "x-vector-distance" not in prop
+    assert "x-vector-encoder-id" not in prop

--- a/tests/test_postgres_pgvector.py
+++ b/tests/test_postgres_pgvector.py
@@ -1,0 +1,231 @@
+"""Integration tests for PostgresMetaStore + pgvector."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import psycopg2
+import pytest
+
+from specstar.query_types import (
+    DataSearchCondition,
+    DataSearchOperator,
+    ResourceMetaSearchQuery,
+    VectorDistanceCondition,
+    VectorDistanceSort,
+)
+from specstar.resource_manager.basic import Encoding
+from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+from specstar.types import ResourceMeta
+
+PG_DSN = "postgresql://admin:password@localhost:5432/your_database"
+
+
+@pytest.fixture
+def store():
+    """Fresh PostgresMetaStore with a unique table name per test."""
+    table_name = f"vec_test_{uuid.uuid4().hex[:8]}"
+    s = PostgresMetaStore(pg_dsn=PG_DSN, encoding=Encoding.json, table_name=table_name)
+    yield s
+    # Cleanup
+    conn = psycopg2.connect(PG_DSN)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{table_name}" CASCADE')
+    finally:
+        conn.close()
+
+
+def _make_meta(rid: str, *, vector: list[float], doctype: str = "abc") -> ResourceMeta:
+    now = dt.datetime(2026, 5, 22)
+    return ResourceMeta(
+        resource_id=rid,
+        current_revision_id=f"{rid}-rev",
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"embedding": vector, "doctype": doctype},
+    )
+
+
+# PV1: capability flag is True when pgvector extension is available
+def test_pv_capability_flag_true_when_pgvector_present(store: PostgresMetaStore) -> None:
+    assert store.supports_native_vector_search is True
+
+
+# PV2: ensure_vector_column creates a vector(N) column + HNSW index
+def test_pv_ensure_vector_column_creates_col_and_index(
+    store: PostgresMetaStore,
+) -> None:
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+
+    conn = psycopg2.connect(PG_DSN)
+    try:
+        with conn.cursor() as cur:
+            # Column exists with vector type
+            cur.execute(
+                f"""
+                SELECT column_name, udt_name
+                FROM information_schema.columns
+                WHERE table_name = '{store.table_name}'
+                  AND column_name = 'vec_embedding'
+                """
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[1] == "vector"
+
+            # HNSW index exists for this column
+            cur.execute(
+                f"""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = '{store.table_name}'
+                  AND indexname LIKE '%embedding%'
+                """
+            )
+            assert cur.fetchone() is not None
+    finally:
+        conn.close()
+
+
+# PV3: cosine distance filter executes natively via SQL
+def test_pv_cosine_filter_sql(store: PostgresMetaStore) -> None:
+    store.ensure_vector_column("embedding", dim=2, distance="cosine")
+
+    store["a"] = _make_meta("a", vector=[1.0, 0.0])
+    store["b"] = _make_meta("b", vector=[0.0, 1.0])
+    store["c"] = _make_meta("c", vector=[0.9, 0.1])
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = sorted(m.resource_id for m in store.iter_search(q))
+    assert "a" in ids
+    assert "c" in ids
+    assert "b" not in ids
+
+
+# PV4: cosine sort via ORDER BY — nearest rows first
+def test_pv_cosine_sort_sql(store: PostgresMetaStore) -> None:
+    store.ensure_vector_column("embedding", dim=2, distance="cosine")
+
+    store["a"] = _make_meta("a", vector=[0.9, 0.1])
+    store["b"] = _make_meta("b", vector=[0.0, 1.0])
+    store["c"] = _make_meta("c", vector=[1.0, 0.0])
+
+    q = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["c", "a", "b"]
+
+
+# PV5: dim > HNSW_MAX_DIM (2000) is truncated to first 2000 in the indexed col
+def test_pv_dim_over_limit_truncates(store: PostgresMetaStore) -> None:
+    big_dim = 2500
+    store.ensure_vector_column("big_vec", dim=big_dim, distance="cosine")
+
+    # Verify the column was created with vector(2000), not vector(2500)
+    conn = psycopg2.connect(PG_DSN)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT atttypmod
+                FROM pg_attribute
+                JOIN pg_class ON attrelid = pg_class.oid
+                WHERE relname = '{store.table_name}'
+                  AND attname = 'vec_big_vec'
+                """
+            )
+            row = cur.fetchone()
+            # pgvector stores dim directly in atttypmod
+            assert row is not None
+            assert row[0] == store.HNSW_MAX_DIM
+    finally:
+        conn.close()
+
+    # Writing a 2500-dim vector → first 2000 are stored
+    long_vec = [float(i % 7) / 10 for i in range(big_dim)]
+    now = dt.datetime(2026, 5, 22)
+    meta = ResourceMeta(
+        resource_id="x",
+        current_revision_id="x-rev",
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"big_vec": long_vec},
+    )
+    store["x"] = meta
+    # Query with prefix of stored vector → must match
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="big_vec",
+                query_vector=long_vec,  # full-length; framework truncates to 2000
+                operator=DataSearchOperator.less_than,
+                threshold=0.01,
+                distance="cosine",
+            ),
+        ],
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["x"]
+
+
+# PV6: scalar (jsonb) + vector conditions compose in WHERE
+def test_pv_scalar_and_vector_compose(store: PostgresMetaStore) -> None:
+    store.ensure_vector_column("embedding", dim=2, distance="cosine")
+
+    store["abc-near"] = _make_meta("abc-near", vector=[1.0, 0.0], doctype="abc")
+    store["abc-far"] = _make_meta("abc-far", vector=[0.0, 1.0], doctype="abc")
+    store["xyz-near"] = _make_meta("xyz-near", vector=[1.0, 0.0], doctype="xyz")
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            DataSearchCondition(
+                field_path="doctype",
+                operator=DataSearchOperator.equals,
+                value="abc",
+            ),
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            ),
+        ],
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[1.0, 0.0],
+                distance="cosine",
+            ),
+        ],
+        limit=10,
+    )
+    ids = [m.resource_id for m in store.iter_search(q)]
+    assert ids == ["abc-near"]

--- a/tests/test_qb_vector.py
+++ b/tests/test_qb_vector.py
@@ -1,0 +1,95 @@
+"""Tests for QB vector methods: cosine / l2 / ip on Field."""
+
+from __future__ import annotations
+
+import pytest
+
+from specstar.query import QB, Query
+from specstar.query_types import (
+    DataSearchOperator,
+    ResourceMetaSortDirection,
+    VectorDistanceCondition,
+    VectorDistanceSort,
+)
+
+
+def _vc(cb) -> VectorDistanceCondition:
+    """Pull the VectorDistanceCondition out of a ConditionBuilder."""
+    return cb._condition
+
+
+# QB1 + QB2: Field.cosine(q) returns expr; expr < t builds a vector cond
+def test_qb_cosine_returns_expr_with_distance() -> None:
+    expr = QB["embedding"].cosine([0.1, 0.2, 0.3])
+    cb = expr < 0.3
+    cond = _vc(cb)
+    assert isinstance(cond, VectorDistanceCondition)
+    assert cond.field_path == "embedding"
+    assert cond.distance == "cosine"
+    assert cond.query_vector == [0.1, 0.2, 0.3]
+    assert cond.operator == DataSearchOperator.less_than
+    assert cond.threshold == 0.3
+
+
+# QB3: lte / gt / gte all produce VectorDistanceCondition with right operator
+def test_qb_comparison_operators_cover_all_four() -> None:
+    q = [0.1, 0.2, 0.3]
+    assert _vc(QB["e"].cosine(q) <= 0.5).operator == DataSearchOperator.less_than_or_equal
+    assert _vc(QB["e"].cosine(q) > 0.5).operator == DataSearchOperator.greater_than
+    assert (
+        _vc(QB["e"].cosine(q) >= 0.5).operator
+        == DataSearchOperator.greater_than_or_equal
+    )
+
+
+# QB4: l2 and ip methods carry the correct distance metric
+def test_qb_l2_and_ip_methods() -> None:
+    q = [0.1, 0.2]
+    assert _vc(QB["e"].l2(q) < 1.0).distance == "l2"
+    assert _vc(QB["e"].ip(q) > 0.5).distance == "ip"
+
+
+# QB5: passing expr to .sort() yields ascending VectorDistanceSort
+def test_qb_expr_passed_to_sort_yields_ascending_sort() -> None:
+    q = [0.1, 0.2, 0.3]
+    query = Query().sort(QB["embedding"].cosine(q)).limit(10).build()
+    assert len(query.sorts) == 1
+    s = query.sorts[0]
+    assert isinstance(s, VectorDistanceSort)
+    assert s.field_path == "embedding"
+    assert s.query_vector == q
+    assert s.direction == ResourceMetaSortDirection.ascending
+    assert s.distance == "cosine"
+
+
+# QB6: .desc() produces descending sort
+def test_qb_expr_desc_yields_descending_sort() -> None:
+    q = [0.1, 0.2]
+    query = Query().sort(QB["e"].cosine(q).desc()).build()
+    s = query.sorts[0]
+    assert isinstance(s, VectorDistanceSort)
+    assert s.direction == ResourceMetaSortDirection.descending
+
+
+# QB7: vector condition composes with scalar conditions via &
+def test_qb_vector_condition_composes_with_and() -> None:
+    q = [0.1, 0.2, 0.3]
+    # ConditionBuilder is itself a Query, so chain .sort().limit().build() on it
+    query = (
+        ((QB["doctype"] == "abc") & (QB["vec"].cosine(q) < 0.3))
+        .sort(QB["vec"].cosine(q))
+        .limit(10)
+        .build()
+    )
+
+    assert len(query.conditions) == 1
+    from specstar.query_types import DataSearchGroup
+
+    group = query.conditions[0]
+    assert isinstance(group, DataSearchGroup)
+    # Group has both a scalar condition and a vector-distance condition
+    types_in_group = {type(c) for c in group.conditions}
+    assert VectorDistanceCondition in types_in_group
+    # sort wired up
+    assert isinstance(query.sorts[0], VectorDistanceSort)
+    assert query.limit == 10

--- a/tests/test_str_query_vector.py
+++ b/tests/test_str_query_vector.py
@@ -1,0 +1,156 @@
+"""Tests for resolving str query_vector → list[float] via encoder at search time."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated
+
+import pytest
+from msgspec import Struct
+
+from specstar import SpecStar, Vector
+from specstar.query_types import (
+    DataSearchOperator,
+    ResourceMetaSearchQuery,
+    VectorDistanceCondition,
+    VectorDistanceSort,
+)
+
+
+def _stub_encoder(text: str) -> list[float]:
+    # Two text inputs map to opposite-direction vectors so we can assert ordering
+    if text == "near_query":
+        return [1.0, 0.0]
+    if text == "far_query":
+        return [0.0, 1.0]
+    return [0.5, 0.5]
+
+
+# Q1: str query_vector in a condition resolved before backend dispatch
+def test_q_str_condition_resolved_via_encoder() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2, encoder="stub")]
+
+    spec = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(vector_encoders={"stub": _stub_encoder})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    mgr.create(Doc(title="aligned", embedding=[1.0, 0.0]))
+    mgr.create(Doc(title="opposed", embedding=[0.0, 1.0]))
+    mgr.create(Doc(title="close", embedding=[0.9, 0.1]))
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector="near_query",  # str — encoder must resolve
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            ),
+        ],
+    )
+    metas = mgr.search_resources(q)
+    titles = sorted(
+        mgr.get(m.resource_id).data.title for m in metas
+    )
+    assert "aligned" in titles
+    assert "close" in titles
+    assert "opposed" not in titles
+
+
+# Q2: str query_vector in a sort is also resolved
+def test_q_str_sort_resolved_via_encoder() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2, encoder="stub")]
+
+    spec = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(vector_encoders={"stub": _stub_encoder})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    mgr.create(Doc(title="aligned", embedding=[1.0, 0.0]))
+    mgr.create(Doc(title="opposed", embedding=[0.0, 1.0]))
+    mgr.create(Doc(title="close", embedding=[0.9, 0.1]))
+
+    q = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector="near_query",
+                distance="cosine",
+            ),
+        ],
+    )
+    metas = mgr.search_resources(q)
+    titles = [mgr.get(m.resource_id).data.title for m in metas]
+    assert titles == ["aligned", "close", "opposed"]
+
+
+# Q3: async encoder + sync search → raises with clear message
+def test_q_async_encoder_in_sync_search_raises() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2, encoder="async_stub")]
+
+    async def async_encoder(text: str) -> list[float]:
+        return [1.0, 0.0]
+
+    spec = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(vector_encoders={"async_stub": async_encoder})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+    mgr.create(Doc(title="x", embedding=[1.0, 0.0]))
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector="hello",
+                operator=DataSearchOperator.less_than,
+                threshold=0.5,
+            ),
+        ],
+    )
+    with pytest.raises(RuntimeError, match="async"):
+        mgr.search_resources(q)
+
+
+# Q4: str query_vector + no encoder configured → clear ValueError
+def test_q_str_query_without_encoder_raises() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2)]  # no encoder
+
+    spec = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+    mgr.create(Doc(title="x", embedding=[1.0, 0.0]))
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector="hello",
+                operator=DataSearchOperator.less_than,
+                threshold=0.5,
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="No encoder"):
+        mgr.search_resources(q)

--- a/tests/test_vector_dim_validator.py
+++ b/tests/test_vector_dim_validator.py
@@ -1,0 +1,87 @@
+"""Tests for ``_VectorDimValidator`` — write-time dim validation."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from msgspec import Struct
+
+from specstar.resource_manager.vector_validator import VectorDimValidator
+from specstar.types import Embedding, ValidationError, Vector
+
+
+# DV1: tracer — raw list[float] dim mismatch raises
+def test_dv_raw_vector_dim_mismatch_raises() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=4)]
+
+    validator = VectorDimValidator(Doc)
+    bad = Doc(embedding=[0.1, 0.2])  # len=2, expected=4
+    with pytest.raises(ValidationError):
+        validator.validate(bad)
+
+
+# DV2: matching dim passes
+def test_dv_matching_dim_passes() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=4)]
+
+    validator = VectorDimValidator(Doc)
+    ok = Doc(embedding=[0.1, 0.2, 0.3, 0.4])
+    validator.validate(ok)  # no exception
+
+
+# DV3: nullable raw vector with None passes
+def test_dv_nullable_raw_vector_none_passes() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float] | None, Vector(dim=4)] = None
+
+    validator = VectorDimValidator(Doc)
+    validator.validate(Doc(embedding=None))  # no exception
+
+
+# DV4: Embedding(vector=wrong_len) raises
+def test_dv_embedding_vector_dim_mismatch_raises() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4)]
+
+    validator = VectorDimValidator(Doc)
+    bad = Doc(summary=Embedding(content="hi", vector=[0.1, 0.2]))  # len=2
+    with pytest.raises(ValidationError):
+        validator.validate(bad)
+
+
+# DV5: Embedding without vector (UNSET) passes — processor will fill it
+def test_dv_embedding_unset_vector_passes() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=4)]
+
+    validator = VectorDimValidator(Doc)
+    # vector defaults to UNSET when user just provides content
+    validator.validate(Doc(summary=Embedding(content="hi")))  # no exception
+
+
+# DV6: error message contains field name, expected dim, actual dim
+def test_dv_error_message_includes_expected_and_actual() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=1536)]
+
+    validator = VectorDimValidator(Doc)
+    bad = Doc(embedding=[0.1, 0.2, 0.3])  # len=3, expected=1536
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate(bad)
+    msg = str(exc_info.value)
+    assert "embedding" in msg
+    assert "1536" in msg
+    assert "3" in msg
+
+
+# DV7: model without vector fields → validator is a noop
+def test_dv_noop_when_no_vector_fields() -> None:
+    class Plain(Struct):
+        title: str
+        age: int
+
+    validator = VectorDimValidator(Plain)
+    validator.validate(Plain(title="hi", age=20))  # no exception

--- a/tests/test_vector_field_info.py
+++ b/tests/test_vector_field_info.py
@@ -1,0 +1,69 @@
+"""Tests for ``extract_vector_field_infos`` — richer extractor returning
+(name, marker, is_embedding, nullable) for each Vector-annotated field.
+
+Used downstream by EmbeddingProcessor and the dim validator.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from msgspec import Struct
+
+from specstar.types import Embedding, Vector, extract_vector_field_infos
+
+
+# VF1: tracer — raw list[float] field
+def test_vf_raw_vector_field() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=1536)]
+
+    infos = extract_vector_field_infos(Doc)
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.name == "embedding"
+    assert info.marker.dim == 1536
+    assert info.is_embedding is False
+    assert info.nullable is False
+
+
+# VF2: Embedding-typed field reports is_embedding=True
+def test_vf_embedding_field() -> None:
+    class Doc(Struct):
+        summary: Annotated[Embedding, Vector(dim=1536, encoder="openai_small")]
+
+    infos = extract_vector_field_infos(Doc)
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.name == "summary"
+    assert info.is_embedding is True
+    assert info.nullable is False
+
+
+# VF3: Annotated[list[float] | None, Vector(...)] → nullable=True
+def test_vf_nullable_raw_vector() -> None:
+    class Doc(Struct):
+        embedding: Annotated[list[float] | None, Vector(dim=1536)] = None
+
+    infos = extract_vector_field_infos(Doc)
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.name == "embedding"
+    assert info.is_embedding is False
+    assert info.nullable is True
+
+
+# VF4: Annotated[Embedding | None, Vector(...)] → nullable=True, is_embedding=True
+def test_vf_nullable_embedding() -> None:
+    class Doc(Struct):
+        body: Annotated[Embedding | None, Vector(dim=3072, encoder="openai_large")] = (
+            None
+        )
+
+    infos = extract_vector_field_infos(Doc)
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.name == "body"
+    assert info.is_embedding is True
+    assert info.nullable is True
+    assert info.marker.encoder == "openai_large"

--- a/tests/test_vector_integration.py
+++ b/tests/test_vector_integration.py
@@ -1,0 +1,264 @@
+"""End-to-end integration tests for Vector + Embedding features."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated
+
+import pytest
+from msgspec import Struct
+
+from specstar import Embedding, SpecStar, Vector
+
+
+def _stub_encoder(text: str) -> list[float]:
+    """Deterministic 2-D vector based on text length & first char ordinal."""
+    return [float(len(text)), float(ord(text[0]) if text else 0)]
+
+
+# INT1: spec.configure(vector_encoders=...) registers encoders globally
+def test_int_configure_vector_encoders() -> None:
+    spec = SpecStar()
+    spec.configure(vector_encoders={"stub": _stub_encoder})
+
+    # The registry must contain "stub"
+    assert spec.encoder_registry.resolve("stub") is _stub_encoder
+
+
+# INT2: add_model auto-mounts the VectorDimValidator; create() with wrong-len
+# vector raises ValidationError without an explicit validator arg
+def test_int_dim_validator_auto_mounted() -> None:
+    from specstar import ValidationError
+
+    class Doc(Struct):
+        embedding: Annotated[list[float], Vector(dim=4)]
+
+    spec = SpecStar(default_user="tester", default_now=lambda: dt.datetime(2026, 5, 22))
+    spec.add_model(Doc)
+
+    mgr = spec.get_resource_manager(Doc)
+    with pytest.raises(ValidationError):
+        mgr.create(Doc(embedding=[0.1, 0.2]))  # len=2 != dim=4
+
+
+# INT3: add_model with Embedding field auto-encodes vector via the registry
+def test_int_embedding_processor_auto_mounted() -> None:
+    class Doc(Struct):
+        title: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+    spec = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(vector_encoders={"stub": _stub_encoder})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    # User only supplies content; framework computes the vector
+    info = mgr.create(Doc(title="t", summary=Embedding(content="hi")))
+    stored = mgr.get(info.resource_id)
+    assert stored.data.summary.vector == _stub_encoder("hi")
+    assert stored.data.summary.encoder_id == "stub"
+    assert stored.data.summary.content_hash  # filled in
+
+
+# INT4: end-to-end QB cosine search returns rows in distance order
+def test_int_end_to_end_qb_cosine_search() -> None:
+    from specstar.query import QB
+
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2)]
+
+    spec = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    # Aligned with [1, 0] = near; orthogonal = far
+    mgr.create(Doc(title="aligned", embedding=[1.0, 0.0]))
+    mgr.create(Doc(title="close", embedding=[0.9, 0.1]))
+    mgr.create(Doc(title="orthogonal", embedding=[0.0, 1.0]))
+
+    q = [1.0, 0.0]
+    query = (
+        (QB["embedding"].cosine(q) < 0.5)
+        .sort(QB["embedding"].cosine(q))
+        .limit(10)
+        .build()
+    )
+    results = mgr.list_resources(query, returns=["data"])
+    titles = [r.data.title for r in results]
+    assert titles == ["aligned", "close"]
+    assert "orthogonal" not in titles
+
+
+# UPD1: update() reuses the cached vector when content + encoder are unchanged
+def test_int_update_cache_reuse() -> None:
+    class Doc(Struct):
+        title: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+    call_count = 0
+
+    def counting_encoder(text: str) -> list[float]:
+        nonlocal call_count
+        call_count += 1
+        return [float(len(text)), float(ord(text[0]))]
+
+    spec = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(vector_encoders={"stub": counting_encoder})
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    info = mgr.create(Doc(title="t1", summary=Embedding(content="hello")))
+    assert call_count == 1
+
+    # Update changes title but not summary.content → encoder must not be called again
+    mgr.update(
+        info.resource_id,
+        Doc(title="t2", summary=Embedding(content="hello")),
+    )
+    assert call_count == 1  # cache reuse worked
+
+    # Changing content triggers re-encoding
+    mgr.update(
+        info.resource_id,
+        Doc(title="t2", summary=Embedding(content="goodbye")),
+    )
+    assert call_count == 2
+
+
+# INT5: add_model on a postgres backend auto-creates the pgvector column + index
+def test_int_add_model_creates_pgvector_column() -> None:
+    import psycopg2
+
+    from specstar import BackendBinding, BackendConfig
+
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=2, distance="cosine")]
+
+    # Unique table prefix per-test
+    import uuid as _uuid
+
+    table_prefix = f"int_v_{_uuid.uuid4().hex[:6]}_"
+
+    spec = SpecStar(
+        default_user="tester",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(
+        backend=BackendConfig(
+            meta=BackendBinding(
+                type="postgres",
+                options={
+                    "dsn": "postgresql://admin:password@localhost:5432/your_database",
+                    "table_prefix": table_prefix,
+                },
+            ),
+            resource=BackendBinding(type="memory"),
+            blob=BackendBinding(type="memory"),
+        ),
+    )
+    spec.add_model(Doc)
+
+    try:
+        # vec_embedding column + HNSW index must exist
+        table_name = f"{table_prefix}doc_meta"
+        conn = psycopg2.connect(
+            "postgresql://admin:password@localhost:5432/your_database"
+        )
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT udt_name FROM information_schema.columns
+                WHERE table_name='{table_name}' AND column_name='vec_embedding'
+                """
+            )
+            row = cur.fetchone()
+            assert row is not None and row[0] == "vector"
+            cur.execute(
+                f"""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename='{table_name}' AND indexname LIKE '%embedding%hnsw'
+                """
+            )
+            assert cur.fetchone() is not None
+        conn.close()
+    finally:
+        # cleanup table
+        conn = psycopg2.connect(
+            "postgresql://admin:password@localhost:5432/your_database"
+        )
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{table_prefix}doc_meta" CASCADE')
+        conn.close()
+
+
+# INT6: e2e on pg — create rows with Embedding, query with QB cosine via str
+def test_int_pg_e2e_embedding_with_str_query() -> None:
+    import psycopg2
+    import uuid as _uuid
+
+    from specstar import BackendBinding, BackendConfig
+    from specstar.query import QB
+
+    def stub_embed(text: str) -> list[float]:
+        if "near" in text or "hello" in text:
+            return [1.0, 0.0]
+        if "far" in text or "orthogonal" in text:
+            return [0.0, 1.0]
+        return [0.7, 0.7]
+
+    class Doc(Struct):
+        title: str
+        summary: Annotated[Embedding, Vector(dim=2, encoder="stub")]
+
+    table_prefix = f"int_pg_e2e_{_uuid.uuid4().hex[:6]}_"
+    spec = SpecStar(
+        default_user="t",
+        default_now=lambda: dt.datetime(2026, 5, 22),
+    )
+    spec.configure(
+        backend=BackendConfig(
+            meta=BackendBinding(
+                type="postgres",
+                options={
+                    "dsn": "postgresql://admin:password@localhost:5432/your_database",
+                    "table_prefix": table_prefix,
+                },
+            ),
+            resource=BackendBinding(type="memory"),
+            blob=BackendBinding(type="memory"),
+        ),
+        vector_encoders={"stub": stub_embed},
+    )
+    spec.add_model(Doc)
+    mgr = spec.get_resource_manager(Doc)
+
+    try:
+        mgr.create(Doc(title="hello-row", summary=Embedding(content="hello world")))
+        mgr.create(Doc(title="orthogonal-row", summary=Embedding(content="orthogonal text")))
+
+        # Query via str, runs through encoder, dispatched to pgvector SQL
+        q = (QB["summary"].cosine("near_query") < 0.3).build()
+        results = mgr.list_resources(q, returns=["data"])
+        titles = [r.data.title for r in results]
+        assert "hello-row" in titles
+        assert "orthogonal-row" not in titles
+    finally:
+        conn = psycopg2.connect(
+            "postgresql://admin:password@localhost:5432/your_database"
+        )
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{table_prefix}doc_meta" CASCADE')
+        conn.close()

--- a/tests/test_vector_marker.py
+++ b/tests/test_vector_marker.py
@@ -1,0 +1,135 @@
+"""Tests for the ``Vector`` annotation marker and ``extract_vectors`` helper."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from msgspec import Struct
+
+from specstar.types import Vector, extract_vectors
+
+
+class _FakeEmbedding(Struct):
+    """Placeholder representing the future Embedding type, used by B7."""
+
+    content: str
+
+
+# B1: tracer
+def test_vector_dim_only_defaults() -> None:
+    v = Vector(dim=1536)
+    assert v.dim == 1536
+    assert v.distance is None
+    assert v.encoder is None
+
+
+# B2: full params carried
+def test_vector_full_params() -> None:
+    v = Vector(dim=1536, distance="cosine", encoder="openai_small")
+    assert v.dim == 1536
+    assert v.distance == "cosine"
+    assert v.encoder == "openai_small"
+
+
+# B3: extract_vectors single field
+def test_extract_vectors_single_field() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float], Vector(dim=1536, distance="cosine")]
+
+    pairs = extract_vectors(Doc)
+    assert len(pairs) == 1
+    name, marker = pairs[0]
+    assert name == "embedding"
+    assert marker.dim == 1536
+    assert marker.distance == "cosine"
+
+
+# B4: extract_vectors preserves definition order
+def test_extract_vectors_preserves_order() -> None:
+    class Doc(Struct):
+        title: str
+        body_vec: Annotated[list[float], Vector(dim=3072)]
+        author: str
+        title_vec: Annotated[list[float], Vector(dim=512)]
+
+    pairs = extract_vectors(Doc)
+    assert [name for name, _ in pairs] == ["body_vec", "title_vec"]
+    assert pairs[0][1].dim == 3072
+    assert pairs[1][1].dim == 512
+
+
+# B5: extract_vectors empty when no annotations
+def test_extract_vectors_empty() -> None:
+    class Plain(Struct):
+        title: str
+        age: int
+
+    assert extract_vectors(Plain) == []
+
+
+# B6: extract_vectors handles nullable list[float] | None
+def test_extract_vectors_nullable() -> None:
+    class Doc(Struct):
+        title: str
+        embedding: Annotated[list[float] | None, Vector(dim=1536)] = None
+
+    pairs = extract_vectors(Doc)
+    assert len(pairs) == 1
+    name, marker = pairs[0]
+    assert name == "embedding"
+    assert marker.dim == 1536
+
+
+# B7: extract_vectors works on any inner type (Embedding placeholder)
+def test_extract_vectors_arbitrary_inner_type() -> None:
+    class Doc(Struct):
+        summary: Annotated[_FakeEmbedding, Vector(dim=1536, encoder="openai_small")]
+
+    pairs = extract_vectors(Doc)
+    assert len(pairs) == 1
+    name, marker = pairs[0]
+    assert name == "summary"
+    assert marker.encoder == "openai_small"
+
+
+# B8: Vector(dim<=0) raises
+@pytest.mark.parametrize("bad_dim", [0, -1, -1536])
+def test_vector_rejects_non_positive_dim(bad_dim: int) -> None:
+    with pytest.raises(ValueError):
+        Vector(dim=bad_dim)
+
+
+# B9: Vector(distance=invalid) raises; valid values stay accepted
+def test_vector_rejects_invalid_distance() -> None:
+    with pytest.raises(ValueError):
+        Vector(dim=1536, distance="bogus")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("good_distance", ["cosine", "l2", "ip", None])
+def test_vector_accepts_known_distances(good_distance) -> None:
+    v = Vector(dim=1536, distance=good_distance)
+    assert v.distance == good_distance
+
+
+# B10: __eq__ and __hash__ consistency — usable as dict / set keys
+def test_vector_equality_and_hash() -> None:
+    a = Vector(dim=1536, distance="cosine", encoder="openai_small")
+    b = Vector(dim=1536, distance="cosine", encoder="openai_small")
+    c = Vector(dim=1536, distance="cosine", encoder="openai_large")  # different encoder
+    d = Vector(dim=512, distance="cosine", encoder="openai_small")  # different dim
+
+    # equal Vectors compare equal and hash the same
+    assert a == b
+    assert hash(a) == hash(b)
+
+    # different Vectors are not equal
+    assert a != c
+    assert a != d
+
+    # usable in a set: duplicates collapse
+    assert len({a, b, c, d}) == 3
+
+    # non-Vector comparison returns NotImplemented → False
+    assert a != "not a vector"

--- a/tests/test_vector_query_types.py
+++ b/tests/test_vector_query_types.py
@@ -1,0 +1,93 @@
+"""Tests for vector-aware additions to query_types.py."""
+
+from __future__ import annotations
+
+from specstar.query_types import (
+    DataSearchOperator,
+    ResourceMetaSortDirection,
+    VectorDistanceCondition,
+    VectorDistanceSort,
+)
+
+
+# VC1: VectorDistanceCondition constructs with required fields
+def test_vector_distance_condition_constructs() -> None:
+    cond = VectorDistanceCondition(
+        field_path="embedding",
+        query_vector=[0.1, 0.2, 0.3],
+        operator=DataSearchOperator.less_than,
+        threshold=0.3,
+    )
+    assert cond.field_path == "embedding"
+    assert cond.query_vector == [0.1, 0.2, 0.3]
+    assert cond.operator == DataSearchOperator.less_than
+    assert cond.threshold == 0.3
+    assert cond.distance is None  # default
+
+
+# VC2: query_vector accepts a str (will be encoded at query time)
+def test_vector_distance_condition_accepts_str() -> None:
+    cond = VectorDistanceCondition(
+        field_path="embedding",
+        query_vector="hello world",
+        operator=DataSearchOperator.less_than,
+        threshold=0.3,
+        distance="cosine",
+    )
+    assert cond.query_vector == "hello world"
+    assert cond.distance == "cosine"
+
+
+# VC3: VectorDistanceSort defaults to ascending
+def test_vector_distance_sort_defaults_ascending() -> None:
+    s = VectorDistanceSort(
+        field_path="embedding",
+        query_vector=[0.1, 0.2, 0.3],
+    )
+    assert s.field_path == "embedding"
+    assert s.query_vector == [0.1, 0.2, 0.3]
+    assert s.direction == ResourceMetaSortDirection.ascending
+    assert s.distance is None
+
+
+# VC4: ResourceMetaSearchQuery accepts vector primitives in conditions/sorts
+def test_resource_meta_search_query_accepts_vector_primitives() -> None:
+    from specstar.query_types import (
+        DataSearchCondition,
+        ResourceMetaSearchQuery,
+    )
+
+    q = ResourceMetaSearchQuery(
+        conditions=[
+            DataSearchCondition(
+                field_path="doctype",
+                operator=DataSearchOperator.equals,
+                value="abc",
+            ),
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[0.1, 0.2, 0.3, 0.4],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+            ),
+        ],
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding",
+                query_vector=[0.1, 0.2, 0.3, 0.4],
+            ),
+        ],
+        limit=10,
+    )
+    assert len(q.conditions) == 2
+    assert isinstance(q.conditions[1], VectorDistanceCondition)
+    assert isinstance(q.sorts[0], VectorDistanceSort)
+
+    # round-trip through msgspec — proves the union is correctly declared,
+    # not just accepted by Python at construction time
+    import msgspec
+
+    encoded = msgspec.json.encode(q)
+    decoded = msgspec.json.decode(encoded, type=type(q))
+    assert isinstance(decoded.conditions[1], VectorDistanceCondition)
+    assert isinstance(decoded.sorts[0], VectorDistanceSort)


### PR DESCRIPTION
Vector similarity search becomes a first-class SpecStar feature. Two annotation
patterns — raw `list[float]` and a high-level `Embedding(content, vector,
content_hash, encoder_id)` struct — wire into the existing `add_model` flow.
The pgvector backend handles native indexing; every other backend transparently
falls back to brute-force Python comparison so dev and CI work without
infrastructure.

## Summary

- **Annotation marker**: `Vector(dim, distance, encoder)` on `list[float]` or
  `Embedding` fields. `Embedding(content="...")` triggers auto-encoding at write
  time; the framework reuses the previous revision's vector when content and
  encoder are unchanged (`xxh3_128` cache key).
- **Query primitives**: `VectorDistanceCondition` and `VectorDistanceSort`
  slot into `ResourceMetaSearchQuery.conditions` / `.sorts` and compose
  freely with scalar conditions / sorts. QB adds
  `QB["field"].cosine(q) / .l2(q) / .ip(q)`; `q` is `list[float]` **or**
  `str` (strings go through the registered encoder at query time).
- **Backend matrix**:
  - `postgres` + pgvector → native `vector(N)` column with HNSW index, SQL
    `<=>` / `<->` / `<#>`. `dim > 2000` truncates to the HNSW limit
    (Matryoshka-prefix strategy) with a startup warning.
  - Memory / disk / sqlite / etc. → brute-force Python comparison.
  - `IMetaStore.supports_native_vector_search` flag drives the dispatch.
- **Encoder registry** with override hierarchy: `Vector(encoder=...)` >
  `add_model(vector_encoders=...)` > `spec.configure(vector_encoders=...)`.
  Sync / async encoders both supported on the write path; sync only on the
  query path (clear error if you mix).
- **OpenAPI**: `x-vector-dim`, `x-vector-distance`, `x-vector-encoder-id`
  custom extensions on vector field properties.
- **CLI**: `specstar backfill-vectors --spec module:attr --model NAME --field F`
  re-encodes existing rows; only Embedding fields (raw vectors have no
  recomputable source).

## Notable design choices

- **Implicit unwrap on Embedding fields**: `QB["summary"].cosine(q)` works
  even though the value lives at `summary.vector`. Achieved via a new
  `IndexableField.index_key` field so the extractor reads from
  `"summary.vector"` but exposes the value under the short alias
  `"summary"` in `indexed_data`.
- **Atomic write semantics**: encoder exceptions propagate, no partial state.
- **Cache reuse**: only `(content_hash, encoder_id)` together skip re-encoding,
  so swapping encoders correctly invalidates all rows on next write.
- **SpecStar ships no embedding model.** Users wire their own encoder
  (`Callable[[str], list[float]]`); docs include concrete OpenAI /
  sentence-transformers / HuggingFace Inference API examples.

## Files

- `specstar/types.py` — `Vector`, `Embedding`, `VectorFieldInfo`,
  `extract_vector_field_infos`, `IndexableField.index_key`
- `specstar/query_types.py`, `specstar/query.py` —
  `VectorDistanceCondition` / `Sort`, QB `cosine/l2/ip`
- `specstar/util/vector_distance.py` — sync cosine/l2/ip helpers
- `specstar/resource_manager/`
  - `vector_validator.py` (`VectorDimValidator`, `CompositeValidator`)
  - `encoder_registry.py` (`EncoderRegistry`, `lookup_encoder` with override
    hierarchy)
  - `embedding_processor.py` (sync + async, cache reuse via previous revision)
  - `backfill.py` (`backfill_vectors`)
  - `meta_store/postgres.py` — pgvector DDL + SQL translation + capability
    detection
  - `basic.py` — brute-force matcher / sort handler + capability flag
  - `core.py` — `ResourceManager` wires processor + str-query resolution into
    `create / update / modify / search_resources / count_resources`
- `specstar/crud/`
  - `core.py` — `add_model` auto-mounts `VectorDimValidator`, augments
    `indexed_fields`, runs `ensure_vector_column` when backend is native
  - `openapi_builder.py` — `x-vector-*` injection
- `specstar/cli/_backfill.py` — `backfill-vectors` subcommand
- `docs/en/howto/vector-search.md`, `docs/en/concepts/vector-and-embedding.md`,
  `docs/design/add-vector-plan.md`

## Test plan

- [x] 81 new unit / integration tests, all green
  - annotation extraction (`test_vector_marker.py`, `test_vector_field_info.py`)
  - `Embedding` struct (`test_embedding_type.py`)
  - dim validator (`test_vector_dim_validator.py`)
  - encoder registry + override hierarchy (`test_encoder_registry.py`)
  - embedding processor sync + async + cache reuse + error propagation
    (`test_embedding_processor.py`)
  - query schema + JSON round-trip (`test_vector_query_types.py`)
  - QB cosine / l2 / ip / sort / composition (`test_qb_vector.py`)
  - brute-force memory backend filter + sort + missing-vector handling
    (`test_brute_force_vector.py`)
  - PostgresMetaStore + pgvector: capability flag, DDL, SQL filter, SQL sort,
    `dim > 2000` truncation, scalar + vector composition
    (`test_postgres_pgvector.py`)
  - `add_model` integration: validator auto-mount, processor auto-mount,
    end-to-end QB cosine search, update cache reuse, pgvector column
    provisioning, e2e Embedding + str query through PG
    (`test_vector_integration.py`)
  - backfill helper + CLI (`test_backfill_vectors.py`,
    `test_backfill_cli.py`)
  - str → vector at query time (`test_str_query_vector.py`)
  - OpenAPI extension injection (`test_openapi_vector.py`)
  - every executable docs example
    (`test_docs_examples.py` — 8 tests covering TL;DR, raw vector,
    Embedding auto-fill, encoder hierarchy, QB composition, validation error
    format, cache reuse, l2 / ip metrics)
- [x] Full `tests/meta_store/` regression: **1053 passed, 11 skipped, 0
      failed** (PG + pgvector required for the new pg tests; available via the
      `pgvector/pgvector:pg16` Docker image).
- [x] `mkdocs build` clean for new pages.

## Out of scope (V2)

- Admin UI controls for vector fields (frontend, separate PR).
- GraphQL vector queries (SDL ergonomics for vector input deferred).
- `list[Embedding]` multi-vector fields per resource (pgvector indexing for
  array-of-vectors is a separate strategy).
- Auto-migration when `dim` or `distance` changes on an existing column
  (currently raises and asks for an explicit schema-version bump + backfill).
- Async encoder on the sync query path (raises a clear error today).

## Requirements added

- `xxhash >= 3.5.0` (already in `pyproject.toml`).
- For PG backend at runtime: pgvector extension on the server
  (`CREATE EXTENSION vector;`).
