### PR TITLE
align Data Versioning quickstart with the API + add get(include_deleted=) 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,19 +38,20 @@ jobs:
         run: uv sync --extra dev
 
       # Public-API contract tests (fast, no external services).
+      # ``-x`` stops at the first failure so the run fails fast.
       - name: Contract tests
-        run: uv run pytest tests/test_docs_contract.py -q
+        run: uv run pytest tests/test_docs_contract.py -q -x
 
       # Executable documentation: the ```python blocks in these files must run.
       # Expand the list as more pages are annotated (```python continuation / notest).
       - name: Documentation examples
-        run: uv run pytest --markdown-docs README.md -q
+        run: uv run pytest --markdown-docs README.md -q -x
 
       # Service-free unit + route tests. Integration tests (Postgres / S3 /
       # MinIO / RabbitMQ) are tagged via the root tests/conftest.py and
       # excluded here; benchmarks and known-slow tests are also excluded.
       - name: Unit + route tests (no external services)
-        run: uv run pytest -m "not integration and not benchmark and not slow" -q
+        run: uv run pytest -m "not integration and not benchmark and not slow" -q -x
 
   # Single status check that fans in from every required job above.
   # Make THIS the required check in branch protection — that way adding a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`ResourceManager.get(..., include_deleted=True)`** reads a revision of a
+  soft-deleted resource instead of raising `ResourceIsDeletedError`, mirroring
+  `get_meta(include_deleted=...)`. Defaults to `False`, so existing behavior is
+  unchanged. Fixes the Data Versioning quickstart, which showed inspecting an
+  old revision after a soft delete.
+
 ### Changed
 
 - **BREAKING — `resource_id` is rejected in request bodies (was silently

--- a/docs/en/quickstart/data-versioning.md
+++ b/docs/en/quickstart/data-versioning.md
@@ -141,12 +141,15 @@ This makes it easy to compare current and historical states of the same resource
 
 ## 4. List revision history
 
-You can inspect the full revision history of a resource:
+You can inspect the full revision history of a resource. `list_revisions()`
+returns the revision **id strings**; use `get_revision_info()` to fetch the
+metadata (created time, author, …) for each one:
 
 ```python
-revision_list = mgr.list_revisions(info.resource_id)
+revision_ids = mgr.list_revisions(info.resource_id)
 
-for rev in revision_list:
+for revision_id in revision_ids:
+    rev = mgr.get_revision_info(info.resource_id, revision_id=revision_id)
     print(rev.revision_id, rev.created_time, rev.created_by)
 ```
 
@@ -163,16 +166,22 @@ This is useful for:
 Deleting a resource does not have to mean losing it forever.
 
 The resource is not physically removed — a new revision marks it as deleted.
+`delete()` returns the resource's `ResourceMeta` (now with `is_deleted=True`),
+not a `RevisionInfo`:
 
 ```python
-deleted_info = mgr.delete(info.resource_id)
-print(deleted_info.revision_id)
+deleted_meta = mgr.delete(info.resource_id)
+print(deleted_meta.is_deleted, deleted_meta.current_revision_id)
 ```
 
-You can still inspect older revisions if needed:
+You can still inspect older revisions if needed. Reading any revision of a
+soft-deleted resource requires `include_deleted=True` (the same flag
+`get_meta()` accepts); without it `get()` raises `ResourceIsDeletedError`:
 
 ```python
-old_issue = mgr.get(info.resource_id, revision_id=info.revision_id)
+old_issue = mgr.get(
+    info.resource_id, revision_id=info.revision_id, include_deleted=True
+)
 print(old_issue.data)
 ```
 
@@ -266,8 +275,9 @@ old_issue = mgr.get(info.resource_id, revision_id=info.revision_id)
 print("latest issue:", latest_issue.data)
 print("old issue:", old_issue.data)
 
-revision_list = mgr.list_revisions(info.resource_id)
-for rev in revision_list:
+revision_ids = mgr.list_revisions(info.resource_id)
+for revision_id in revision_ids:
+    rev = mgr.get_revision_info(info.resource_id, revision_id=revision_id)
     print("history:", rev.revision_id, rev.created_time, rev.created_by)
 ```
 

--- a/specstar/events.py
+++ b/specstar/events.py
@@ -196,6 +196,7 @@ _get_context: list[_DefstructField] = [
     ("resource_id", str),
     ("revision_id", str | UnsetType, UNSET),
     ("schema_version", str | None | UnsetType, UNSET),
+    ("include_deleted", bool, False),
 ]
 
 BeforeGet = defstruct(

--- a/specstar/events.pyi
+++ b/specstar/events.pyi
@@ -173,6 +173,7 @@ class BeforeGet(Struct, kw_only=True, tag=True, tag_field="context_type"):
     resource_id: str
     revision_id: str | UnsetType = UNSET
     schema_version: str | None | UnsetType = UNSET
+    include_deleted: bool = False
 
 class AfterGet(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -183,6 +184,7 @@ class AfterGet(Struct, kw_only=True, tag=True, tag_field="context_type"):
     resource_id: str
     revision_id: str | UnsetType = UNSET
     schema_version: str | None | UnsetType = UNSET
+    include_deleted: bool = False
 
 class OnSuccessGet(
     Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"
@@ -195,6 +197,7 @@ class OnSuccessGet(
     resource_id: str
     revision_id: str | UnsetType = UNSET
     schema_version: str | None | UnsetType = UNSET
+    include_deleted: bool = False
     resource: Resource[T]
 
 class OnFailureGet(Struct, kw_only=True, tag=True, tag_field="context_type"):
@@ -208,6 +211,7 @@ class OnFailureGet(Struct, kw_only=True, tag=True, tag_field="context_type"):
     resource_id: str
     revision_id: str | UnsetType = UNSET
     schema_version: str | None | UnsetType = UNSET
+    include_deleted: bool = False
 
 class BeforeGetMeta(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["before"] = "before"

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2054,6 +2054,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         *,
         revision_id: str | UnsetType = UNSET,
         schema_version: str | None | UnsetType = UNSET,
+        include_deleted: bool = False,
     ) -> Resource[T]:
         """
         Get a resource by its ID.
@@ -2062,16 +2063,21 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             resource_id (str): The ID of the resource to retrieve.
             revision_id (str | UnsetType): (Optional) The specific revision ID to retrieve. If not set, retrieves the latest revision.
             schema_version (str | None | UnsetType): (Optional) The schema version of the resource.
+            include_deleted (bool): If True, return the requested revision even
+                for a soft-deleted resource instead of raising
+                ``ResourceIsDeletedError``. Mirrors ``get_meta()``. Defaults to
+                ``False`` so existing behavior is unchanged.
 
         Returns:
             resource (Resource[T]): The resource object containing both data and metadata.
 
         Raises:
             ResourceIDNotFoundError: If the resource ID or revision ID does not exist.
-            ResourceIsDeletedError: If the resource has been soft-deleted.
+            ResourceIsDeletedError: If the resource has been soft-deleted and
+                *include_deleted* is ``False``.
         """
         if revision_id is UNSET or schema_version is UNSET:
-            meta = self.get_meta(resource_id)
+            meta = self.get_meta(resource_id, include_deleted=include_deleted)
             if revision_id is UNSET:
                 revision_id = meta.current_revision_id
             if schema_version is UNSET:

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -1095,6 +1095,7 @@ class IResourceManager(ABC, Generic[T]):
         *,
         revision_id: str | UnsetType = UNSET,
         schema_version: str | None | UnsetType = UNSET,
+        include_deleted: bool = False,
     ) -> Resource[T]:
         """Get the current revision of the resource.
 
@@ -1102,12 +1103,17 @@ class IResourceManager(ABC, Generic[T]):
             resource_id (str): the id of the resource to get.
             revision_id (str | UnsetType): the id of a specific revision to get.
               If UNSET, the current revision is returned.
+            include_deleted (bool): if True, return the requested revision even
+              for a soft-deleted resource instead of raising
+              ``ResourceIsDeletedError``. Mirrors ``get_meta()``. Defaults to
+              ``False``.
         Returns:
             resource (Resource[T]): the resource with its data and revision info.
 
         Raises:
             ResourceIDNotFoundError: if resource id does not exist.
-            ResourceIsDeletedError: if resource is soft-deleted.
+            ResourceIsDeletedError: if resource is soft-deleted and
+              *include_deleted* is ``False``.
 
         ---
 
@@ -1116,9 +1122,11 @@ class IResourceManager(ABC, Generic[T]):
 
         This method will raise different exceptions based on the resource state:
         - ResourceIDNotFoundError: The resource ID does not exist in storage
-        - ResourceIsDeletedError: The resource exists but is marked as deleted (is_deleted=True)
+        - ResourceIsDeletedError: The resource exists but is marked as deleted
+          (is_deleted=True) and *include_deleted* is False
 
-        For soft-deleted resources, use restore() first to make them accessible again.
+        To read a soft-deleted resource's revision pass ``include_deleted=True``,
+        or use ``restore()`` first to make it accessible again.
         """
 
     @abstractmethod

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from msgspec import Struct
 
-from specstar import SpecStar, Schema
+from specstar import Schema, SpecStar
 from specstar.backend import DiskStorageFactory
 from specstar.crud.route_templates.migrate import MigrateRouteTemplate
 
@@ -114,3 +114,79 @@ def test_breaking_migration_then_rollback(tmp_path):
     rm.migrate(rid, revision_id=oldest)
     rm.switch(rid, oldest)
     assert rm.get(rid).data.name == "Bob"
+
+
+# --- Data Versioning quickstart (docs/en/quickstart/data-versioning.md) ---
+
+
+class _Doc(Struct):
+    title: str
+    body: str = ""
+
+
+def _doc_mgr(tmp_path):
+    sp = _fresh(tmp_path)
+    app = FastAPI()
+    sp.add_model(Schema(_Doc, "v1"))
+    sp.apply(app)
+    return sp.get_resource_manager(_Doc)
+
+
+def test_get_old_revision_after_soft_delete_with_include_deleted(tmp_path):
+    """§5: after a soft delete you can still read an older revision via
+    ``get(..., include_deleted=True)``."""
+    rm = _doc_mgr(tmp_path)
+    info = rm.create(_Doc(title="Onboarding", body="v1"))
+    rm.update(info.resource_id, _Doc(title="Onboarding", body="v2"))
+    rm.delete(info.resource_id)
+
+    old = rm.get(
+        info.resource_id, revision_id=info.revision_id, include_deleted=True
+    )
+    assert old.data.body == "v1"
+
+
+def test_get_after_soft_delete_still_raises_by_default(tmp_path):
+    """Back-compat: ``include_deleted`` defaults to False, so reading a
+    soft-deleted resource still raises (no behavior change)."""
+    from specstar.types import ResourceIsDeletedError
+
+    rm = _doc_mgr(tmp_path)
+    info = rm.create(_Doc(title="Onboarding", body="v1"))
+    rm.delete(info.resource_id)
+
+    with pytest.raises(ResourceIsDeletedError):
+        rm.get(info.resource_id, revision_id=info.revision_id)
+
+
+def test_list_revisions_returns_ids_and_get_revision_info(tmp_path):
+    """§4: list_revisions() returns revision-id *strings*; rich per-revision
+    metadata (revision_id / created_time / created_by) comes from
+    get_revision_info()."""
+    rm = _doc_mgr(tmp_path)
+    info = rm.create(_Doc(title="t", body="v1"))
+    rm.update(info.resource_id, _Doc(title="t", body="v2"))
+
+    rev_ids = rm.list_revisions(info.resource_id)
+    assert len(rev_ids) == 2
+    assert all(isinstance(rid, str) for rid in rev_ids)
+
+    rev = rm.get_revision_info(info.resource_id, revision_id=rev_ids[0])
+    assert isinstance(rev.revision_id, str)
+    assert rev.created_time is not None
+    assert isinstance(rev.created_by, str)
+
+
+def test_delete_returns_resource_meta_not_revision_info(tmp_path):
+    """§5: delete() returns a ResourceMeta (is_deleted=True) — it has
+    current_revision_id, not a .revision_id."""
+    from specstar.types import ResourceMeta
+
+    rm = _doc_mgr(tmp_path)
+    info = rm.create(_Doc(title="t", body="v1"))
+    meta = rm.delete(info.resource_id)
+
+    assert isinstance(meta, ResourceMeta)
+    assert meta.is_deleted is True
+    assert isinstance(meta.current_revision_id, str)
+    assert not hasattr(meta, "revision_id")


### PR DESCRIPTION
  Three doc/reality mismatches reported on the Data Versioning quickstart:
  
  1. list_revisions() returns revision-id strings, not objects — the doc
     iterated `rev.revision_id`. Iterate ids and fetch RevisionInfo via
     get_revision_info() (docs §4 + appendix).
  2. delete() returns ResourceMeta (no .revision_id) — print is_deleted /
     current_revision_id instead (docs §5).
  3. Reading an old revision after a soft delete raised ResourceIsDeletedError
     and get() had no include_deleted (only get_meta did). Add
     get(..., include_deleted=True), default False so existing behavior is
     unchanged; thread it through get_meta and the Get event contexts.
  
  Guard all three patterns in tests/test_docs_contract.py (run in CI).