### PR TITLE
Production-hardening pass: audit fields, RFC 7386 PATCH, list-scan safety nets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Programmatic writes without an operation context now fall back to
+  `anonymous` + `now()` (non-strict mode).** `ResourceManager.create()` /
+  `update()` / `modify()` / etc. called without a `using()` context and with no
+  configured `default_user` / `default_now` previously leaked a raw
+  `LookupError`; they now record `created_by="anonymous"` and the current UTC
+  time — the same values an unauthenticated HTTP request produces. Set
+  `strict_operation_context=True` to restore the hard failure (a friendly
+  `MissingOperationContextError`).
 - **`add_model(default_user=...)` now propagates to HTTP audit fields.**
   Resources created over HTTP for that model record the per-model
   `created_by` / `updated_by` instead of `"anonymous"`. Precedence: a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `get_meta(include_deleted=...)`. Defaults to `False`, so existing behavior is
   unchanged. Fixes the Data Versioning quickstart, which showed inspecting an
   old revision after a soft delete.
+- **RFC 7386 JSON Merge Patch support.** `PATCH` now accepts a partial-update
+  object (e.g. `{"qty": 50}`) in addition to RFC 6902 JSON Patch (the op array).
+  The same endpoint disambiguates by explicit `Content-Type`
+  (`application/merge-patch+json` vs `application/json-patch+json`) or, for a
+  generic `application/json`, by body shape (object → merge, array → ops).
+  Previously a partial object returned `400`; this is additive (error → success).
+  Programmatically, `ResourceManager.patch()` and `.modify()` now accept a
+  `MergePatch(...)` (new, exported from `specstar`) alongside a `JsonPatch`,
+  mirroring the RFC 6902 path — the HTTP route delegates to these.
+- **`ResourceManager.iter_all(query=None, *, batch_size=1000)`** yields every
+  matching resource by paging internally, so a full scan can never silently
+  truncate (unlike a `search`/list bounded by `limit`).
+- **List truncation signals on `GET /{model}`**: an always-present `X-Has-More`
+  header (computed cheaply via a limit+1 probe) and an opt-in `X-Total-Count`
+  header (`?with_total=true`). The response body is unchanged (a bare array).
+- **`SpecStarWarning`** advisory category, emitted once at `apply()` when
+  permissive defaults are left in place: `forbid_unknown_fields` off, or no
+  `SPECSTAR_DEFAULT_QUERY_LIMIT` configured. Silence via standard `warnings`
+  filters.
+- **Production Hardening guide** section consolidating the above into one
+  copy-pasteable baseline (`docs/en/guides/from-demo-to-production.md`).
 
 ### Changed
 
+- **`add_model(default_user=...)` now propagates to HTTP audit fields.**
+  Resources created over HTTP for that model record the per-model
+  `created_by` / `updated_by` instead of `"anonymous"`. Precedence: a real
+  `get_user` (authentication) > per-model `default_user` > global
+  `configure(default_user=...)` > `"anonymous"`. Only affects apps that set a
+  per-model `default_user` (others are unchanged).
 - **BREAKING — `resource_id` is rejected in request bodies (was silently
   dropped).** Sending `resource_id` in a `POST` / `PUT` body, or targeting
   `/resource_id` in a `PATCH` op, now returns **`422`** instead of `200`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [0.11.1] — 2026-05-23
 
 ### Added
 
@@ -16,44 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `get_meta(include_deleted=...)`. Defaults to `False`, so existing behavior is
   unchanged. Fixes the Data Versioning quickstart, which showed inspecting an
   old revision after a soft delete.
-- **RFC 7386 JSON Merge Patch support.** `PATCH` now accepts a partial-update
-  object (e.g. `{"qty": 50}`) in addition to RFC 6902 JSON Patch (the op array).
-  The same endpoint disambiguates by explicit `Content-Type`
-  (`application/merge-patch+json` vs `application/json-patch+json`) or, for a
-  generic `application/json`, by body shape (object → merge, array → ops).
-  Previously a partial object returned `400`; this is additive (error → success).
-  Programmatically, `ResourceManager.patch()` and `.modify()` now accept a
-  `MergePatch(...)` (new, exported from `specstar`) alongside a `JsonPatch`,
-  mirroring the RFC 6902 path — the HTTP route delegates to these.
-- **`ResourceManager.iter_all(query=None, *, batch_size=1000)`** yields every
-  matching resource by paging internally, so a full scan can never silently
-  truncate (unlike a `search`/list bounded by `limit`).
-- **List truncation signals on `GET /{model}`**: an always-present `X-Has-More`
-  header (computed cheaply via a limit+1 probe) and an opt-in `X-Total-Count`
-  header (`?with_total=true`). The response body is unchanged (a bare array).
-- **`SpecStarWarning`** advisory category, emitted once at `apply()` when
-  permissive defaults are left in place: `forbid_unknown_fields` off, or no
-  `SPECSTAR_DEFAULT_QUERY_LIMIT` configured. Silence via standard `warnings`
-  filters.
-- **Production Hardening guide** section consolidating the above into one
-  copy-pasteable baseline (`docs/en/guides/from-demo-to-production.md`).
 
 ### Changed
 
-- **Programmatic writes without an operation context now fall back to
-  `anonymous` + `now()` (non-strict mode).** `ResourceManager.create()` /
-  `update()` / `modify()` / etc. called without a `using()` context and with no
-  configured `default_user` / `default_now` previously leaked a raw
-  `LookupError`; they now record `created_by="anonymous"` and the current UTC
-  time — the same values an unauthenticated HTTP request produces. Set
-  `strict_operation_context=True` to restore the hard failure (a friendly
-  `MissingOperationContextError`).
-- **`add_model(default_user=...)` now propagates to HTTP audit fields.**
-  Resources created over HTTP for that model record the per-model
-  `created_by` / `updated_by` instead of `"anonymous"`. Precedence: a real
-  `get_user` (authentication) > per-model `default_user` > global
-  `configure(default_user=...)` > `"anonymous"`. Only affects apps that set a
-  per-model `default_user` (others are unchanged).
 - **BREAKING — `resource_id` is rejected in request bodies (was silently
   dropped).** Sending `resource_id` in a `POST` / `PUT` body, or targeting
   `/resource_id` in a `PATCH` op, now returns **`422`** instead of `200`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,35 @@ perf: 效能優化
 - 為新功能添加範例
 - 更新 API 參考文檔
 
+### 變更紀錄（Changelog）
+
+`CHANGELOG.md` 的新版本區段由 [git-cliff](https://git-cliff.org/) 從
+**Conventional Commits** 自動生成,**不要直接手改尚未釋出的區段**(手寫的
+歷史區段 ≤ 0.11.1 會保留不動)。
+
+因此面向使用者的變更請用規範化的 commit 訊息,它才會進 changelog:
+
+```
+feat: 新增 XXX          → Added
+fix: 修復 XXX           → Fixed
+perf: 效能優化          → Performance
+refactor: 重構 XXX      → Changed
+docs: 文件             → Documentation
+```
+
+> **注意**:不符合格式的 commit(例如 `--`、`wip`)以及 `ci`/`chore`/`test`/
+> 合併 commit **會被忽略,不會出現在 changelog**。真正面向使用者的變更請務必
+> 用上面的前綴。
+
+```bash
+make changelog-preview          # 預覽尚未釋出的紀錄(從 commit 生成)
+```
+
+釋出時由維護者執行 `make release patch|minor|major`(版本由 git-cliff 依語意化
+規則自動算出),或 `make release VERSION=X.Y.Z` 指定明確版本。它會:bump
+`__version__` → 把尚未釋出的 commit 收成 `## [X.Y.Z]` 區段(插到既有歷史之前)
+→ commit `bump vX.Y.Z`。接著照原本流程打上 `vX.Y.Z` tag 並發佈。
+
 ## 開發工作流程
 
 ### 本地測試

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,37 @@ stubs-check:
 		exit 1)
 	@rm -f /tmp/events.pyi.expected
 
+# 預覽尚未釋出的變更紀錄（從 conventional commits 生成；非規範 commit 會被忽略）
+.PHONY: changelog-preview
+changelog-preview:
+	uv run git-cliff --unreleased
+
+# 釋出第一步:bump 版本 → 生成 CHANGELOG 區段 → commit "bump vX.Y.Z"。
+# 用法:  make release patch        # 0.11.1 → 0.11.2
+#        make release minor        # 0.11.1 → 0.12.0
+#        make release major        # 0.11.1 → 1.0.0
+#        make release VERSION=1.2.3 # 指定明確版本
+# 版本由 git-cliff 依語意化規則算出;之後接原本流程(打 tag → build → PyPI)。
+.PHONY: release patch minor major
+# patch/minor/major 是 release 的參數,被當成 no-op goal 消化掉
+patch minor major:
+	@:
+release:
+	@git diff --quiet && git diff --cached --quiet || { \
+		echo "工作區不乾淨,請先 commit 或 stash 再 release"; exit 1; }; \
+	bump="$(filter patch minor major,$(MAKECMDGOALS))"; \
+	if [ -n "$(VERSION)" ]; then new="$(VERSION)"; \
+	elif [ -n "$$bump" ]; then \
+		new="$$(uv run git-cliff --bumped-version --bump $$bump 2>/dev/null | tail -1 | sed 's/^v//')"; \
+	else echo "用法: make release patch|minor|major  或  make release VERSION=X.Y.Z"; exit 1; fi; \
+	[ -n "$$new" ] || { echo "無法決定版本"; exit 1; }; \
+	echo "release → v$$new"; \
+	sed -i "s/^__version__ = .*/__version__ = \"$$new\"/" specstar/__init__.py; \
+	uv run git-cliff --unreleased --tag "v$$new" --prepend CHANGELOG.md; \
+	git add specstar/__init__.py CHANGELOG.md; \
+	git commit -m "bump v$$new"; \
+	echo "✅ 已 commit \"bump v$$new\"。接著:git tag v$$new → build → 發佈。"
+
 # 清理所有暫存和構建文件
 .PHONY: clean
 clean: clean-dev clean-docs

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,58 @@
+# git-cliff configuration — generates CHANGELOG.md from Conventional Commits.
+# https://git-cliff.org/docs/configuration
+#
+# Commits that are NOT conventional (e.g. "--", "wip") are dropped, by design:
+# only feat/fix/perf/refactor/docs land in the changelog. See the Makefile
+# (`make changelog`, `make changelog-preview`) and CONTRIBUTING.md.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to SpecStar (formerly `autocrud`).
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+# The whole point of this setup: non-conventional commits are excluded.
+filter_unconventional = true
+filter_commits = true
+protect_breaking_commits = true
+tag_pattern = "v[0-9].*"
+# Collapse "(... #123)" footers in the subject to a clean "(#123)".
+commit_preprocessors = [
+  { pattern = '\\((\\w+\\s)?#([0-9]+)\\)', replace = "(#${2})" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^bump", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^test", skip = true },
+  { message = "^style", skip = true },
+  { message = "^Merge", skip = true },
+]

--- a/docs/en/guides/from-demo-to-production.md
+++ b/docs/en/guides/from-demo-to-production.md
@@ -135,7 +135,39 @@ interactive admin action.
 
 ---
 
-## 5. Production checklist
+## 5. Harden permissive defaults
+
+SpecStar's defaults favor flexibility. A few are worth tightening for an
+internal / production system, gathered here instead of scattered across pages:
+
+```python
+spec.configure(
+    forbid_unknown_fields=True,   # reject typo'd / unknown fields with 422
+                                  # instead of silently dropping them
+    default_user="svc",           # populate created_by/updated_by; or supply a real get_user
+)
+```
+
+Then, outside `configure()`:
+
+* **List page size** — set the `SPECSTAR_DEFAULT_QUERY_LIMIT` environment
+  variable to a finite number. The default is effectively unlimited, so one
+  `GET /{model}` can pull an entire table into memory. To scan everything
+  safely, use `mgr.iter_all(...)` or page on the `X-Has-More` response header
+  (add `?with_total=true` for an `X-Total-Count` header).
+* **Permanent delete** — lock `DELETE /{model}/{id}/permanently` behind
+  stricter permissions. It is **irreversible**, unlike soft delete + restore,
+  and the route differs from soft delete only by the `/permanently` suffix.
+* **Audit fields** — confirm `created_by` / `updated_by` are populated for real
+  users. `configure(default_user=...)` (or a real `get_user` dependency) wires
+  the HTTP user; `add_model(default_user=...)` overrides it for one model. A
+  real `get_user` always wins. Without either, writes record `"anonymous"`.
+
+If you start without these, SpecStar emits a one-time `SpecStarWarning` for the
+unset query limit and for `forbid_unknown_fields` being off — silence it via the
+standard `warnings` filters once you've made a deliberate choice.
+
+## 6. Production checklist
 
 Before calling a system production-ready, verify that:
 

--- a/docs/en/howto/api-conventions.md
+++ b/docs/en/howto/api-conventions.md
@@ -191,6 +191,42 @@ Route templates typically call `get_meta(...)` first, so `include_deleted` is a 
 
 ---
 
+## PATCH: two flavors
+
+`PATCH /{model}/{resource_id}` accepts **both** standard REST patch formats on
+the same endpoint:
+
+| Body shape | Standard | Meaning |
+|------------|----------|---------|
+| JSON **array** of ops | RFC 6902 (JSON Patch) | `[{"op":"replace","path":"/qty","value":50}]` |
+| JSON **object** | RFC 7386 (JSON Merge Patch) | `{"qty": 50}` — partial update; `null` deletes a field |
+
+Disambiguation:
+
+* If you send an explicit `Content-Type` it wins —
+  `application/json-patch+json` (6902) or `application/merge-patch+json` (7386).
+* Otherwise the **body shape** decides: array → 6902, object → 7386. The two
+  are structurally disjoint for object resources, so there's no ambiguity.
+
+The intuitive partial update (`PATCH {"qty": 50}`) therefore "just works" as a
+merge patch. A `PUT` remains a full replacement of the whole resource.
+
+Programmatically, both flavors are first-class manager operations — pass a
+`jsonpatch.JsonPatch` (6902) or a `MergePatch` (7386) to
+`ResourceManager.patch()` / `.modify()`:
+
+```python
+from specstar import MergePatch
+
+mgr.patch(rid, MergePatch({"qty": 50}))   # merge: keep other fields; null deletes
+```
+
+> A single stray RFC 6902 op sent as an object (e.g. `{"op": "replace", ...}`
+> without the surrounding array) returns `422` with a hint, rather than being
+> silently merged.
+
+---
+
 ## Revisions and mutability
 
 SpecStar has two update modes with different revision semantics:

--- a/docs/en/howto/gotchas.md
+++ b/docs/en/howto/gotchas.md
@@ -111,12 +111,19 @@ The one exception: if your Struct *legitimately* declares a field named
 |-----------------|-----------------|
 | `PUT /user/unknown-id` creates the user | Returns `404` — `PUT` requires the resource to exist. Use `POST /user` to create. |
 
-### `PATCH` requires a JSON Patch **array of ops**, not a partial object
+### `PATCH` accepts two flavors — pick by shape (array = ops, object = merge)
+
+`PATCH` understands **both** REST patch standards on the same endpoint:
 
 ```
-PATCH /user/123  {"name": "new"}                          # 400 "expected sequence of operations"
-PATCH /user/123  [{"op":"replace","path":"/name","value":"new"}]   # works
+PATCH /user/123  [{"op":"replace","path":"/name","value":"new"}]   # RFC 6902 JSON Patch (array)
+PATCH /user/123  {"name": "new"}                                   # RFC 7386 Merge Patch (object)
 ```
+
+A JSON **array** is treated as RFC 6902 operations; a JSON **object** is a
+RFC 7386 merge patch (partial update; `null` deletes a field). Set
+`Content-Type: application/json-patch+json` or `application/merge-patch+json`
+to be explicit. See [API conventions § PATCH](./api-conventions.md#patch-two-flavors).
 
 ### Same-content writes are de-duplicated
 

--- a/docs/en/howto/gotchas.md
+++ b/docs/en/howto/gotchas.md
@@ -192,16 +192,26 @@ spec.configure(admin="/admin")  # username "/admin" — almost certainly NOT wha
 
 The web admin UI is the separate TypeScript app under `wizard/`.
 
-### Programmatic `mgr.create/update/migrate/switch` need an operation context
+### Programmatic `mgr.create/update/...` use `anonymous` + `now()` if you don't set a user
 
-Without one, they raise `MissingOperationContextError` (which surfaces as
-a bare `LookupError` for the underlying `ContextVar`). Either:
+By default (non-strict) a programmatic write with no operation context records
+the same values an unauthenticated HTTP request would — `created_by="anonymous"`
+and the current UTC time — so it "just works". To attribute writes to a real
+user, set a default or wrap the call:
 
 ```python
 spec.configure(default_user="me", default_now=datetime.utcnow)
 # or, per-call
 with mgr.using(user="me", now=datetime.utcnow()):
     mgr.create(...)
+```
+
+If you'd rather a missing context be a hard error (no silent `anonymous`), opt
+into strict mode — then `create`/`update`/`migrate`/`switch` without a context
+raise `MissingOperationContextError`:
+
+```python
+spec.configure(strict_operation_context=True)
 ```
 
 ### `MigrateRouteTemplate` is opt-in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
 ]
 dev = [
     "coverage>=7.9.2",
+    "git-cliff>=2.0.0",
     "pytest>=8.4.1",
     "pytest-rerunfailures>=15.0",
     "ruff>=0.12.4",

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,13 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --strict-markers --strict-config --tb=short
-markers = 
+markers =
     slow: marks tests as slow
     integration: marks tests as integration tests
     benchmark: marks tests as benchmark tests that require external systems
+filterwarnings =
+    # SpecStar's permissive-default advisories are intentional at runtime but
+    # would flood the suite (most fixtures use the default config). The
+    # dedicated tests in test_startup_warnings.py still assert them via
+    # pytest.warns, which overrides this filter inside its own context.
+    ignore::specstar.types.SpecStarWarning

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -22,9 +22,9 @@ from specstar.types import (
     Embedding,
     IConstraintChecker,
     IValidator,
-    ValidationError,
     Job,
     JobRedirectInfo,
+    MergePatch,
     OnDelete,
     OnDuplicate,
     Ref,
@@ -33,6 +33,7 @@ from specstar.types import (
     SearchedResource,
     TaskStatus,
     Unique,
+    ValidationError,
     Vector,
 )
 
@@ -56,6 +57,7 @@ __all__ = [
     "Job",
     "JobRedirectInfo",
     "LoadStats",
+    "MergePatch",
     "OnDelete",
     "OnDuplicate",
     "QB",

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime as dt
 import inspect
 import logging
+import os
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
@@ -63,6 +64,7 @@ from specstar.permission.rbac import RBACPermissionChecker
 from specstar.permission.simple import AllowAll
 from specstar.query import Query
 from specstar.query_types import (
+    DEFAULT_QUERY_LIMIT_ENV_VAR,
     DataSearchCondition,
     DataSearchOperator,
     ResourceMetaSearchQuery,
@@ -98,6 +100,7 @@ from specstar.types import (
     ResourceIsDeletedError,
     RevisionInfo,
     RevisionStatus,
+    SpecStarWarning,
     TaskStatus,
     _RefInfo,
     extract_refs,
@@ -265,6 +268,13 @@ class SpecStar:
         self.message_queues: OrderedDict[str, IMessageQueue] = OrderedDict()
         self.model_names: dict[type, str | None] = {}
         self.relationships: list[_RefInfo] = []
+        # Per-model ``default_user`` set *explicitly* on ``add_model`` (not the
+        # global fallback). Used at ``apply()`` to give that model's routes a
+        # DependencyProvider whose default user is the per-model one, so the
+        # audit fields (created_by / updated_by) reflect it over HTTP.
+        self._model_default_user: dict[str, "str | Callable[[], str]"] = {}
+        # One-shot guard so re-``apply()`` doesn't repeat startup advisories.
+        self._emitted_startup_warnings = False
 
         # Initialize attributes with defaults before applying configuration
         self.storage_factory = MemoryStorageFactory()
@@ -1376,6 +1386,11 @@ class SpecStar:
             **other_options,
         )
         self.resource_managers[model_name] = resource_manager
+        # Remember an *explicit* per-model default_user so apply() can route
+        # it into this model's HTTP DependencyProvider (a real ``get_user``
+        # still wins; see DependencyProvider.with_default_user).
+        if default_user is not UNSET:
+            self._model_default_user[model_name] = default_user
 
         # If meta store supports native vector indexing, register pgvector
         # columns + HNSW indices for each Vector / Embedding field
@@ -1473,6 +1488,37 @@ class SpecStar:
 
         OpenAPIBuilder._promote_defs_to_components(schema)
 
+    def _warn_permissive_defaults(self) -> None:
+        """Emit one-shot advisories for permissive defaults left in place.
+
+        These surface the footguns on the *default* path — the operator most
+        at risk is the one who never opted into a safer setting. Each warning
+        uses :class:`SpecStarWarning` so it is easy to silence, and fires at
+        most once per instance.
+        """
+        if self._emitted_startup_warnings:
+            return
+        self._emitted_startup_warnings = True
+        if not self.forbid_unknown_fields:
+            warnings.warn(
+                "forbid_unknown_fields is off (the default): unknown / "
+                "misspelled fields in writes are silently dropped and the "
+                "request still succeeds. Set forbid_unknown_fields=True in "
+                "production.",
+                SpecStarWarning,
+                stacklevel=3,
+            )
+        if os.getenv(DEFAULT_QUERY_LIMIT_ENV_VAR) is None:
+            warnings.warn(
+                f"No {DEFAULT_QUERY_LIMIT_ENV_VAR} is configured: list "
+                "endpoints default to an effectively unlimited page size, so "
+                "a single GET can load an entire table. Set "
+                f"{DEFAULT_QUERY_LIMIT_ENV_VAR}, pass an explicit ?limit=, or "
+                "use iter_all() / the X-Has-More header to page safely.",
+                SpecStarWarning,
+                stacklevel=3,
+            )
+
     def apply(
         self,
         app: FastAPI | APIRouter,
@@ -1543,6 +1589,8 @@ class SpecStar:
               skipped (``APIRouter`` has no OpenAPI schema).
             - ``structs`` is ignored when ``app`` is not a ``FastAPI`` instance.
         """
+        self._warn_permissive_defaults()
+
         # Determine the target router for route generation. ``FastAPI``
         # is not an ``APIRouter``, but it owns one at ``.router``; the
         # downstream route templates only need an APIRouter-shaped
@@ -1576,11 +1624,24 @@ class SpecStar:
 
         self.route_templates.sort(key=lambda rt: rt.order)
         for model_name, resource_manager in self.resource_managers.items():
+            per_model_user = self._model_default_user.get(model_name)
             for route_template in self.route_templates:
+                # When this model declared its own ``default_user``, generate
+                # its routes with a DependencyProvider whose default user is
+                # that value, so HTTP-created revisions record it. A real
+                # ``get_user`` (auth) is never overridden — ``with_default_user``
+                # returns the provider unchanged in that case.
+                base_deps = getattr(route_template, "deps", None)
+                swap = per_model_user is not None and base_deps is not None
+                if swap:
+                    route_template.deps = base_deps.with_default_user(per_model_user)
                 try:
                     route_template.apply(model_name, resource_manager, target)
                 except Exception:
                     pass
+                finally:
+                    if swap:
+                        route_template.deps = base_deps
 
         # Register custom create action routes
         self._apply_create_actions(target)

--- a/specstar/crud/route_templates/patch.py
+++ b/specstar/crud/route_templates/patch.py
@@ -10,6 +10,7 @@ from specstar.crud.route_templates.basic import (
     BaseRouteTemplate,
     MsgspecResponse,
     jsonschema_to_json_schema_extra,
+    reject_resource_id_in_body,
     reject_resource_id_in_patch,
     struct_declares_resource_id,
     struct_to_responses_type,
@@ -18,6 +19,7 @@ from specstar.crud.route_templates.exception_handlers import to_http_exception
 from specstar.crud.route_templates.update import _check_precondition
 from specstar.types import (
     IResourceManager,
+    MergePatch,
     RevisionInfo,
     RevisionStatus,
 )
@@ -62,6 +64,54 @@ RFC6902 = (
     | RFC6902_Test
     | RFC6902_Copy
 )
+
+
+def _patch_flavor(content_type: str | None, body) -> str:
+    """Decide which PATCH flavor a request uses.
+
+    Explicit media types win (RFC 6902 ``application/json-patch+json`` vs
+    RFC 7386 ``application/merge-patch+json``). For a generic
+    ``application/json`` we disambiguate by shape: a JSON *array* is a 6902 op
+    list, a JSON *object* is a 7386 merge patch. The two are structurally
+    disjoint for object resources, so this is unambiguous.
+
+    Returns ``"merge"`` (RFC 7386) or ``"patch"`` (RFC 6902).
+    """
+    ct = (content_type or "").lower()
+    if "merge-patch+json" in ct:
+        return "merge"
+    if "json-patch+json" in ct:
+        return "patch"
+    return "merge" if isinstance(body, dict) else "patch"
+
+
+def _guard_merge_patch_body(body, content_type, struct_owns_resource_id) -> None:
+    """Validate an RFC 7386 merge-patch body before handing it to the manager.
+
+    HTTP-layer concerns only: reject ``resource_id`` in the body, and raise a
+    helpful ``422`` when an object looks like a stray RFC 6902 operation the
+    caller forgot to wrap in an array. The merge itself is the manager's job
+    (``patch`` / ``modify`` with a ``MergePatch``).
+    """
+    explicit_merge = "merge-patch+json" in (content_type or "").lower()
+    if (
+        not explicit_merge
+        and isinstance(body, dict)
+        and "op" in body
+        and "path" in body
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "This looks like a single JSON Patch (RFC 6902) operation. "
+                "RFC 6902 patches must be a JSON array of operations "
+                '(e.g. [{"op": "replace", "path": "/field", "value": ...}]). '
+                "For a partial update (RFC 7386 merge patch), send the changed "
+                "fields as an object without op/path keys."
+            ),
+        )
+    if not struct_owns_resource_id:
+        reject_resource_id_in_body(body)
 
 
 class PatchRouteTemplate(BaseRouteTemplate):
@@ -149,32 +199,51 @@ class PatchRouteTemplate(BaseRouteTemplate):
                     "optimistic concurrency)."
                 ),
             ),
+            content_type: str | None = Header(None, alias="Content-Type"),
         ):
-            from jsonpatch import JsonPatch
-
             if mode != "modify" and change_status is not None:
                 raise HTTPException(
                     status_code=400,
                     detail="change_status can only be used with mode 'modify'",
                 )
-            if not _struct_owns_resource_id:
-                reject_resource_id_in_patch(body)
+
+            flavor = _patch_flavor(content_type, body)
             try:
                 _check_precondition(
                     resource_manager, resource_id, expected_revision_id, if_match
                 )
                 with resource_manager.using(current_user, current_time):
-                    patch = JsonPatch(body)
-                    if mode == "update":
-                        info = resource_manager.patch(resource_id, patch)
-                    else:  # mode == "modify"
-                        info = resource_manager.modify(
-                            resource_id,
-                            patch,
-                            status=msgspec.UNSET
-                            if change_status is None
-                            else change_status,
+                    if flavor == "merge":
+                        _guard_merge_patch_body(
+                            body, content_type, _struct_owns_resource_id
                         )
+                        merge = MergePatch(body)
+                        if mode == "update":
+                            info = resource_manager.patch(resource_id, merge)
+                        else:  # mode == "modify"
+                            info = resource_manager.modify(
+                                resource_id,
+                                merge,
+                                status=msgspec.UNSET
+                                if change_status is None
+                                else change_status,
+                            )
+                    else:  # RFC 6902 JSON Patch
+                        from jsonpatch import JsonPatch
+
+                        if not _struct_owns_resource_id:
+                            reject_resource_id_in_patch(body)
+                        patch = JsonPatch(body)
+                        if mode == "update":
+                            info = resource_manager.patch(resource_id, patch)
+                        else:  # mode == "modify"
+                            info = resource_manager.modify(
+                                resource_id,
+                                patch,
+                                status=msgspec.UNSET
+                                if change_status is None
+                                else change_status,
+                            )
                 return MsgspecResponse(info)
             except Exception as e:
                 raise to_http_exception(e)

--- a/specstar/crud/route_templates/search.py
+++ b/specstar/crud/route_templates/search.py
@@ -359,12 +359,18 @@ class ListRouteTemplate(BaseRouteTemplate):
                 query = build_query(query_params, request)
                 fields = get_partial_fields(request, query_params)
 
+                # Fetch one extra row than requested so we can report whether
+                # more results exist beyond this page without a count query.
+                probe = msgspec.structs.replace(query, limit=query.limit + 1)
                 with resource_manager.using(current_user, current_time):
                     results = resource_manager.list_resources(
-                        query,
+                        probe,
                         returns=returns,
                         partial=fields,
                     )
+                has_more = len(results) > query.limit
+                if has_more:
+                    results = results[: query.limit]
 
                 # Map SearchedResource back to FullResourceResponse for API compat
                 responses = []
@@ -376,7 +382,22 @@ class ListRouteTemplate(BaseRouteTemplate):
                             meta=item.meta,  # ty:ignore[invalid-argument-type]
                         )
                     )
-                return MsgspecResponse(responses)
+                # Truncation is never silent: X-Has-More is always present;
+                # X-Total-Count is opt-in (it costs an extra count query).
+                headers = {"X-Has-More": "true" if has_more else "false"}
+                if request.query_params.get("with_total", "").lower() in (
+                    "true",
+                    "1",
+                    "yes",
+                ):
+                    count_query = msgspec.structs.replace(
+                        query, limit=2**63 - 1, offset=0
+                    )
+                    with resource_manager.using(current_user, current_time):
+                        headers["X-Total-Count"] = str(
+                            resource_manager.count_resources(count_query)
+                        )
+                return MsgspecResponse(responses, headers=headers)
             except Exception as e:
                 raise to_http_exception(e)
 

--- a/specstar/errors.py
+++ b/specstar/errors.py
@@ -14,6 +14,7 @@ from specstar.types import (
     RevisionNotFoundError,
     RevisionNotMigratedError,
     SchemaConflictError,
+    SpecStarWarning,
     UniqueConstraintError,
     ValidationError,
 )
@@ -32,6 +33,7 @@ __all__ = [
     "RevisionNotFoundError",
     "RevisionNotMigratedError",
     "SchemaConflictError",
+    "SpecStarWarning",
     "UniqueConstraintError",
     "ValidationError",
 ]

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -117,6 +117,7 @@ from specstar.types import (
     IndexableField,
     IResourceManager,
     IValidator,
+    MergePatch,
     OnDuplicate,
     PermissionDeniedError,
     RawResource,
@@ -470,6 +471,25 @@ class PermissionEventHandler(IEventHandler):
                 f"Permission denied for user '{context.user}' "
                 f"to perform '{context.action}' on '{context.resource_name}'",
             )
+
+
+def _rfc7386_merge(target, patch):
+    """Apply an RFC 7386 JSON Merge Patch to ``target`` and return the result.
+
+    A non-object patch replaces the target wholesale; ``null`` values delete the
+    corresponding key; nested objects merge recursively.
+    """
+    if not isinstance(patch, dict):
+        return patch
+    result = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        elif isinstance(value, dict):
+            result[key] = _rfc7386_merge(result.get(key), value)
+        else:
+            result[key] = value
+    return result
 
 
 def coerce_data_to_resource_type(func):
@@ -1071,7 +1091,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         This allows Pydantic users to pass native Pydantic instances
         or plain dicts without knowing about msgspec.
         """
-        if data is UNSET or type(data) is JsonPatch:
+        if data is UNSET or type(data) is JsonPatch or type(data) is MergePatch:
             return data
         if isinstance(data, Struct):
             return data
@@ -1889,6 +1909,43 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         query = self._resolve_str_query_vectors(query)
         return self.storage.search(query)
 
+    def iter_all(
+        self,
+        query: "ResourceMetaSearchQuery | Query | None" = None,
+        *,
+        batch_size: int = 1000,
+    ) -> Generator[ResourceMeta]:
+        """Yield *every* resource matching ``query``, paging internally.
+
+        Unlike :meth:`search_resources` — which is bounded by the query's
+        ``limit`` and can silently truncate — this walks the full result set
+        in ``batch_size`` chunks. Use it whenever you genuinely want "all
+        rows" so a forgotten ``limit`` can't drop data. ``query`` defaults to
+        "all resources".
+
+        Arguments:
+            query: search query (or ``Query`` builder); ``None`` matches all.
+            batch_size: page size used internally for the scan.
+
+        Yields:
+            ResourceMeta: one per matching resource, oldest page first.
+        """
+        if query is None:
+            query = ResourceMetaSearchQuery()
+        elif isinstance(query, Query):
+            query = query.build()
+        offset = 0
+        while True:
+            page = self.search_resources(
+                msgspec.structs.replace(query, limit=batch_size, offset=offset)
+            )
+            if not page:
+                return
+            yield from page
+            if len(page) < batch_size:
+                return
+            offset += batch_size
+
     def _default_worker_num(self, nr_work: int) -> int:
         """Calculate the number of worker threads for parallel fetch."""
         if nr_work <= 10:
@@ -2291,7 +2348,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
     def modify(
         self,
         resource_id: str,
-        data: T | JsonPatch | UnsetType = UNSET,
+        data: "T | JsonPatch | MergePatch | UnsetType" = UNSET,
         status: RevisionStatus | UnsetType = UNSET,
         *,
         user: str | UnsetType = UNSET,
@@ -2330,6 +2387,8 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             raise CannotModifyResourceError(resource_id)
         if type(data) is JsonPatch:
             data = self._apply_patch(resource_id, data)
+        elif type(data) is MergePatch:
+            data = self._apply_merge_patch(resource_id, data)
 
         if data is not UNSET:
             data = self._process_binary_fields(data)
@@ -2381,17 +2440,18 @@ class ResourceManager(IResourceManager[T], Generic[T]):
     def patch(
         self,
         resource_id: str,
-        patch_data: JsonPatch,
+        patch_data: "JsonPatch | MergePatch",
         *,
         user: str | UnsetType = UNSET,
         now: dt.datetime | UnsetType = UNSET,
     ) -> RevisionInfo:
         """
-        Apply RFC 6902 JSON Patch operations to the resource.
+        Apply an RFC 6902 JSON Patch or RFC 7386 Merge Patch to the resource.
 
         Arguments:
             resource_id (str): the id of the resource to patch.
-            patch_data (JsonPatch): RFC 6902 JSON Patch operations to apply.
+            patch_data (JsonPatch | MergePatch): RFC 6902 operations
+                (``JsonPatch``) or an RFC 7386 merge patch (``MergePatch``).
             user (str | UnsetType): The user performing the action.
             now (datetime | UnsetType): The current timestamp.
 
@@ -2402,7 +2462,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             ResourceIDNotFoundError: if resource id does not exist.
             ResourceIsDeletedError: if resource is soft-deleted.
         """
-        data = self._apply_patch(resource_id, patch_data)
+        if type(patch_data) is MergePatch:
+            data = self._apply_merge_patch(resource_id, patch_data)
+        else:
+            data = self._apply_patch(resource_id, patch_data)
         return self.update(resource_id, data)
 
     def _apply_patch(self, resource_id: str, patch_data: JsonPatch) -> T:
@@ -2413,6 +2476,16 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             d = msgspec.to_builtins(data)
         patch_data.apply(d, in_place=True)
         return msgspec.convert(d, self.resource_type)
+
+    def _apply_merge_patch(self, resource_id: str, merge_patch: dict) -> T:
+        """RFC 7386 analogue of :meth:`_apply_patch`: merge ``merge_patch`` into
+        the current data and return the resulting full resource."""
+        data = self.get(resource_id).data
+        if isinstance(data, msgspec.Raw):
+            d = json.loads(bytes(data))
+        else:
+            d = msgspec.to_builtins(data)
+        return msgspec.convert(_rfc7386_merge(d, merge_patch), self.resource_type)
 
     @execute_with_events(
         (BeforeSwitch, AfterSwitch, OnSuccessSwitch, OnFailureSwitch),

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -883,10 +883,19 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 f"migration must be Schema, IMigration, or None, got {type(migration).__name__}"
             )
 
+        # When no default is configured we fall back to the same values an
+        # unauthenticated HTTP request records ("anonymous" + UTC now), so a
+        # programmatic ``create``/``update`` without a ``using()`` context
+        # behaves like the HTTP path instead of leaking a raw ``LookupError``.
+        # In strict mode we leave the context defaultless so a missing context
+        # raises ``MissingOperationContextError`` (see _validate_write_context).
         self.user_ctx: Ctx[str]
         self.now_ctx: Ctx[dt.datetime]
         if default_user is UNSET:
-            self.user_ctx = Ctx("user_ctx", strict_type=str)
+            if strict_operation_context:
+                self.user_ctx = Ctx("user_ctx", strict_type=str)
+            else:
+                self.user_ctx = Ctx("user_ctx", strict_type=str, default="anonymous")
         elif isinstance(default_user, str):
             self.user_ctx = Ctx("user_ctx", strict_type=str, default=default_user)
         else:
@@ -895,11 +904,17 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 strict_type=str,
                 default_factory=default_user,
             )
-        if default_now is UNSET:
+        if default_now is not UNSET:
+            self.now_ctx = Ctx(
+                "now_ctx", strict_type=dt.datetime, default_factory=default_now
+            )
+        elif strict_operation_context:
             self.now_ctx = Ctx("now_ctx", strict_type=dt.datetime)
         else:
             self.now_ctx = Ctx(
-                "now_ctx", strict_type=dt.datetime, default_factory=default_now
+                "now_ctx",
+                strict_type=dt.datetime,
+                default_factory=lambda: dt.datetime.now(dt.timezone.utc),
             )
         self.id_ctx = Ctx[str | UnsetType]("id_ctx", default=UNSET)
         self._resource_type = resource_type

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -867,6 +867,28 @@ class IMigration(ABC, Generic[T]):
         ...
 
 
+class MergePatch(dict):
+    """An RFC 7386 JSON Merge Patch payload.
+
+    A thin ``dict`` marker so :meth:`IResourceManager.patch` /
+    :meth:`IResourceManager.modify` can tell a *merge patch* (partial update;
+    ``null`` deletes a field) apart from full replacement data — mirroring how
+    ``jsonpatch.JsonPatch`` marks an RFC 6902 operation list. Construct it
+    around the changed fields::
+
+        mgr.patch(rid, MergePatch({"qty": 50}))   # merge, keep other fields
+    """
+
+    @property
+    def patch(self) -> dict:
+        """The merge-patch payload.
+
+        Mirrors ``jsonpatch.JsonPatch.patch`` so the Patch event payload (which
+        reads ``patch_data.patch``) resolves uniformly for both flavors.
+        """
+        return dict(self)
+
+
 class IResourceManager(ABC, Generic[T]):
     """Interface for managing versioned resources with full lifecycle support.
 
@@ -1409,7 +1431,7 @@ class IResourceManager(ABC, Generic[T]):
     def modify(
         self,
         resource_id: str,
-        data: T | JsonPatch | UnsetType = UNSET,
+        data: "T | JsonPatch | MergePatch | UnsetType" = UNSET,
         status: RevisionStatus | UnsetType = UNSET,
         *,
         user: str | UnsetType = UNSET,
@@ -1432,12 +1454,12 @@ class IResourceManager(ABC, Generic[T]):
     def patch(
         self,
         resource_id: str,
-        patch_data: JsonPatch,
+        patch_data: "JsonPatch | MergePatch",
         *,
         user: str | UnsetType = UNSET,
         now: dt.datetime | UnsetType = UNSET,
     ) -> RevisionInfo:
-        """Apply RFC 6902 JSON Patch operations to the resource.
+        """Apply an RFC 6902 JSON Patch or RFC 7386 Merge Patch to the resource.
 
         Args:
             resource_id (str): the id of the resource to patch.
@@ -1808,6 +1830,14 @@ class IResourceManager(ABC, Generic[T]):
 
 class PermissionDeniedError(Exception):
     pass
+
+
+class SpecStarWarning(UserWarning):
+    """Category for SpecStar advisory warnings (e.g. permissive defaults).
+
+    Suppress with the standard ``warnings`` machinery, e.g.
+    ``warnings.filterwarnings("ignore", category=SpecStarWarning)``.
+    """
 
 
 class ResourceNotFoundError(Exception):

--- a/tests/test_default_context_fallback.py
+++ b/tests/test_default_context_fallback.py
@@ -1,0 +1,51 @@
+"""Programmatic writes without an operation context follow HTTP's behavior.
+
+In non-strict mode (the default) a ``mgr.create()`` with no ``using()`` and no
+configured ``default_user`` / ``default_now`` falls back to ``"anonymous"`` +
+``now()`` — exactly what an unauthenticated HTTP request records — instead of
+leaking a raw ``LookupError``. ``strict_operation_context=True`` restores the
+hard failure (a friendly ``MissingOperationContextError``).
+"""
+
+import datetime as dt
+
+import msgspec
+import pytest
+
+from specstar import Schema, SpecStar
+from specstar.types import MissingOperationContextError
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def test_programmatic_create_without_context_defaults_to_anonymous():
+    sp = SpecStar()  # non-strict default; no default_user / default_now
+    sp.add_model(Schema(Item, "v1"))
+    mgr = sp.get_resource_manager(Item)
+
+    info = mgr.create(Item(name="x"))
+    assert mgr.get_meta(info.resource_id).created_by == "anonymous"
+
+
+def test_now_defaults_to_current_time_without_context():
+    sp = SpecStar()
+    sp.add_model(Schema(Item, "v1"))
+    mgr = sp.get_resource_manager(Item)
+
+    before = dt.datetime.now(dt.timezone.utc)
+    info = mgr.create(Item(name="x"))
+    created = mgr.get_meta(info.resource_id).created_time
+    assert isinstance(created, dt.datetime)
+    # populated from now() rather than left unset / erroring
+    assert (created - before).total_seconds() == pytest.approx(0, abs=5)
+
+
+def test_strict_mode_still_raises_without_context():
+    sp = SpecStar(strict_operation_context=True)
+    sp.add_model(Schema(Item, "v1"))
+    mgr = sp.get_resource_manager(Item)
+
+    with pytest.raises(MissingOperationContextError):
+        mgr.create(Item(name="x"))

--- a/tests/test_list_truncation.py
+++ b/tests/test_list_truncation.py
@@ -1,0 +1,59 @@
+"""Slice 5: list truncation is never silent.
+
+``GET /{model}`` always returns an ``X-Has-More`` header (cheap, via a
+limit+1 probe) and, opt-in via ``?with_total=true``, an ``X-Total-Count``
+header. The body stays a bare JSON array (non-breaking). ``iter_all()`` pages
+through everything programmatically so a full scan can never truncate.
+"""
+
+import msgspec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import Schema, SpecStar
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def _client_with(n: int):
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    app = FastAPI()
+    sp.add_model(Schema(Item, "v1"))
+    sp.apply(app)
+    c = TestClient(app)
+    for i in range(n):
+        c.post("/item", json={"name": f"i{i}"})
+    return sp, c
+
+
+def test_has_more_header_true_when_truncated():
+    _, c = _client_with(3)
+    r = c.get("/item?limit=1")
+    assert r.status_code == 200
+    assert r.headers["X-Has-More"] == "true"
+    assert len(r.json()) == 1
+
+
+def test_has_more_header_false_when_all_returned():
+    _, c = _client_with(3)
+    r = c.get("/item?limit=10")
+    assert r.headers["X-Has-More"] == "false"
+    assert len(r.json()) == 3
+
+
+def test_total_count_is_opt_in():
+    _, c = _client_with(3)
+    assert "X-Total-Count" not in c.get("/item?limit=1").headers
+    r = c.get("/item?limit=1&with_total=true")
+    assert r.headers["X-Total-Count"] == "3"
+    assert r.headers["X-Has-More"] == "true"
+
+
+def test_iter_all_yields_everything_without_truncation():
+    sp, _ = _client_with(5)
+    mgr = sp.get_resource_manager(Item)
+    metas = list(mgr.iter_all(batch_size=2))
+    assert len(metas) == 5

--- a/tests/test_merge_patch_manager.py
+++ b/tests/test_merge_patch_manager.py
@@ -1,0 +1,58 @@
+"""RFC 7386 merge-patch as a first-class ResourceManager operation.
+
+``patch`` and ``modify`` already accept an RFC 6902 ``JsonPatch``; a
+``MergePatch`` marker carries an RFC 7386 merge patch through the same methods,
+so programmatic callers (and the HTTP layer) share one implementation.
+"""
+
+import datetime as dt
+
+import msgspec
+
+from specstar import Schema, SpecStar
+from specstar.types import MergePatch
+
+
+class Item(msgspec.Struct):
+    qty: int = 0
+    name: str = ""
+    note: str | None = None
+
+
+def _mgr():
+    sp = SpecStar()
+    sp.configure(
+        default_user="t", default_now=lambda: dt.datetime.now(dt.timezone.utc)
+    )
+    sp.add_model(Schema(Item, "v1"))
+    return sp.get_resource_manager(Item)
+
+
+def test_manager_patch_accepts_merge_patch():
+    mgr = _mgr()
+    info0 = mgr.create(Item(qty=1, name="a"))
+    info1 = mgr.patch(info0.resource_id, MergePatch({"qty": 50}))
+    got = mgr.get(info0.resource_id).data
+    assert got.qty == 50  # merged
+    assert got.name == "a"  # preserved
+    assert info1.revision_id != info0.revision_id  # new revision
+
+
+def test_manager_merge_patch_null_deletes_field():
+    mgr = _mgr()
+    info0 = mgr.create(Item(qty=1, name="a", note="hi"))
+    mgr.patch(info0.resource_id, MergePatch({"note": None}))
+    assert mgr.get(info0.resource_id).data.note is None
+
+
+def test_manager_modify_accepts_merge_patch():
+    from specstar.types import RevisionStatus
+
+    mgr = _mgr()
+    info0 = mgr.create(Item(qty=1, name="a"), status=RevisionStatus.draft)
+    info1 = mgr.modify(info0.resource_id, MergePatch({"qty": 50}))
+    got = mgr.get(info0.resource_id).data
+    assert got.qty == 50
+    assert got.name == "a"
+    # modify mutates the current (draft) revision in place — no new revision
+    assert info1.revision_id == info0.revision_id

--- a/tests/test_operation_context.py
+++ b/tests/test_operation_context.py
@@ -5,7 +5,7 @@ import threading
 import warnings
 
 import pytest
-from msgspec import UNSET, Struct
+from msgspec import Struct
 
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.simple import MemoryMetaStore
@@ -129,11 +129,12 @@ class TestUsingBasic:
     def test_using_context_cleanup(self):
         rm = make_rm()
         with rm.using(user="alice", now=NOW):
-            pass
-        # After scope exits, context should be cleaned up.
-        # Without defaults, accessing user should raise.
-        assert rm.user_or_unset is UNSET
-        assert rm.now_or_unset is UNSET
+            assert rm.user == "alice"
+        # After scope exits the explicit context is popped. A non-strict RM
+        # then falls back to its HTTP-matching defaults ("anonymous" + now()),
+        # which proves "alice" no longer lingers.
+        assert rm.user_or_unset == "anonymous"
+        assert isinstance(rm.now_or_unset, dt.datetime)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -297,12 +298,14 @@ class TestStrictMode:
             rm.create(Item(name="a"), user="bob")
         assert exc_info.value.missing_fields == ["now"]
 
-    def test_non_strict_missing_context_no_error(self):
-        """Non-strict mode: missing context causes LookupError from ContextVar,
-        not MissingOperationContextError."""
+    def test_non_strict_missing_context_falls_back_to_anonymous(self):
+        """Non-strict mode (default): a missing operation context falls back to
+        "anonymous" + now() — matching an unauthenticated HTTP request —
+        instead of leaking a raw LookupError."""
         rm = make_rm(strict=False)
-        with pytest.raises(LookupError):
-            rm.create(Item(name="a"))
+        info = rm.create(Item(name="a"))
+        assert info.created_by == "anonymous"
+        assert isinstance(info.created_time, dt.datetime)
 
     def test_strict_update_without_context_raises(self):
         storage = _make_storage()

--- a/tests/test_patch_merge_patch.py
+++ b/tests/test_patch_merge_patch.py
@@ -1,0 +1,87 @@
+"""Slice 2: PATCH accepts both RFC 6902 (JSON Patch) and RFC 7386 (Merge Patch).
+
+The same endpoint disambiguates by Content-Type when explicit, else by body
+shape: a JSON array is RFC 6902 ops (unchanged); a JSON object is an RFC 7386
+merge patch (previously a 400). ``null`` in a merge patch deletes/optionalises
+a field per RFC 7386.
+"""
+
+import msgspec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import Schema, SpecStar
+
+
+class Item(msgspec.Struct):
+    qty: int = 0
+    name: str = ""
+    note: str | None = None
+
+
+def _client():
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    app = FastAPI()
+    sp.add_model(Schema(Item, "v1"))
+    sp.apply(app)
+    return TestClient(app)
+
+
+def _data(c, rid):
+    return c.get(f"/item/{rid}/data").json()
+
+
+def test_merge_patch_partial_object_merges_and_succeeds():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a"}).json()["resource_id"]
+    r = c.patch(f"/item/{rid}", json={"qty": 50})
+    assert r.status_code == 200
+    # qty updated, name preserved (merge, not full replace)
+    assert _data(c, rid) == {"qty": 50, "name": "a", "note": None}
+
+
+def test_rfc6902_array_still_works():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a"}).json()["resource_id"]
+    r = c.patch(f"/item/{rid}", json=[{"op": "replace", "path": "/qty", "value": 9}])
+    assert r.status_code == 200
+    assert _data(c, rid)["qty"] == 9
+
+
+def test_merge_patch_null_deletes_field():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a", "note": "hi"}).json()[
+        "resource_id"
+    ]
+    r = c.patch(f"/item/{rid}", json={"note": None})
+    assert r.status_code == 200
+    assert _data(c, rid)["note"] is None
+
+
+def test_merge_patch_via_explicit_content_type():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a"}).json()["resource_id"]
+    r = c.patch(
+        f"/item/{rid}",
+        content=b'{"qty": 7}',
+        headers={"Content-Type": "application/merge-patch+json"},
+    )
+    assert r.status_code == 200
+    assert _data(c, rid)["qty"] == 7
+
+
+def test_stray_single_6902_op_object_gives_helpful_error():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a"}).json()["resource_id"]
+    r = c.patch(f"/item/{rid}", json={"op": "replace", "path": "/qty", "value": 5})
+    assert r.status_code == 422
+    assert "array of operations" in r.json()["detail"]
+
+
+def test_resource_id_in_merge_patch_object_rejected():
+    c = _client()
+    rid = c.post("/item", json={"qty": 1, "name": "a"}).json()["resource_id"]
+    r = c.patch(f"/item/{rid}", json={"qty": 2, "resource_id": "x"})
+    assert r.status_code == 422
+    assert "resource_id" in r.json()["detail"]

--- a/tests/test_per_model_default_user_http.py
+++ b/tests/test_per_model_default_user_http.py
@@ -1,0 +1,66 @@
+"""Slice 1: per-model ``default_user`` must reach HTTP-created audit fields.
+
+Previously ``add_model(default_user="alice")`` only set the manager's
+programmatic default; HTTP requests still recorded ``"anonymous"`` because the
+route pushed the global DependencyProvider's user. These tests pin the fixed
+precedence: real ``get_user`` (auth) > per-model default_user >
+global ``configure`` default_user > ``"anonymous"``.
+"""
+
+import datetime as dt
+
+import msgspec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import Schema, SpecStar
+from specstar.crud.route_templates.basic import DependencyProvider
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def _created_by(sp: SpecStar) -> str:
+    app = FastAPI()
+    sp.apply(app)
+    c = TestClient(app)
+    rid = c.post("/item", json={"name": "x"}).json()["resource_id"]
+    return sp.get_resource_manager(Item).get_meta(rid).created_by
+
+
+def test_add_model_default_user_reaches_http_created_by():
+    sp = SpecStar()
+    sp.configure()
+    sp.add_model(Schema(Item, "v1"), default_user="alice")
+    assert _created_by(sp) == "alice"
+
+
+def test_real_get_user_wins_over_per_model_default():
+    """A real authentication ``get_user`` must never be overridden by a
+    per-model default — auth is the top of the precedence chain."""
+    sp = SpecStar()
+    sp.configure(dependency_provider=DependencyProvider(get_user=lambda: "real-bob"))
+    sp.add_model(Schema(Item, "v1"), default_user="alice")
+    assert _created_by(sp) == "real-bob"
+
+
+def test_per_model_default_user_overrides_global_configure():
+    sp = SpecStar()
+    sp.configure(default_user="global-bob")
+    sp.add_model(Schema(Item, "v1"), default_user="alice")
+    assert _created_by(sp) == "alice"
+
+
+def test_add_model_default_now_overrides_configure_default_now():
+    """Per-model ``default_now`` overrides the global one (programmatic path).
+    (We intentionally do not wire default_now into HTTP; see the issue.)"""
+    per_model = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+    sp = SpecStar()
+    sp.configure(
+        default_user="t", default_now=lambda: dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    )
+    sp.add_model(Schema(Item, "v1"), default_now=lambda: per_model)
+    mgr = sp.get_resource_manager(Item)
+    info = mgr.create(Item(name="x"))
+    assert mgr.get_meta(info.resource_id).created_time == per_model

--- a/tests/test_specstar.py
+++ b/tests/test_specstar.py
@@ -145,12 +145,14 @@ class TestSpecStar:
         assert info.created_by == "system"
 
     def test_add_model_without_default_user(self):
+        # Non-strict (default): a missing user falls back to "anonymous"
+        # (now is supplied here via the context).
         spec = SpecStar()
         spec.add_model(User)
         mgr = spec.get_resource_manager(User)
-        with pytest.raises(LookupError):
-            with mgr.meta_provide(now=dt.datetime.now()):
-                mgr.create({"name": "Alice", "age": 30})  # ty:ignore[invalid-argument-type]
+        with mgr.meta_provide(now=dt.datetime.now()):
+            info = mgr.create({"name": "Alice", "age": 30})  # ty:ignore[invalid-argument-type]
+        assert info.created_by == "anonymous"
 
     @pytest.mark.parametrize("level", ["spec", "model"])
     def test_add_model_with_default_now(self, level: str):
@@ -166,12 +168,15 @@ class TestSpecStar:
         assert info.created_time == dt.datetime(2023, 1, 1)
 
     def test_add_model_without_default_now(self):
+        # Non-strict (default): a missing now falls back to now()
+        # (user is supplied here via the context).
         spec = SpecStar()
         spec.add_model(User)
         mgr = spec.get_resource_manager(User)
-        with pytest.raises(LookupError):
-            with mgr.meta_provide("system"):
-                mgr.create({"name": "Alice", "age": 30})  # ty:ignore[invalid-argument-type]
+        with mgr.meta_provide("system"):
+            info = mgr.create({"name": "Alice", "age": 30})  # ty:ignore[invalid-argument-type]
+        assert info.created_by == "system"
+        assert isinstance(info.created_time, dt.datetime)
 
     def test_add_model_with_default_user_and_now(self):
         spec = SpecStar()

--- a/tests/test_startup_warnings.py
+++ b/tests/test_startup_warnings.py
@@ -1,0 +1,47 @@
+"""Slice 4: loud-but-suppressible startup warnings for permissive defaults.
+
+At ``apply()`` SpecStar warns (once, via :class:`SpecStarWarning`) when the
+default path leaves a known footgun open: unknown-field dropping is off, or no
+query limit is configured. Explicit settings silence the respective warning.
+"""
+
+import msgspec
+import pytest
+from fastapi import FastAPI
+
+from specstar import Schema, SpecStar
+from specstar.errors import SpecStarWarning
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def test_warns_when_forbid_unknown_fields_off(monkeypatch):
+    monkeypatch.setenv("SPECSTAR_DEFAULT_QUERY_LIMIT", "1000")  # silence the other one
+    sp = SpecStar()
+    sp.configure()
+    sp.add_model(Schema(Item, "v1"))
+    with pytest.warns(SpecStarWarning, match="forbid_unknown_fields"):
+        sp.apply(FastAPI())
+
+
+def test_warns_when_no_query_limit_configured(monkeypatch):
+    monkeypatch.delenv("SPECSTAR_DEFAULT_QUERY_LIMIT", raising=False)
+    sp = SpecStar()
+    sp.configure(forbid_unknown_fields=True)  # silence the other one
+    sp.add_model(Schema(Item, "v1"))
+    with pytest.warns(SpecStarWarning, match="SPECSTAR_DEFAULT_QUERY_LIMIT"):
+        sp.apply(FastAPI())
+
+
+def test_hardened_config_emits_no_warning(monkeypatch):
+    import warnings as w
+
+    monkeypatch.setenv("SPECSTAR_DEFAULT_QUERY_LIMIT", "1000")
+    sp = SpecStar(forbid_unknown_fields=True)
+    sp.add_model(Schema(Item, "v1"))
+    with w.catch_warnings(record=True) as rec:
+        w.simplefilter("always")
+        sp.apply(FastAPI())
+    assert not [r for r in rec if issubclass(r.category, SpecStarWarning)]

--- a/uv.lock
+++ b/uv.lock
@@ -1461,6 +1461,26 @@ wheels = [
 ]
 
 [[package]]
+name = "git-cliff"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/57/b12494e2cbc3c9154c942e64659b5aec2b1ce9f12d07f6dc6167e2c63ae5/git_cliff-2.13.1.tar.gz", hash = "sha256:e949ea9c3951ba6037b99eec465162be2584f27f0836ace45f44d6f45650f8c6", size = 113119, upload-time = "2026-04-26T10:33:42.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/dd/24768c3c0030710d36706c17b997d06aee27cb76b27ab2abb058ae254175/git_cliff-2.13.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:08a9cb0ec760e165210ed22fefa295b6549a3520b420db995ccbb3620cbb1fbe", size = 7260035, upload-time = "2026-04-26T10:33:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/842973ead79d27a58cd1eccd167191c0a71513e5c1e9dc30337dafdb7d36/git_cliff-2.13.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e92cf470ecbe73f7d2963dfa80e8961a6b76888d0c19949b0f028a28a0a0470c", size = 6854384, upload-time = "2026-04-26T10:33:18.808Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4d/6d6efa7d61be8632563990ccd402e401695e4a85a0bb1002f28730d03268/git_cliff-2.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e8d8e420adf6a36b97e0fbdbf2b07e47712199a9baf3675c9a759430243ea26", size = 7308164, upload-time = "2026-04-26T10:33:20.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4a/98b8d2f53a2d0b7d313e98ab363ad7e0d6a514e878a8d678f22402cb0ec7/git_cliff-2.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ab059d671565189faa4f3858b2fb42535aa39fe265ad95d84d5c116a2724fc7", size = 7687163, upload-time = "2026-04-26T10:33:23.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/07/cdd149b3909644aa3f0be7960406d9bbb38598f8618e039ac48cbb43ded6/git_cliff-2.13.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a93db30da45967c42df607fbbc2092111fcd576b0ca9e2fbddd3f653d8c71be7", size = 7317670, upload-time = "2026-04-26T10:33:25.323Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/11/6d377a7f3113f6e26d87a28a32013eb05bd62bce176d6f8ee808e4868c1f/git_cliff-2.13.1-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:df9f5a2bd16e5225030c9c2362e6ac70b34a906c0fbb83f8cbf5ae46932ba0d2", size = 7502294, upload-time = "2026-04-26T10:33:27.315Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6b/e1da9acf3aec99e6600be02b6ce0c9e8bd42d072e3120384514c905231e2/git_cliff-2.13.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c12276784d280aa6a7148d3e52ff139e891f4c97720cd9be581b19892ea39fe0", size = 7927258, upload-time = "2026-04-26T10:33:29.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ea/9f2188a5e474e5f02193d9c1cdf7028773d483a3f508a1df4f1d93c9cc80/git_cliff-2.13.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:17da93dc605cbc48c762770402067fa726437cedbd62514f9caef6e0ccb58a43", size = 7308153, upload-time = "2026-04-26T10:33:31.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/70/5e2b2a0e42c07956f911e1eccd6dc6d79b96fc6c8a604a526c1ee0474c84/git_cliff-2.13.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cd4a08cf3f638ec71d2ed451aa8673bef99e1107a36366153db97ca18d981655", size = 7502287, upload-time = "2026-04-26T10:33:33.894Z" },
+    { url = "https://files.pythonhosted.org/packages/05/50/cc4c1d3d360621c0235d66d2c74472d9993d8aadf23ffa311eaf29d7a3aa/git_cliff-2.13.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c5bb87f6e1db18be09e50c9d59234dc949713e20c2700e94eca378d22ad79719", size = 7927253, upload-time = "2026-04-26T10:33:36.205Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5d/717d30f37dad65a6cc5220b04a3ef1bc44c31fb56d0ce2895114e159df4f/git_cliff-2.13.1-py3-none-win32.whl", hash = "sha256:c8878972e0a6c26d9137fc406a611116239333578d95ac05064d2807920bd83c", size = 6718261, upload-time = "2026-04-26T10:33:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b2/99fac50978b9a90bfec0f1b89354a667ec83f4990301f6c708abce05484e/git_cliff-2.13.1-py3-none-win_amd64.whl", hash = "sha256:856d831a0bede9c258229dbd4d4c2b1c0810d8fce3d3882729669e8dc09c72bf", size = 7714969, upload-time = "2026-04-26T10:33:40.163Z" },
+]
+
+[[package]]
 name = "graphql-core"
 version = "3.2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4546,6 +4566,7 @@ dev = [
     { name = "celery" },
     { name = "coverage" },
     { name = "datamodel-code-generator", extra = ["http"] },
+    { name = "git-cliff" },
     { name = "httpx" },
     { name = "matplotlib" },
     { name = "mkdocs" },
@@ -4665,6 +4686,7 @@ requires-dist = [
     { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'cli'", specifier = ">=0.35.0" },
     { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'dev'", specifier = ">=0.35.0" },
     { name = "fastapi", specifier = ">=0.115,<1" },
+    { name = "git-cliff", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'cli'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

Responds to the "harden a few permissive defaults" evaluation report. It tightens the audit trail, makes `PATCH` accept the intuitive partial-update format, makes the HTTP and programmatic write paths behave consistently, and adds safety nets around the unbounded-list footgun — while keeping the change surface almost entirely additive/opt-in.

Three commits on top of `v0.11.1`: the two feature/behavior commits below, plus one `chore:` that adopts git-cliff + `make release` for changelog/version management (see *Tooling*). **No hard breaking changes** — the surface is additive plus two behavior fixes that only change a previously-broken or previously-erroring path (details below; both are non-breaking in the CHANGELOG sense).

## Fixed / behavior changes

- **`add_model(default_user=...)` now reaches the HTTP audit fields** (previously a no-op for HTTP — the documented setting was silently ignored). Resources created over HTTP for that model record the per-model `created_by` / `updated_by` instead of `"anonymous"`.
  - Precedence: a real `get_user` (authentication) **>** per-model `default_user` **>** global `configure(default_user=...)` **>** `"anonymous"`.
  - This is a bug fix (the setting now does what it documents), not an API break. **Note:** it does change recorded `created_by` values for apps that set a per-model `default_user` *and* create over HTTP — those rows now carry the configured user instead of `"anonymous"`. Apps with a real `get_user`, or that never set `default_user`, are unchanged.
- **Programmatic writes without an operation context now match HTTP.** In the default (non-strict) mode, `ResourceManager.create()` / `update()` / `modify()` / etc. called with no `using()` context and no configured `default_user` / `default_now` now record `created_by="anonymous"` + current UTC time — the same values an unauthenticated HTTP request produces — instead of leaking a raw `LookupError`. This removes an HTTP-vs-programmatic inconsistency and an ugly internal-exception leak.
  - `strict_operation_context=True` restores the hard failure (a friendly `MissingOperationContextError`), for callers who want a missing context to be loud.
  - Existing code that sets a context, a `default_user`, or goes through HTTP is unaffected (error → success only for the previously-erroring path).

## Added (additive / opt-in)

- **RFC 7386 JSON Merge Patch.** `PATCH /{model}/{id}` now accepts a partial object (`{"qty": 50}`) in addition to the RFC 6902 op array. The same endpoint disambiguates by explicit `Content-Type` (`application/merge-patch+json` vs `application/json-patch+json`) or, for a generic `application/json`, by body shape (object → merge, array → ops). A partial object previously returned `400`, so this is error → success.
  - First-class at the manager layer too: `ResourceManager.patch()` / `.modify()` accept a `MergePatch(...)` (new, exported from `specstar`) alongside `JsonPatch`, mirroring the 6902 path. The HTTP route delegates to them (single source of truth).
- **`ResourceManager.iter_all(query=None, *, batch_size=1000)`** pages through every match internally, so a deliberate full scan can never silently truncate.
- **List truncation signals on `GET /{model}`** — an always-present `X-Has-More` header (computed cheaply via a `limit+1` probe) and an opt-in `X-Total-Count` header (`?with_total=true`). The response body is unchanged (a bare array), so this is non-breaking.
- **`SpecStarWarning` startup advisories**, emitted once at `apply()` when a permissive default is left in place: `forbid_unknown_fields` is off, or no `SPECSTAR_DEFAULT_QUERY_LIMIT` is configured. Suppressible via standard `warnings` filters (and silenced in the test suite via `pytest.ini`).

## Docs

- New **"Harden permissive defaults"** section in the *From Demo to Production* guide (one annotated baseline: `forbid_unknown_fields=True`, query-limit guidance, lock down `/{id}/permanently`, populate `created_by`).
- New **"PATCH: two flavors"** section in *API conventions*; updated the `gotchas` PATCH entry and the operation-context entry (now documents the `anonymous`/`now()` fallback + `strict_operation_context`).

## Tooling (the `chore:` commit)

- Changelog is now generated from Conventional Commits with **git-cliff** (non-conventional commits are intentionally excluded); `CHANGELOG.md` gained a proper `[0.11.1]` section (previously-released changes were drifting under a stale `Unreleased`).
- **`make release patch|minor|major`** (or `VERSION=X.Y.Z`) bumps `specstar/__init__.py`, prepends the new `CHANGELOG.md` section, and commits `bump vX.Y.Z`; `make changelog-preview` shows pending notes. git-cliff is an opt-in `dev` extra (not pulled by a plain `uv sync`).
- *Note:* because the feature work above is in two squashed `feat:` commits, the changelog section produced at release time will be terse — the detailed notes live in this PR description. This commit is orthogonal infra; it can be split into its own PR if you prefer (the CHANGELOG edits are mildly entangled with the feature commits, so splitting needs a little care).

## Design notes

- **No `preset=` bundle.** An opinionated preset was prototyped, but with only one safe flag to bundle (`forbid_unknown_fields=True`) it was just indirection over a one-liner, so it was dropped. A named preset is worth revisiting once there are 2–3 genuinely-safe settings to group (with a pinned "contents evolve only on minor/major + CHANGELOG" policy).
- **No silent numeric query-limit cap.** A magic default (e.g. `1000`) would reintroduce the *silent truncation* bug the report explicitly warned against. The unbounded-list footgun is instead addressed by the startup warning + `X-Has-More` (truncation is never silent) + `iter_all()` (safe full scan).

## Testing

- Full service-free gate green: **2901 passed, 4 skipped, 0 failures** (`pytest -m "not integration and not benchmark and not slow"`).
- 23 new tests covering each behavior (per-model `default_user` precedence, RFC 7386 at both HTTP and manager layers, truncation headers + `iter_all`, startup warnings, programmatic no-context fallback). Four pre-existing tests that asserted the old `LookupError` / `UNSET` behavior were updated to the new fallback.
- `ruff` clean on all changed files.
