### PR TITLE
Evaluation hardening (batch 3): GET response shape, raw-body import, louder defaults, doc fixes

### DIFF
--- a/docs/en/concepts/data-model.md
+++ b/docs/en/concepts/data-model.md
@@ -40,7 +40,8 @@ Resource-level metadata (`ResourceMeta`) is accessed via dedicated endpoints (or
 
 ### `resource_id`
 
-* A UUID string
+* Format: `"{model_name}:{uuid}"` — the model name, a colon, then a UUID
+  (e.g. `material:2c08f3a1-...`). It is **not** a bare UUID string.
 * Created at `create()` time
 
 ### `revision_id`
@@ -51,8 +52,8 @@ SpecStar uses a human-readable revision identifier:
 
 Example:
 
-* `f1b2...:1`
-* `f1b2...:2`
+* `material:f1b2...:1`
+* `material:f1b2...:2`
 
 ## Revision graph and branching
 

--- a/docs/en/howto/api-conventions.md
+++ b/docs/en/howto/api-conventions.md
@@ -86,6 +86,36 @@ Examples:
 
 > Note: Any section not listed in `returns` will be returned as `UNSET` (omitted in the serialized output, depending on encoder behavior).
 
+#### Bare objects: `only-*`
+
+`returns=data` still wraps the result in the `{ "data": ... }` envelope. To get
+a **bare, unwrapped** section (a front end that wants a plain object), use a
+single `only-*` value:
+
+* `only-data` → the data object itself, e.g. `{"title": "..."}`
+* `only-meta` → the bare `ResourceMeta`
+* `only-revision_info` (alias `only-revision-info`) → the bare `RevisionInfo`
+
+An `only-*` value **must be used alone** — combining it with any other value
+(e.g. `only-data,meta`) is a **422**, as is an unknown section. `revision-info`
+(hyphen) is accepted as an alias of `revision_info` in the regular list too.
+
+#### Server default: `default_get_returns`
+
+When the client omits `?returns=`, the response shape comes from
+`default_get_returns` (set on `SpecStar(...)` / `configure(...)` /
+`add_model(...)`; accepts a list or comma-string). It defaults to the full
+envelope `data,revision_info,meta`. Set it to `only-data` if your clients
+expect bare objects by default:
+
+```python
+spec.configure(default_get_returns="only-data")  # GET /{model}/{id} → bare data
+```
+
+Leaving it unset emits a one-time `SpecStarWarning` at startup (the envelope is
+the default and surprises front ends); setting it explicitly — to any value,
+including the envelope — silences that.
+
 ---
 
 ## Strictness: unknown fields on write
@@ -188,6 +218,11 @@ SpecStar supports field-level projection through `partial` (or `partial[]` for a
 * If the user passes `field` (no leading slash), SpecStar normalizes it to `/field`.
 
 > `partial` is treated as a structural selector (similar to JSON Pointer style paths), and is passed into `filter_struct_partial()` / `get_partial()`.
+
+> ⚠️ `partial` is **not a boolean**. `partial=true` selects a (non-existent)
+> field literally named `true` and so clears the section to `{}`. Passing a
+> boolean-looking value emits a `SpecStarWarning`. Use field paths
+> (`partial=/name`) or omit it.
 
 ### Prefix routing: project across `data`, `meta`, `revision_info`
 

--- a/docs/en/howto/event-handlers.md
+++ b/docs/en/howto/event-handlers.md
@@ -19,11 +19,12 @@ An event handler receives an event context object describing:
 A simple handler looks like this:
 
 ```python
-from specstar.resource_manager.events import do
-from specstar.types import EventContext, ResourceAction
+from specstar.events import do
+from specstar.events import EventContextProto
+from specstar.types import ResourceAction
 
 
-def audit_log(context: EventContext) -> None:
+def audit_log(context: EventContextProto) -> None:
     print(context.phase, context.action, context.resource_name)
 
 
@@ -104,7 +105,7 @@ Use it for:
 You can define several handlers in one fluent expression:
 
 ```python
-from specstar.resource_manager.events import do
+from specstar.events import do
 from specstar.types import ResourceAction
 
 
@@ -139,7 +140,7 @@ You can also attach one function to multiple actions by using the grouped action
 ### Audit every write
 
 ```python
-from specstar.resource_manager.events import do
+from specstar.events import do
 from specstar.types import ResourceAction
 
 
@@ -153,10 +154,11 @@ event_handlers = do(audit).on_success(ResourceAction.write)
 ### Block invalid input early
 
 ```python
-from specstar.types import EventContext, ResourceAction
+from specstar.events import EventContextProto
+from specstar.types import ResourceAction
 
 
-def validate_title(context: EventContext) -> None:
+def validate_title(context: EventContextProto) -> None:
     if context.action == ResourceAction.create and not context.data.title.strip():
         raise ValueError("title must not be empty")
 ```
@@ -164,7 +166,7 @@ def validate_title(context: EventContext) -> None:
 ### Log failures
 
 ```python
-from specstar.resource_manager.events import do
+from specstar.events import do
 from specstar.types import ResourceAction
 
 

--- a/docs/en/howto/gotchas.md
+++ b/docs/en/howto/gotchas.md
@@ -18,10 +18,19 @@ these are 0.x trade-offs that may sharpen up before 1.0.
 | `GET /user/123` → `{name: "...", email: "..."}` | `GET /user/123` → `{"data": {...}, "revision_info": {...}, "meta": {...}}` |
 
 The envelope is intentional: the same endpoint can return data, revision
-info, and metadata together. To get the bare data only:
+info, and metadata together. To get the bare data **object**:
 
-* `GET /user/123/data` — single-section read, or
-* `GET /user/123?returns=data` — same effect via `returns` selector.
+* `GET /user/123/data`, or
+* `GET /user/123?returns=only-data` — the `only-*` selector unwraps the
+  section. (Plain `?returns=data` still wraps it as `{"data": {...}}`.)
+
+To change the default shape for every GET, set `default_get_returns`
+(e.g. `spec.configure(default_get_returns="only-data")`).
+
+Note the asymmetry: `POST` / `PUT` return a **flat** `RevisionInfo` (top-level
+`resource_id`, `revision_id`, `created_by`, …) — a different shape from this GET
+envelope. A client reads the new id from the flat write response, then reads the
+resource back through the envelope.
 
 See [API conventions](./api-conventions.md#canonical-read-api-get-modelresource_id).
 
@@ -29,7 +38,8 @@ See [API conventions](./api-conventions.md#canonical-read-api-get-modelresource_
 
 `partial` is a **field selector** (slash-prefixed paths), not a boolean.
 `?partial=true` is normalised to the path `/true` which matches no field in
-your struct, so the projector strips data down to an empty object. Use
+your struct, so the projector strips data down to an empty object (a
+boolean-looking `partial` value also emits a `SpecStarWarning`). Use
 slash-prefixed field names instead:
 
 ```
@@ -143,6 +153,49 @@ delete, capture timestamps). If you only care about success, just check
 Distinct from "never existed" `404`. Pass `?include_deleted=true` to
 read them through the same endpoints.
 
+### `Unique()` ignores soft-deleted rows
+
+A `Unique()` constraint only considers **live** resources. After you soft-delete
+a row, its value (SKU, employee id, …) can be reused by a new resource. This is
+often desirable, but surprising if you expected the value to stay reserved.
+Permanently delete (or keep the row) if you need the value held.
+
+---
+
+## Blobs / attachments
+
+### Deleting a resource does **not** delete its blobs
+
+Blobs (`Binary` / `file_id`) are **not** reference-counted or garbage-collected
+on delete, so deleting a resource leaves its uploaded files behind. Do **not**
+naively delete a resource's blobs in an on-delete handler: the same `file_id`
+can be referenced by **other resources, other fields, or older revisions** of
+the same resource (and soft-deleted resources can still be restored). Deleting
+it would corrupt those references.
+
+Safe cleanup is a refcount-aware sweep, not an on-delete hook. Recipe:
+
+```python
+# Run as a periodic / manual GC, never inline on delete.
+# A blob is an orphan only if NO live resource/revision references it.
+def collect_orphan_blobs(manager, *, dry_run=True):
+    referenced: set[str] = set()
+    # 1. gather every file_id referenced by any live revision of any resource
+    for meta in manager.iter_all():                  # all live resources
+        for rev_id in manager.list_revisions(meta.resource_id):
+            data = manager.get_resource_revision(meta.resource_id, rev_id).data
+            referenced |= file_ids_in(data)          # your model-specific extractor
+    # 2. delete blobs that nothing references
+    orphans = [bid for bid in manager.blob_store.list_blobs() if bid not in referenced]
+    if not dry_run:
+        for bid in orphans:
+            manager.blob_store.delete(bid)
+    return orphans
+```
+
+Adapt `file_ids_in(...)` and the blob-store listing to your storage backend;
+both a full revision scan and blob enumeration are required to be correct.
+
 ---
 
 ## Versioning / migration
@@ -231,12 +284,13 @@ The mounted paths follow `model_naming` and are singular —
 
 ## Backup / restore
 
-### `/import` accepts `multipart/form-data` even though `/export` returns raw bytes
+### `/import` accepts both a `multipart` `file` field and a raw body
 
-`GET /{model}/export` streams `application/octet-stream`, but
-`POST /{model}/import` expects `multipart/form-data` with a `file`
-field. Sending the export body raw → `422`. See [Backup &
-Restore](./backup-restore.md#per-model-import) for a `curl` recipe.
+`GET /{model}/export` streams `application/octet-stream`.
+`POST /{model}/import` accepts **either** `multipart/form-data` with a `file`
+field **or** the archive as a raw `application/octet-stream` body — so the
+export bytes round-trip directly (`--data-binary @dump.acbak`). See [Backup &
+Restore](./backup-restore.md#per-model-import) for `curl` recipes.
 
 ---
 
@@ -260,7 +314,8 @@ spec.add_route_template(GraphQLRouteTemplate())
 
 ### Multi-word class names are kebab-cased, not snake-cased
 
-`BlogPost → /blog-post`, `XMLNode → /x-m-l-node`. The default
+`BlogPost → /blog-post`, `XMLNode → /xml-node` (acronyms are treated as one
+word, not split letter-by-letter). The default
 `model_naming="kebab"` is lowercase with hyphens; see [Routes howto §
 `model_naming` reference](./routes.md#model_naming-reference) for a full
 matrix and an example of supplying a callable (e.g. to pluralise).

--- a/docs/en/howto/routes.md
+++ b/docs/en/howto/routes.md
@@ -52,10 +52,10 @@ words joined by hyphens.
 
 | `model_naming` | `User`     | `BlogPost`   | `URLPath`    | `XMLNode`   |
 |----------------|------------|--------------|--------------|-------------|
-| `"kebab"` *(default)* | `/user`    | `/blog-post` | `/u-r-l-path` | `/x-m-l-node` |
-| `"snake"`      | `/user`    | `/blog_post` | `/u_r_l_path` | `/x_m_l_node` |
-| `"camel"`      | `/user`    | `/blogPost`  | `/uRLPath`   | `/xMLNode`  |
-| `"pascal"`     | `/User`    | `/BlogPost`  | `/URLPath`   | `/XMLNode`  |
+| `"kebab"` *(default)* | `/user`    | `/blog-post` | `/url-path` | `/xml-node` |
+| `"snake"`      | `/user`    | `/blog_post` | `/url_path` | `/xml_node` |
+| `"camel"`      | `/user`    | `/blogPost`  | `/urlPath`   | `/xmlNode`  |
+| `"pascal"`     | `/User`    | `/BlogPost`  | `/UrlPath`   | `/XmlNode`  |
 | `"same"`       | `/User`    | `/BlogPost`  | `/URLPath`   | `/XMLNode`  |
 | callable       | `model_naming=lambda cls: cls.__name__.lower() + "s"` → `/users` |
 

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -289,6 +289,7 @@ class SpecStar:
         validate_refs: bool = False,
         on_decode_error: OnDecodeError = OnDecodeError.skip,
         on_unindexed_query: OnUnindexedQuery = OnUnindexedQuery.warn,
+        default_get_returns: "str | list[str] | UnsetType" = UNSET,
     ):
         # Initialize empty collections
         self.resource_managers: OrderedDict[str, IResourceManager] = OrderedDict()
@@ -319,6 +320,9 @@ class SpecStar:
         self.forbid_unknown_fields = False
         self.on_decode_error: OnDecodeError = OnDecodeError.skip
         self.on_unindexed_query: OnUnindexedQuery = OnUnindexedQuery.warn
+        # UNSET = caller never chose a GET shape → the envelope is used and the
+        # startup advisory fires. Setting it (even to the envelope) silences it.
+        self.default_get_returns: "str | list[str] | UnsetType" = UNSET
         self.structured_errors = False
         self.validate_refs = False
         self._pending_create_actions: list[_PendingCreateAction] = []
@@ -351,6 +355,7 @@ class SpecStar:
             validate_refs=validate_refs,
             on_decode_error=on_decode_error,
             on_unindexed_query=on_unindexed_query,
+            default_get_returns=default_get_returns,
         )
 
     def _apply_configuration(
@@ -380,6 +385,7 @@ class SpecStar:
         validate_refs: bool | UnsetType = UNSET,
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
+        default_get_returns: "str | list[str] | UnsetType" = UNSET,
     ) -> None:
         """Apply configuration settings to the SpecStar instance.
 
@@ -547,6 +553,10 @@ class SpecStar:
         if on_unindexed_query is not UNSET:
             self.on_unindexed_query = OnUnindexedQuery(on_unindexed_query)
 
+        # Update default_get_returns
+        if default_get_returns is not UNSET:
+            self.default_get_returns = default_get_returns
+
         # Update structured_errors
         if structured_errors is not UNSET:
             self.structured_errors = structured_errors
@@ -581,6 +591,7 @@ class SpecStar:
         validate_refs: bool | UnsetType = UNSET,
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
+        default_get_returns: "str | list[str] | UnsetType" = UNSET,
         vector_encoders: dict[str, Callable] | UnsetType = UNSET,
     ) -> None:
         """Configure the SpecStar instance dynamically.
@@ -689,6 +700,7 @@ class SpecStar:
             validate_refs=validate_refs,
             on_decode_error=on_decode_error,
             on_unindexed_query=on_unindexed_query,
+            default_get_returns=default_get_returns,
         )
 
         # Register vector encoders into the registry
@@ -1124,6 +1136,7 @@ class SpecStar:
         vector_encoders: dict[str, str | Callable] | None = None,
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
+        default_get_returns: "str | list[str] | UnsetType" = UNSET,
     ) -> None:
         """Register a resource model (or `Schema`) and create its `ResourceManager`.
 
@@ -1448,6 +1461,15 @@ class SpecStar:
                 if on_unindexed_query is not UNSET
                 else self.on_unindexed_query
             ),
+            default_get_returns=(
+                default_get_returns
+                if default_get_returns is not UNSET
+                else (
+                    self.default_get_returns
+                    if self.default_get_returns is not UNSET
+                    else "data,revision_info,meta"
+                )
+            ),
             encoder_registry=self.encoder_registry,
             vector_encoders=vector_encoders,
             **other_options,
@@ -1582,6 +1604,26 @@ class SpecStar:
                 "a single GET can load an entire table. Set "
                 f"{DEFAULT_QUERY_LIMIT_ENV_VAR}, pass an explicit ?limit=, or "
                 "use iter_all() / the X-Has-More header to page safely.",
+                SpecStarWarning,
+                stacklevel=3,
+            )
+        if not self.validate_refs:
+            warnings.warn(
+                "validate_refs is off (the default): writes accept Ref(...) "
+                "values pointing at non-existent targets, creating dangling "
+                "references silently. Set validate_refs=True to reject them at "
+                "write time.",
+                SpecStarWarning,
+                stacklevel=3,
+            )
+        if self.default_get_returns is UNSET:
+            # Never chose a GET shape → the envelope is in effect.
+            warnings.warn(
+                "default_get_returns is unset, so GET /{model}/{id} returns the "
+                'full envelope {"data": ..., "meta": ..., "revision_info": ...}, '
+                "not a bare object. Set default_get_returns='only-data' (or pass "
+                "?returns=only-data) if your clients expect a plain object; set "
+                "it explicitly to silence this.",
                 SpecStarWarning,
                 stacklevel=3,
             )

--- a/specstar/crud/route_templates/backup.py
+++ b/specstar/crud/route_templates/backup.py
@@ -152,23 +152,29 @@ class ImportRouteTemplate(BaseRouteTemplate):
                 Use ``on_duplicate`` to control behaviour when a resource ID
                 already exists.
 
-                **Upload format:** ``multipart/form-data`` with a single
-                ``file`` field carrying the archive bytes — NOT a raw
-                ``application/octet-stream`` body. Sending the archive as
-                the raw request body (as ``GET /{model_name}/export``
-                returns it) will fail with ``422`` because FastAPI cannot
-                find the ``file`` form field.
+                **Upload format:** either ``multipart/form-data`` with a single
+                ``file`` field, or the archive as a raw
+                ``application/octet-stream`` request body — the latter so the
+                bytes from ``GET /{model_name}/export`` round-trip directly.
 
-                Example with ``curl``:
+                Examples with ``curl``:
                 ```
+                # multipart form field
                 curl -X POST -F 'file=@dump.acbak' \\
-                     -F 'on_duplicate=overwrite' \\
-                     http://localhost:8000/{model_name}/import
+                     'http://localhost:8000/{model_name}/import?on_duplicate=overwrite'
+
+                # raw body (round-trips with export)
+                curl -X POST --data-binary @dump.acbak \\
+                     -H 'Content-Type: application/octet-stream' \\
+                     'http://localhost:8000/{model_name}/import?on_duplicate=overwrite'
                 ```
             """),
         )
         async def import_model(
-            file: UploadFile = File(..., description=".acbak archive file"),
+            request: Request,
+            file: UploadFile | None = File(
+                None, description=".acbak archive file (multipart)"
+            ),
             on_duplicate: str = Query(
                 "overwrite",
                 description="Strategy: overwrite | skip | raise_error",
@@ -198,7 +204,17 @@ class ImportRouteTemplate(BaseRouteTemplate):
                 )
 
             # --- read & validate archive ------------------------------
-            data = await file.read()
+            # Accept either a multipart ``file`` field or a raw request body so
+            # the bytes from ``GET /{model}/export`` can be POSTed back directly.
+            data = await file.read() if file is not None else await request.body()
+            if not data:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Empty import: send the archive as a multipart 'file' "
+                        "field or as a raw application/octet-stream body."
+                    ),
+                )
             reader = DumpStreamReader(io.BytesIO(data))
 
             try:

--- a/specstar/crud/route_templates/get.py
+++ b/specstar/crud/route_templates/get.py
@@ -194,6 +194,10 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
             include_deleted=False,
         ):
             # 獲取資源和元數據
+            if returns is None:
+                returns = getattr(
+                    resource_manager, "default_get_returns", "data,revision_info,meta"
+                )
             try:
                 fields = partial or partial_brackets
                 if fields is None:
@@ -205,6 +209,53 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
                     if raw:
                         fields = raw
                 returns_list = [r.strip() for r in returns.split(",")]
+                # hyphen aliases for the underscore section name
+                _RETURNS_ALIASES = {
+                    "revision-info": "revision_info",
+                    "only-revision-info": "only-revision_info",
+                }
+                returns_list = [_RETURNS_ALIASES.get(r, r) for r in returns_list]
+
+                if any(r.startswith("only-") for r in returns_list):
+                    # ``only-<section>`` returns that section *bare* (unwrapped),
+                    # unlike ``<section>`` which keeps the {data,meta,...} envelope.
+                    # It must be used alone.
+                    if len(returns_list) != 1:
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                "An 'only-*' returns value must be used alone; "
+                                f"got {returns!r}."
+                            ),
+                        )
+                    section = returns_list[0][len("only-") :]
+                    if section not in ("data", "meta", "revision_info"):
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Unknown returns value {returns_list[0]!r}. "
+                                "Use only-data, only-meta, or only-revision_info."
+                            ),
+                        )
+                    meta = resource_manager.get_meta(
+                        resource_id, include_deleted=include_deleted
+                    )
+                    target_revision_id = revision_id or meta.current_revision_id
+                    if section == "data":
+                        bare = resource_manager.get_resource_revision(
+                            resource_id,
+                            target_revision_id,
+                            schema_version=meta.schema_version,
+                        ).data
+                    elif section == "meta":
+                        bare = meta
+                    else:  # revision_info
+                        bare = resource_manager.get_revision_info(
+                            resource_id,
+                            target_revision_id,
+                            schema_version=meta.schema_version,
+                        )
+                    return MsgspecResponse(bare)
 
                 # Classify partial fields by prefix
                 spec = classify_partial_fields(fields, default_category="data")
@@ -315,9 +366,14 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
             ),
             current_user: str = Depends(self.deps.get_user),
             current_time: dt.datetime = Depends(self.deps.get_now),
-            returns: str = Query(
-                default="data,revision_info,meta",
-                description="Fields to return, comma-separated. Options: data, revision_info, meta",
+            returns: Optional[str] = Query(
+                default=None,
+                description=(
+                    "Sections to return, comma-separated: data, revision_info, "
+                    "meta (the envelope). Or a single only-data / only-meta / "
+                    "only-revision_info for a bare (unwrapped) object. Omit to "
+                    "use the server default (default_get_returns)."
+                ),
             ),
         ):
             return await _handle_get_with_returns(
@@ -741,9 +797,14 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
             ),
             current_user: str = Depends(self.deps.get_user),
             current_time: dt.datetime = Depends(self.deps.get_now),
-            returns: str = Query(
-                default="data,revision_info,meta",
-                description="Fields to return, comma-separated. Options: data, revision_info, meta",
+            returns: Optional[str] = Query(
+                default=None,
+                description=(
+                    "Sections to return, comma-separated: data, revision_info, "
+                    "meta (the envelope). Or a single only-data / only-meta / "
+                    "only-revision_info for a bare (unwrapped) object. Omit to "
+                    "use the server default (default_get_returns)."
+                ),
             ),
         ):
             return await _handle_get_with_returns(

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -851,6 +851,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         forbid_unknown_fields: bool = False,
         on_decode_error: OnDecodeError = OnDecodeError.skip,
         on_unindexed_query: OnUnindexedQuery = OnUnindexedQuery.warn,
+        default_get_returns: "str | list[str]" = "data,revision_info,meta",
         encoder_registry: "Any | None" = None,
         vector_encoders: "dict[str, str | Callable] | None" = None,
     ):
@@ -877,6 +878,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         self._forbid_unknown_fields = forbid_unknown_fields
         self._on_decode_error = OnDecodeError(on_decode_error)
         self._on_unindexed_query = OnUnindexedQuery(on_unindexed_query)
+        self._default_get_returns = (
+            ",".join(default_get_returns)
+            if isinstance(default_get_returns, (list, tuple))
+            else default_get_returns
+        )
         self._warned_lazy_migration = False
 
         # ── Resolve Schema vs legacy migration/validator ──────────────
@@ -1188,6 +1194,12 @@ class ResourceManager(IResourceManager[T], Generic[T]):
     @property
     def resource_type(self):
         return self._resource_type
+
+    @property
+    def default_get_returns(self) -> str:
+        """Default value for the GET ``returns`` query param (the response shape
+        when the client omits ``?returns=``). See ``OnUnindexedQuery`` siblings."""
+        return self._default_get_returns
 
     @property
     def schema_version(self) -> str:

--- a/specstar/resource_manager/partial.py
+++ b/specstar/resource_manager/partial.py
@@ -325,6 +325,20 @@ def classify_partial_fields(
     if not fields:
         return PartialFieldsSpec()
 
+    if any(f.strip().lstrip("/").lower() in ("true", "false") for f in fields):
+        import warnings
+
+        from specstar.types import SpecStarWarning
+
+        warnings.warn(
+            "partial received a boolean-looking value ('true'/'false'). "
+            "`partial` is a slash-path field selector, not a boolean — e.g. "
+            "partial=true selects a (non-existent) field named 'true' and "
+            "clears the section. Use partial=/field paths, or omit it.",
+            SpecStarWarning,
+            stacklevel=2,
+        )
+
     data_fields: list[str] = []
     meta_fields: list[str] = []
     info_fields: list[str] = []

--- a/tests/test_export_import_roundtrip.py
+++ b/tests/test_export_import_roundtrip.py
@@ -1,0 +1,49 @@
+"""`GET /{model}/export` returns raw bytes; `POST /{model}/import` accepts
+them. The import endpoint takes either a multipart `file` field or — so that
+`export | import` round-trips — a raw `application/octet-stream` body.
+"""
+
+import msgspec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import SpecStar
+
+
+class Widget(msgspec.Struct):
+    name: str
+
+
+def _app() -> TestClient:
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Widget, name="widget")
+    app = FastAPI()
+    sp.apply(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_export_then_import_raw_bytes_round_trips():
+    src = _app()
+    src.post("/widget", json={"name": "roundtrip"})
+    archive = src.get("/widget/export").content
+
+    dst = _app()
+    r = dst.post(
+        "/widget/import",
+        content=archive,  # raw body, not multipart
+        headers={"content-type": "application/octet-stream"},
+    )
+    assert r.status_code == 200, r.text
+    assert len(dst.get("/widget").json()) == 1  # the resource landed
+
+
+def test_import_still_accepts_multipart_file():
+    src = _app()
+    src.post("/widget", json={"name": "viaform"})
+    archive = src.get("/widget/export").content
+
+    dst = _app()
+    r = dst.post("/widget/import", files={"file": ("dump.acbak", archive)})
+    assert r.status_code == 200, r.text
+    assert len(dst.get("/widget").json()) == 1

--- a/tests/test_get_returns_shape.py
+++ b/tests/test_get_returns_shape.py
@@ -1,0 +1,135 @@
+"""GET response-shape control via the `returns` vocabulary.
+
+`?returns=data,meta,revision_info` (the default) returns the full envelope.
+The new `only-*` values return a *bare* section (unwrapped), so a front end
+that wants a plain object can ask for `?returns=only-data`. `only-*` must be
+used alone — combining it with any other value is a 422.
+"""
+
+import warnings
+
+import msgspec
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import SpecStar
+from specstar.errors import SpecStarWarning
+
+
+class Widget(msgspec.Struct):
+    name: str
+
+
+def _client(**cfg) -> TestClient:
+    sp = SpecStar()
+    sp.configure(default_user="t", **cfg)
+    sp.add_model(Widget, name="widget")
+    app = FastAPI()
+    sp.apply(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _create(c: TestClient, name: str = "x") -> str:
+    return c.post("/widget", json={"name": name}).json()["resource_id"]
+
+
+def test_returns_only_data_is_a_bare_object():
+    c = _client()
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "only-data"})
+    assert r.status_code == 200
+    assert r.json() == {"name": "x"}  # bare object, not {"data": {...}}
+
+
+def test_returns_only_meta_is_bare_meta():
+    c = _client()
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "only-meta"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resource_id"] == rid  # bare ResourceMeta, not {"meta": {...}}
+    assert "current_revision_id" in body
+    assert "meta" not in body
+
+
+def test_returns_only_revision_info_is_bare_info():
+    c = _client()
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "only-revision_info"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["revision_id"].startswith(rid)  # bare RevisionInfo
+    assert "revision_info" not in body
+
+
+def test_only_revision_dash_info_is_alias_for_underscore():
+    c = _client()
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "only-revision-info"})
+    assert r.status_code == 200
+    assert r.json()["revision_id"].startswith(rid)
+
+
+def test_revision_dash_info_alias_in_envelope():
+    # `revision-info` (hyphen) is an alias for the `revision_info` envelope key
+    c = _client()
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "data,revision-info"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "data" in body and "revision_info" in body
+
+
+def test_only_combined_with_other_value_is_422():
+    c = _client()
+    rid = _create(c)
+    for q in ("only-data,meta", "only-data,only-meta", "meta,only-data"):
+        assert c.get(f"/widget/{rid}", params={"returns": q}).status_code == 422, q
+
+
+def test_only_unknown_section_is_422():
+    c = _client()
+    rid = _create(c)
+    assert c.get(f"/widget/{rid}", params={"returns": "only-bogus"}).status_code == 422
+
+
+def test_default_get_returns_config_changes_the_default_shape():
+    c = _client(default_get_returns="only-data")
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}")  # no ?returns= → falls back to the config default
+    assert r.status_code == 200
+    assert r.json() == {"name": "x"}  # bare, because default is only-data
+
+
+def test_per_request_returns_overrides_config_default():
+    c = _client(default_get_returns="only-data")
+    rid = _create(c)
+    r = c.get(f"/widget/{rid}", params={"returns": "data,meta,revision_info"})
+    body = r.json()
+    assert "data" in body and "meta" in body and "revision_info" in body
+
+
+def test_default_is_envelope_when_unconfigured():
+    c = _client()
+    rid = _create(c)
+    body = c.get(f"/widget/{rid}").json()
+    assert "data" in body and "meta" in body and "revision_info" in body
+
+
+def test_default_envelope_emits_startup_advisory():
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Widget, name="widget")
+    with pytest.warns(SpecStarWarning, match="default_get_returns"):
+        sp.apply(FastAPI())
+
+
+def test_non_default_get_returns_no_advisory():
+    sp = SpecStar()
+    sp.configure(default_user="t", default_get_returns="only-data")
+    sp.add_model(Widget, name="widget")
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        sp.apply(FastAPI())
+    assert not any("default_get_returns" in str(w.message) for w in rec)

--- a/tests/test_partial_boolean_nudge.py
+++ b/tests/test_partial_boolean_nudge.py
@@ -1,0 +1,46 @@
+"""`partial` is a slash-path field selector, not a boolean. Passing
+`partial=true` selects a (non-existent) field named "true" and silently clears
+the section — a common front-end mistake. We emit a SpecStarWarning nudge.
+"""
+
+import warnings
+
+import msgspec
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from specstar import SpecStar
+from specstar.errors import SpecStarWarning
+
+
+class Widget(msgspec.Struct):
+    name: str
+
+
+def _client() -> TestClient:
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Widget, name="widget")
+    app = FastAPI()
+    sp.apply(app)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _create(c: TestClient) -> str:
+    return c.post("/widget", json={"name": "x"}).json()["resource_id"]
+
+
+def test_partial_boolean_value_emits_nudge():
+    c = _client()
+    rid = _create(c)
+    with pytest.warns(SpecStarWarning, match="partial"):
+        c.get(f"/widget/{rid}", params={"partial": "true"})
+
+
+def test_partial_real_path_emits_no_nudge():
+    c = _client()
+    rid = _create(c)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SpecStarWarning)
+        c.get(f"/widget/{rid}", params={"partial": "/name"})  # must not warn

--- a/tests/test_startup_warnings.py
+++ b/tests/test_startup_warnings.py
@@ -35,11 +35,23 @@ def test_warns_when_no_query_limit_configured(monkeypatch):
         sp.apply(FastAPI())
 
 
+def test_warns_when_validate_refs_off(monkeypatch):
+    monkeypatch.setenv("SPECSTAR_DEFAULT_QUERY_LIMIT", "1000")  # silence
+    sp = SpecStar(forbid_unknown_fields=True, default_get_returns="only-data")  # silence
+    sp.add_model(Schema(Item, "v1"))
+    with pytest.warns(SpecStarWarning, match="validate_refs"):
+        sp.apply(FastAPI())
+
+
 def test_hardened_config_emits_no_warning(monkeypatch):
     import warnings as w
 
     monkeypatch.setenv("SPECSTAR_DEFAULT_QUERY_LIMIT", "1000")
-    sp = SpecStar(forbid_unknown_fields=True)
+    sp = SpecStar(
+        forbid_unknown_fields=True,
+        validate_refs=True,
+        default_get_returns="data,revision_info,meta",  # explicit shape: silences advisory
+    )
     sp.add_model(Schema(Item, "v1"))
     with w.catch_warnings(record=True) as rec:
         w.simplefilter("always")


### PR DESCRIPTION
## Summary

A third round of evaluation-driven hardening, on top of `v0.11.3`. The
evaluation note was a mix of (a) genuine doc bugs, (b) loose-but-intentional
defaults, (c) response/protocol-shape friction, and (d) "you must handle this
yourself" items. This PR fixes the confirmed doc bugs, makes the biggest
ergonomic papercut (the GET envelope) configurable, lets `export | import`
round-trip, and turns two more silent footguns into loud-but-suppressible
warnings.

**2 commits. No breaking changes** — every behavior change is additive or a new
`SpecStarWarning`; default response shapes and status codes are unchanged.

## Added / changed

- **GET response shape is configurable.** `?returns=` gains `only-data` /
  `only-meta` / `only-revision_info` (with `only-revision-info` / `revision-info`
  hyphen aliases) which return the **bare, unwrapped** section instead of the
  `{data, revision_info, meta}` envelope — for front ends that want a plain
  object. An `only-*` value must be used alone (combining it, or an unknown
  section, is a **422**). A new server config **`default_get_returns`**
  (`SpecStar(...)` / `configure(...)` / per-model `add_model(...)`; list or
  comma-string) sets the shape used when `?returns=` is omitted; it defaults to
  the full envelope, and a per-request `?returns=` always overrides it.
  *(eval §2)*
- **`export | import` round-trips.** `POST /{model}/import` now accepts the
  archive as a raw `application/octet-stream` body in addition to the multipart
  `file` field, so the bytes from `GET /{model}/export` POST back directly.
  Multipart uploads still work. *(eval §7)*

## Louder defaults (new `SpecStarWarning`s, all suppressible)

- **`default_get_returns` unset** → one-shot startup advisory (the envelope is
  the default and surprises front ends). Setting it explicitly — to any value,
  including the envelope — silences it.
- **`validate_refs` off** → startup advisory (writes accept refs to
  non-existent targets, silently creating dangling references). *(eval §5)*
- **`partial=true` / `false`** → request-time advisory. `partial` is a
  slash-path field selector, not a boolean; `partial=true` selects a field named
  "true" and clears the section. *(eval §1)*

## Fixed — confirmed doc bugs (verified against 0.11.3)

- `event-handlers.md`: `from specstar.resource_manager.events import do` (that
  module doesn't exist) → `from specstar.events import do`; `EventContext` isn't
  in `specstar.types` → `EventContextProto` from `specstar.events`. *(eval §9)*
- `data-model.md`: `resource_id` is `"{model}:{uuid}"` (prefixed), **not** "a
  UUID string". *(eval §2/§9)*
- `routes.md` + `gotchas.md`: the kebab/snake/camel/pascal naming examples for
  `URLPath` / `XMLNode` were wrong — acronyms normalise to one word
  (`XMLNode → /xml-node`, not `/x-m-l-node`). *(eval §8)*

## Docs (no code change)

- `api-conventions`: the `only-*` vocabulary, `default_get_returns`, and the
  `partial`-is-not-a-boolean note.
- `gotchas`: corrected the envelope entry (`?returns=data` still wraps; use
  `only-data`), the import entry (now accepts a raw body), a **POST/PUT return a
  flat `RevisionInfo`** note (vs the GET envelope), **`Unique()` ignores
  soft-deleted rows** *(eval §5)*, and a **refcount-aware orphan-blob GC
  recipe** *(eval §6)*.

## Deliberately docs-only / not in this PR

- **Orphan-blob cleanup ships as a recipe, not a helper.** A `file_id` can be
  referenced by other resources, other fields, or older/soft-deleted revisions,
  so a naive on-delete deleter is a data-loss footgun. The safe form is a
  refcount-aware GC sweep, documented as a recipe to adapt per backend.
- **`DELETE` 200+meta**, **POST-flat vs GET-envelope**, **`Unique` soft-delete**
  → documented (harmonising shapes would be breaking).
- Many eval items were already addressed/documented in 0.11.x (`on_unindexed_query`,
  `on_delete` defaults, `get_user` async pitfall, lazy migration, unknown-field
  and query-limit startup advisories).

## Testing

- Full service-free gate green: **2943 passed, 4 skipped, 0 failures**
  (`pytest -m "not integration and not benchmark and not slow"`).
- **17 new tests**, built TDD (red→green per slice): `only-*` × each section +
  aliases + the 422 rule, `default_get_returns` default/override/advisory,
  export↔import round-trip (raw body + multipart), and the `partial` /
  `validate_refs` advisories.
- `ruff` clean on all changed files.
