### PR TITLE
ci: measure coverage and publish a Codecov badge on the README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,11 +47,29 @@ jobs:
       - name: Documentation examples
         run: uv run pytest --markdown-docs README.md -q -x
 
-      # Service-free unit + route tests. Integration tests (Postgres / S3 /
-      # MinIO / RabbitMQ) are tagged via the root tests/conftest.py and
-      # excluded here; benchmarks and known-slow tests are also excluded.
+      # Service-free unit + route tests, instrumented for coverage. Integration
+      # tests (Postgres / S3 / MinIO / RabbitMQ) are tagged via the root
+      # tests/conftest.py and excluded here; benchmarks and known-slow tests are
+      # also excluded. ``coverage run`` uses [tool.coverage.run] from pyproject
+      # (measures the ``specstar`` package); ``-x`` still fails fast.
       - name: Unit + route tests (no external services)
-        run: uv run pytest -m "not integration and not benchmark and not slow" -q -x
+        run: uv run coverage run -m pytest -m "not integration and not benchmark and not slow" -q -x
+
+      # Print a summary in the log and emit coverage.xml for Codecov. These run
+      # only when the test step above succeeded (no ``if: always()``), so a
+      # fail-fast (-x) partial run is never reported as the coverage number.
+      - name: Coverage report
+        run: |
+          uv run coverage report
+          uv run coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          slug: HYChou0515/specstar
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   # Single status check that fans in from every required job above.
   # Make THIS the required check in branch protection — that way adding a

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://pypi.org/project/specstar/"><img alt="PyPI" src="https://img.shields.io/pypi/v/specstar"></a>
   <a href="https://github.com/HYChou0515/specstar/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/pypi/l/specstar"></a>
   <a href="https://hychou0515.github.io/specstar/"><img alt="Docs" src="https://img.shields.io/badge/docs-mkdocs-blue"></a>
+  <a href="https://codecov.io/gh/HYChou0515/specstar"><img alt="Coverage" src="https://codecov.io/gh/HYChou0515/specstar/branch/master/graph/badge.svg"></a>
 </p>
 
 > **Renamed from `autocrud` to `specstar` (v0.10.0).** The old name still installs as a deprecation shim that redirects every `autocrud[.X]` import to `specstar[.X]`. New projects should `pip install specstar`. See the [migration guide](MIGRATION.md).


### PR DESCRIPTION
Instrument the service-free test step with `coverage run -m pytest` — uses the existing [tool.coverage.run] config (measures the specstar package) and needs no new dependency, since `coverage` is already a dev dep. Then emit coverage.xml and upload via codecov-action@v5. The report + upload steps run only when the test step succeeds (no `if: always()`), so a fail-fast (-x) partial run is never reported as the coverage number. Add a Codecov badge to the README badge row.

One-time setup by the maintainer: enable the repo on codecov.io and add a
CODECOV_TOKEN secret. `fail_ci_if_error: false` keeps the gate green until then.