### PR TITLE
fix(create): reject path/URL-unsafe custom resource_id

### DIFF
--- a/docs/en/howto/gotchas.md
+++ b/docs/en/howto/gotchas.md
@@ -115,6 +115,14 @@ To customise how ids are generated, pass `id_generator=` to
 The one exception: if your Struct *legitimately* declares a field named
 `resource_id`, the guard steps aside and treats it as ordinary data.
 
+A **custom** id supplied programmatically (`rm.create(data, resource_id=...)`
+or a custom `id_generator`) must be safe in file paths **and** URLs: ids with
+`/`, `\`, or control characters are rejected with a `ValidationError`. A `/`
+would otherwise break disk storage (the id is used as a filename) and make the
+resource unreachable over HTTP — `/{model}/{resource_id}` is a single path
+segment, so `GET /model/a/b` (and even `a%2Fb`) returns 404. Stick to letters,
+digits, `:`, `-`, `_`.
+
 ### `PUT` is full-replace, not upsert
 
 | Intuitive guess | Actual behavior |

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -174,6 +174,27 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
+def _validate_resource_id(resource_id: str) -> None:
+    """Reject a caller-supplied ``resource_id`` that isn't safe in file paths
+    and URLs.
+
+    Path separators break disk storage (the id is used as a filename), and any
+    ``/`` makes the resource unaddressable over HTTP (``/{model}/{resource_id}``
+    is a single path segment — even ``%2F`` 404s). We fail fast and
+    backend-agnostically rather than crash later or create a REST-invisible row.
+    Auto-generated ids (``model:uuid``) are unaffected.
+    """
+    if not isinstance(resource_id, str) or not resource_id.strip():
+        raise ValidationError("resource_id must be a non-empty string.")
+    if "/" in resource_id or "\\" in resource_id or any(ord(c) < 32 for c in resource_id):
+        raise ValidationError(
+            f"resource_id {resource_id!r} contains characters that are not "
+            "allowed: path separators ('/', '\\') or control characters. A "
+            "resource_id must be safe in both file paths and URLs — use a flat "
+            "id of letters, digits, ':', '-', or '_'."
+        )
+
+
 class IndexedValueExtractor:
     """從資源資料中提取需要索引的欄位值（Enum 會自動轉換為 value）"""
 
@@ -1561,6 +1582,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             if _id is UNSET:
                 resource_id = self.id_generator()
             else:
+                _validate_resource_id(_id)  # caller-supplied id must be path/URL-safe
                 resource_id = _id
             revision_id = f"{resource_id}:1"
             last_revision_id = None

--- a/tests/test_resource_id_validation.py
+++ b/tests/test_resource_id_validation.py
@@ -1,0 +1,55 @@
+"""A caller-supplied ``resource_id`` must be safe in file paths and URLs.
+
+``create(data, resource_id=...)`` accepts a custom id, but ids with path
+separators or control chars break disk storage (FileNotFoundError) and can't be
+addressed over HTTP (``/{model}/{resource_id}`` is a single segment). So they're
+rejected up front, backend-agnostically, with a clear ValidationError.
+"""
+
+import msgspec
+import pytest
+
+from specstar import SpecStar
+from specstar.errors import ValidationError
+
+
+class W(msgspec.Struct):
+    name: str
+
+
+def _mgr():
+    sp = SpecStar()
+    sp.configure(default_user="t")  # in-memory store
+    sp.add_model(W, name="w")
+    return sp.get_resource_manager(W)
+
+
+def test_create_rejects_slash_in_resource_id():
+    mgr = _mgr()
+    with pytest.raises(ValidationError):
+        mgr.create(W(name="x"), resource_id="a/b")
+
+
+def test_create_rejects_backslash_and_control_and_empty():
+    mgr = _mgr()
+    for bad in ("a\\b", "a\nb", "", "   "):
+        with pytest.raises(ValidationError):
+            mgr.create(W(name="x"), resource_id=bad)
+
+
+def test_create_accepts_a_safe_custom_id():
+    mgr = _mgr()
+    info = mgr.create(W(name="x"), resource_id="my-custom_1")
+    assert mgr.get(info.resource_id).data.name == "x"  # round-trips
+
+
+def test_disk_storage_slash_gives_clear_error_not_filenotfound(tmp_path):
+    # The original bug: on disk this raised a confusing FileNotFoundError.
+    from specstar.resource_manager.storage_factory import DiskStorageFactory
+
+    sp = SpecStar()
+    sp.configure(storage_factory=DiskStorageFactory(str(tmp_path)), default_user="t")
+    sp.add_model(W, name="w")
+    mgr = sp.get_resource_manager(W)
+    with pytest.raises(ValidationError):
+        mgr.create(W(name="x"), resource_id="a/b")


### PR DESCRIPTION
A caller-supplied resource_id (rm.create(data, resource_id=...) or a custom id_generator) is used directly as a disk filename and as a URL path segment. A value like "a/b" therefore crashed disk storage with a confusing FileNotFoundError, behaved differently per backend (memory accepted it, s3 made a folder key), and produced a resource that's unreachable over HTTP (/{model}/{resource_id} is a single segment — even %2F 404s).

Validate the supplied id up front, backend-agnostically: reject path separators ('/', '\\') and control characters (and empty/blank) with a clear ValidationError naming resource_id. Auto-generated ids (model:uuid) and ':' / '-' / '_' are unaffected; the check only runs on the create path where a new caller-supplied id enters.

Adds a gotchas note. Tested on memory and disk (the original crash now gives a clear ValidationError instead of FileNotFoundError).