### PR TITLE
feat(search): default_is_deleted option for programmatic list/count/iter

### DIFF
--- a/docs/en/howto/gotchas.md
+++ b/docs/en/howto/gotchas.md
@@ -153,6 +153,31 @@ delete, capture timestamps). If you only care about success, just check
 Distinct from "never existed" `404`. Pass `?include_deleted=true` to
 read them through the same endpoints.
 
+### Programmatic `list_resources()` includes soft-deleted rows (HTTP excludes them)
+
+The two layers disagree on the default:
+
+| Call | Soft-deleted included? |
+|------|------------------------|
+| `rm.list_resources()` / `count_resources()` / `iter_all()` (bare) | **Yes** — the query's `is_deleted` is `UNSET`, i.e. no filter |
+| `GET /{model}` (no `is_deleted` param) | **No** — the route param defaults to `False` |
+
+To exclude them in a single programmatic call, pass it explicitly:
+
+```python
+from specstar.query_types import ResourceMetaSearchQuery
+rm.list_resources(ResourceMetaSearchQuery(is_deleted=False))   # live only
+```
+
+Or set a default for *all* programmatic list/count/iter calls (non-breaking —
+defaults to `None` = include both):
+
+```python
+spec.configure(default_is_deleted=False)   # exclude soft-deleted by default
+# None = include both (default) · False = exclude · True = only deleted
+# An explicit is_deleted in the query always wins.
+```
+
 ### `Unique()` ignores soft-deleted rows
 
 A `Unique()` constraint only considers **live** resources. After you soft-delete

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -290,6 +290,7 @@ class SpecStar:
         on_decode_error: OnDecodeError = OnDecodeError.skip,
         on_unindexed_query: OnUnindexedQuery = OnUnindexedQuery.warn,
         default_get_returns: "str | list[str] | UnsetType" = UNSET,
+        default_is_deleted: "bool | None | UnsetType" = UNSET,
     ):
         # Initialize empty collections
         self.resource_managers: OrderedDict[str, IResourceManager] = OrderedDict()
@@ -323,6 +324,7 @@ class SpecStar:
         # UNSET = caller never chose a GET shape → the envelope is used and the
         # startup advisory fires. Setting it (even to the envelope) silences it.
         self.default_get_returns: "str | list[str] | UnsetType" = UNSET
+        self.default_is_deleted: "bool | None | UnsetType" = UNSET
         self.structured_errors = False
         self.validate_refs = False
         self._pending_create_actions: list[_PendingCreateAction] = []
@@ -356,6 +358,7 @@ class SpecStar:
             on_decode_error=on_decode_error,
             on_unindexed_query=on_unindexed_query,
             default_get_returns=default_get_returns,
+            default_is_deleted=default_is_deleted,
         )
 
     def _apply_configuration(
@@ -386,6 +389,7 @@ class SpecStar:
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
         default_get_returns: "str | list[str] | UnsetType" = UNSET,
+        default_is_deleted: "bool | None | UnsetType" = UNSET,
     ) -> None:
         """Apply configuration settings to the SpecStar instance.
 
@@ -557,6 +561,10 @@ class SpecStar:
         if default_get_returns is not UNSET:
             self.default_get_returns = default_get_returns
 
+        # Update default_is_deleted
+        if default_is_deleted is not UNSET:
+            self.default_is_deleted = default_is_deleted
+
         # Update structured_errors
         if structured_errors is not UNSET:
             self.structured_errors = structured_errors
@@ -592,6 +600,7 @@ class SpecStar:
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
         default_get_returns: "str | list[str] | UnsetType" = UNSET,
+        default_is_deleted: "bool | None | UnsetType" = UNSET,
         vector_encoders: dict[str, Callable] | UnsetType = UNSET,
     ) -> None:
         """Configure the SpecStar instance dynamically.
@@ -701,6 +710,7 @@ class SpecStar:
             on_decode_error=on_decode_error,
             on_unindexed_query=on_unindexed_query,
             default_get_returns=default_get_returns,
+            default_is_deleted=default_is_deleted,
         )
 
         # Register vector encoders into the registry
@@ -1137,6 +1147,7 @@ class SpecStar:
         on_decode_error: OnDecodeError | UnsetType = UNSET,
         on_unindexed_query: OnUnindexedQuery | UnsetType = UNSET,
         default_get_returns: "str | list[str] | UnsetType" = UNSET,
+        default_is_deleted: "bool | None | UnsetType" = UNSET,
     ) -> None:
         """Register a resource model (or `Schema`) and create its `ResourceManager`.
 
@@ -1468,6 +1479,15 @@ class SpecStar:
                     self.default_get_returns
                     if self.default_get_returns is not UNSET
                     else "data,revision_info,meta"
+                )
+            ),
+            default_is_deleted=(
+                default_is_deleted
+                if default_is_deleted is not UNSET
+                else (
+                    self.default_is_deleted
+                    if self.default_is_deleted is not UNSET
+                    else None
                 )
             ),
             encoder_registry=self.encoder_registry,

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -852,6 +852,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         on_decode_error: OnDecodeError = OnDecodeError.skip,
         on_unindexed_query: OnUnindexedQuery = OnUnindexedQuery.warn,
         default_get_returns: "str | list[str]" = "data,revision_info,meta",
+        default_is_deleted: bool | None = None,
         encoder_registry: "Any | None" = None,
         vector_encoders: "dict[str, str | Callable] | None" = None,
     ):
@@ -883,6 +884,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             if isinstance(default_get_returns, (list, tuple))
             else default_get_returns
         )
+        self._default_is_deleted = default_is_deleted
         self._warned_lazy_migration = False
 
         # ── Resolve Schema vs legacy migration/validator ──────────────
@@ -1880,6 +1882,16 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             stacklevel=3,
         )
 
+    def _apply_default_is_deleted(
+        self, query: ResourceMetaSearchQuery
+    ) -> ResourceMetaSearchQuery:
+        """Inject the configured ``default_is_deleted`` when the query didn't
+        specify one. ``None`` leaves it UNSET (include both live and
+        soft-deleted — the default); an explicit ``is_deleted`` always wins."""
+        if self._default_is_deleted is not None and query.is_deleted is UNSET:
+            return msgspec.structs.replace(query, is_deleted=self._default_is_deleted)
+        return query
+
     def count_resources(
         self, query: "ResourceMetaSearchQuery | Query | None" = None
     ) -> int:
@@ -1898,6 +1910,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             query = ResourceMetaSearchQuery()
         elif isinstance(query, Query):
             query = query.build()
+        query = self._apply_default_is_deleted(query)
         self._validate_query_fields(query)
         query = self._resolve_str_query_vectors(query)
         return self.storage.count(query)
@@ -2030,6 +2043,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
     ) -> list[ResourceMeta]:
         if isinstance(query, Query):
             query = query.build()
+        query = self._apply_default_is_deleted(query)
         self._validate_query_fields(query)
         query = self._resolve_str_query_vectors(query)
         return self.storage.search(query)

--- a/tests/test_default_is_deleted.py
+++ b/tests/test_default_is_deleted.py
@@ -1,0 +1,59 @@
+"""``default_is_deleted`` controls whether programmatic list/count/iter include
+soft-deleted resources when the query doesn't say.
+
+Default (``None``) keeps the current behaviour — no filter, so soft-deleted rows
+are included (non-breaking). ``False`` excludes them (matching the HTTP
+``GET /{model}`` default); ``True`` returns only deleted. An explicit
+``is_deleted`` in the query always wins.
+"""
+
+import msgspec
+
+from specstar import SpecStar
+from specstar.query_types import ResourceMetaSearchQuery
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def _rm(**cfg):
+    sp = SpecStar()
+    sp.configure(default_user="t", **cfg)
+    sp.add_model(Item, name="item")
+    rm = sp.get_resource_manager(Item)
+    a = rm.create(Item(name="alpha")).resource_id
+    rm.create(Item(name="beta"))
+    rm.delete(a)  # soft-delete "alpha"
+    return rm
+
+
+def _names(items):
+    return sorted(x.data.name for x in items)
+
+
+def test_default_is_deleted_false_excludes_soft_deleted():
+    rm = _rm(default_is_deleted=False)
+    assert _names(rm.list_resources()) == ["beta"]
+
+
+def test_default_none_is_non_breaking_includes_soft_deleted():
+    rm = _rm()  # unset → current behaviour
+    assert _names(rm.list_resources()) == ["alpha", "beta"]
+
+
+def test_explicit_query_is_deleted_overrides_the_default():
+    rm = _rm(default_is_deleted=False)
+    only_deleted = rm.list_resources(ResourceMetaSearchQuery(is_deleted=True))
+    assert _names(only_deleted) == ["alpha"]  # explicit wins over default=False
+
+
+def test_default_is_deleted_applies_to_count_and_iter():
+    rm = _rm(default_is_deleted=False)
+    assert rm.count_resources() == 1  # excludes the soft-deleted alpha
+    assert len(list(rm.iter_all())) == 1  # iter_all honours it too
+
+
+def test_default_is_deleted_true_returns_only_deleted():
+    rm = _rm(default_is_deleted=True)
+    assert _names(rm.list_resources()) == ["alpha"]


### PR DESCRIPTION
list_resources / count_resources / iter_all left the query's is_deleted UNSET, so they included soft-deleted rows by default — inconsistent with GET /{model}, whose is_deleted param defaults to False (excludes). Add an opt-in config to control the programmatic default; the default is non-breaking.

- default_is_deleted on SpecStar() / configure() / add_model() (and ResourceManager). None (default) keeps current behaviour (no filter -> include both); False excludes soft-deleted (matches HTTP); True returns only deleted.
- Applied in search_resources + count_resources only when the query's is_deleted is UNSET, so an explicit is_deleted always wins. Covers list_resources and iter_all (they delegate to search_resources).
- gotchas note documenting the programmatic-vs-HTTP asymmetry and the option.