### PR TITLE
feat(locks): lease-based distributed lock (#342 #2)

### DIFF
--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -8,14 +8,19 @@ import os
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     Literal,
     TypeVar,
     cast,
 )
+
+if TYPE_CHECKING:
+    from specstar.locks import ILockBackend, LockHandle
 
 from fastapi import APIRouter, Depends, FastAPI, File, HTTPException, UploadFile
 from fastapi.params import Body
@@ -336,6 +341,13 @@ class SpecStar:
 
         self.encoder_registry = EncoderRegistry()
 
+        # Lease-based distributed lock backend (default: in-memory, single
+        # process). Swap via ``configure(lock_backend=...)`` for multi-worker
+        # deployments (Redis / Postgres / etcd).
+        from specstar.locks import InMemoryLockBackend as _InMemoryLockBackend
+
+        self._lock_backend: "ILockBackend" = _InMemoryLockBackend()
+
         # Apply configuration using shared logic
         self._apply_configuration(
             model_naming=model_naming,
@@ -360,6 +372,58 @@ class SpecStar:
             default_get_returns=default_get_returns,
             default_is_deleted=default_is_deleted,
         )
+
+    # ------------------------------------------------------------------
+    # Lease-based distributed lock primitives (#342 #2).
+    #
+    # These complement CAS: CAS detects a stale write *after* the fact, a
+    # lock prevents the race window in the first place. Use them for
+    # multi-step write workflows that need to serialize per-key across
+    # workers (e.g. "rebuild this aggregate") without holding a DB
+    # transaction the whole way through. The TTL is the anti-deadlock
+    # guarantee — a crashed holder cannot block the key past its lease.
+    # ------------------------------------------------------------------
+    def try_lock(self, key: str, ttl: float) -> "LockHandle | None":
+        """Non-blocking acquire. Returns a handle, or ``None`` if held.
+
+        ``ttl`` is the lease length in seconds; after it elapses any caller
+        may re-acquire. Renew with :meth:`renew_lock` if your work outruns
+        the original lease.
+        """
+        return self._lock_backend.try_acquire(key, ttl)
+
+    def release_lock(self, handle: "LockHandle") -> None:
+        """Release a held lock. Raises :class:`LockNotOwnedError` if the
+        handle's token does not match the current owner (stale handle, or
+        the lease expired and someone else took over).
+        """
+        self._lock_backend.release(handle)
+
+    def renew_lock(self, handle: "LockHandle", ttl: float) -> "LockHandle":
+        """Extend the lease. Returns a new handle with an updated
+        ``expires_at``. Raises :class:`LockNotOwnedError` if a different
+        owner has taken over.
+        """
+        return self._lock_backend.renew(handle, ttl)
+
+    @contextmanager
+    def lock(self, key: str, ttl: float):
+        """Acquire ``key`` for the duration of a ``with`` block.
+
+        Raises :class:`LockHeldError` immediately if the key is held — the
+        context manager refuses to silently fall through when the lock
+        wasn't acquired. Use :meth:`try_lock` if you want to handle that
+        case without an exception.
+        """
+        from specstar.locks import LockHeldError as _LockHeldError
+
+        handle = self._lock_backend.try_acquire(key, ttl)
+        if handle is None:
+            raise _LockHeldError(key)
+        try:
+            yield handle
+        finally:
+            self._lock_backend.release(handle)
 
     def _apply_configuration(
         self,
@@ -602,6 +666,7 @@ class SpecStar:
         default_get_returns: "str | list[str] | UnsetType" = UNSET,
         default_is_deleted: "bool | None | UnsetType" = UNSET,
         vector_encoders: dict[str, Callable] | UnsetType = UNSET,
+        lock_backend: "ILockBackend | UnsetType" = UNSET,
     ) -> None:
         """Configure the SpecStar instance dynamically.
 
@@ -717,6 +782,11 @@ class SpecStar:
         if vector_encoders is not UNSET:
             for name, fn in vector_encoders.items():
                 self.encoder_registry.register(name, fn)
+
+        # Swap the lease-lock backend (default: in-memory; swap for Redis /
+        # Postgres / etcd in multi-worker deployments).
+        if lock_backend is not UNSET:
+            self._lock_backend = lock_backend
 
     def get_resource_manager(self, model: type[T] | str) -> IResourceManager[T]:
         """Get the resource manager for a registered model.

--- a/specstar/locks.py
+++ b/specstar/locks.py
@@ -1,0 +1,161 @@
+"""Lease-based distributed lock primitive (#342 follow-up #2).
+
+A lock here is *advisory* and *leased*: callers cooperate by checking the lock
+before doing work, and every grant carries a TTL so a crashed holder cannot
+deadlock the key forever. After the lease expires, the next caller can
+re-acquire — the new owner gets a fresh token, and any operation using the
+old token is rejected.
+
+The default backend is in-memory (single-process). A multi-worker deployment
+swaps in a Redis / Postgres / etcd backend through ``spec.configure(
+lock_backend=...)``; the backend protocol is intentionally small.
+
+Token discipline:
+    Every grant returns a ``LockHandle`` with an opaque ``token`` — a nonce
+    rotated on each acquisition. ``release_lock`` and ``renew_lock`` require
+    the holder's token; a wrong token raises :class:`LockNotOwnedError`. This
+    prevents a stale handle (e.g. from a previous lease window) from
+    releasing the *new* owner's lock.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from typing import Protocol
+
+import msgspec
+
+
+class LockHandle(msgspec.Struct, frozen=True, kw_only=True):
+    """Opaque ownership token returned by :meth:`SpecStar.try_lock`.
+
+    Hold this and pass it back to :meth:`SpecStar.release_lock` /
+    :meth:`SpecStar.renew_lock` to prove you are the current owner. The
+    ``token`` field is the proof-of-ownership nonce — never derive it
+    yourself; only the backend issues valid tokens.
+    """
+
+    key: str
+    token: str
+    expires_at: float  # monotonic-clock deadline
+
+
+class LockHeldError(RuntimeError):
+    """Raised by :meth:`SpecStar.lock` (the context-manager form) when the
+    key is already held by someone else.
+
+    The non-blocking :meth:`try_lock` returns ``None`` in this case; the
+    context manager raises so a ``with`` block can't silently proceed when
+    the lock wasn't acquired.
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"lock {key!r} is already held")
+        self.key = key
+
+
+class LockNotOwnedError(RuntimeError):
+    """Raised by :meth:`release_lock` / :meth:`renew_lock` when the supplied
+    handle's token does not match the current owner's token.
+
+    This protects against two stale-handle scenarios: a release after the
+    lease expired and a new owner took over, and a buggy caller using a
+    handle returned to a different worker.
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"handle for lock {key!r} is not the current owner")
+        self.key = key
+
+
+class ILockBackend(Protocol):
+    """Minimal contract for a lease-lock storage backend.
+
+    A backend owns the atomic compare-and-set semantics. Implementations:
+    in-memory (default), Redis ``SET NX PX`` + Lua release, Postgres
+    advisory locks with a TTL row, etcd lease, etc.
+    """
+
+    def try_acquire(self, key: str, ttl: float) -> LockHandle | None:
+        """Atomically acquire ``key`` if free (or its lease has expired).
+
+        Returns a fresh ``LockHandle`` on success, ``None`` if held.
+        """
+
+    def release(self, handle: LockHandle) -> None:
+        """Release ``key`` iff the handle's token still matches the owner.
+
+        Raises :class:`LockNotOwnedError` on mismatch (stale handle / not
+        the current owner). A no-op if the lease already expired *and*
+        nobody re-acquired — releasing a phantom is fine.
+        """
+
+    def renew(self, handle: LockHandle, ttl: float) -> LockHandle:
+        """Extend the lease iff the handle's token still matches.
+
+        Returns a new ``LockHandle`` with an updated ``expires_at``. Raises
+        :class:`LockNotOwnedError` if a different owner took over (e.g.
+        the prior lease expired before ``renew`` arrived).
+        """
+
+
+class InMemoryLockBackend:
+    """Single-process, threadsafe lease-lock backend.
+
+    Suitable for tests, single-worker deployments, and the default-out-of-
+    the-box experience. For multi-worker deployments, swap in a Redis or
+    Postgres backend via ``spec.configure(lock_backend=...)``.
+    """
+
+    def __init__(self) -> None:
+        self._mu = threading.Lock()
+        # key -> (token, expires_at_monotonic)
+        self._held: dict[str, tuple[str, float]] = {}
+
+    def _expired(self, expires_at: float) -> bool:
+        return time.monotonic() >= expires_at
+
+    def try_acquire(self, key: str, ttl: float) -> LockHandle | None:
+        with self._mu:
+            current = self._held.get(key)
+            if current is not None and not self._expired(current[1]):
+                return None
+            token = secrets.token_urlsafe(16)
+            expires_at = time.monotonic() + ttl
+            self._held[key] = (token, expires_at)
+            return LockHandle(key=key, token=token, expires_at=expires_at)
+
+    def release(self, handle: LockHandle) -> None:
+        with self._mu:
+            current = self._held.get(handle.key)
+            if current is None:
+                # Already gone — releasing a phantom (expired + reaped) is
+                # benign. The "wrong-token" check below is what catches
+                # actual ownership violations.
+                return
+            token, _expires_at = current
+            if token != handle.token:
+                raise LockNotOwnedError(handle.key)
+            del self._held[handle.key]
+
+    def renew(self, handle: LockHandle, ttl: float) -> LockHandle:
+        with self._mu:
+            current = self._held.get(handle.key)
+            if current is None or current[0] != handle.token:
+                raise LockNotOwnedError(handle.key)
+            expires_at = time.monotonic() + ttl
+            self._held[handle.key] = (handle.token, expires_at)
+            return LockHandle(
+                key=handle.key, token=handle.token, expires_at=expires_at
+            )
+
+
+__all__ = [
+    "ILockBackend",
+    "InMemoryLockBackend",
+    "LockHandle",
+    "LockHeldError",
+    "LockNotOwnedError",
+]

--- a/tests/test_lease_lock.py
+++ b/tests/test_lease_lock.py
@@ -1,0 +1,110 @@
+"""#342 #2 — lease-based distributed lock primitive.
+
+``spec.lock(key, ttl)`` / ``try_lock`` / ``renew_lock`` / ``release_lock`` give
+write workflows the cross-worker mutex they need when CAS isn't enough — e.g.
+a multi-step pipeline that must serialize per collection without holding a
+DB transaction the whole way through.
+
+The TTL (lease) means a crashed holder can't deadlock the key forever: once
+the lease expires, anyone can re-acquire.
+
+Single-process default is in-memory. A pluggable ``ILockBackend`` lets a
+multi-worker deployment swap in Redis / Postgres advisory locks — one line
+in ``spec.configure()``.
+"""
+
+import time
+
+import pytest
+
+from specstar import SpecStar
+from specstar.locks import (
+    LockHandle,
+    LockHeldError,
+    LockNotOwnedError,
+)
+
+
+def _spec() -> SpecStar:
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    return sp
+
+
+def test_try_lock_on_free_key_returns_handle():
+    sp = _spec()
+    handle = sp.try_lock("k1", ttl=60)
+    assert isinstance(handle, LockHandle)
+    assert handle.key == "k1"
+    assert handle.token  # opaque ownership nonce
+
+
+def test_try_lock_on_held_key_returns_none():
+    sp = _spec()
+    sp.try_lock("k1", ttl=60)
+    assert sp.try_lock("k1", ttl=60) is None  # already held
+
+
+def test_release_lock_frees_the_key():
+    sp = _spec()
+    h = sp.try_lock("k1", ttl=60)
+    sp.release_lock(h)
+    assert sp.try_lock("k1", ttl=60) is not None  # available again
+
+
+def test_release_lock_with_wrong_token_raises():
+    # Holder A's release must not free B's lock — token is the ownership proof.
+    sp = _spec()
+    real = sp.try_lock("k1", ttl=60)
+    fake = LockHandle(key="k1", token="wrong", expires_at=real.expires_at)
+    with pytest.raises(LockNotOwnedError):
+        sp.release_lock(fake)
+
+
+def test_expired_lock_can_be_reacquired_by_a_new_caller():
+    # The TTL is the anti-deadlock guarantee — a crashed holder must not
+    # block forever.
+    sp = _spec()
+    sp.try_lock("k1", ttl=0.05)
+    time.sleep(0.1)
+    assert sp.try_lock("k1", ttl=60) is not None
+
+
+def test_renew_lock_extends_ttl():
+    sp = _spec()
+    h = sp.try_lock("k1", ttl=0.05)
+    sp.renew_lock(h, ttl=60)
+    time.sleep(0.1)  # past the ORIGINAL ttl
+    assert sp.try_lock("k1", ttl=60) is None  # still held after renew
+
+
+def test_renew_lock_with_wrong_token_raises():
+    sp = _spec()
+    sp.try_lock("k1", ttl=60)
+    bogus = LockHandle(key="k1", token="not-yours", expires_at=time.monotonic() + 60)
+    with pytest.raises(LockNotOwnedError):
+        sp.renew_lock(bogus, ttl=60)
+
+
+def test_lock_context_manager_acquires_and_releases():
+    sp = _spec()
+    with sp.lock("k1", ttl=60):
+        # inside: another caller is locked out
+        assert sp.try_lock("k1", ttl=60) is None
+    # outside: lock released
+    assert sp.try_lock("k1", ttl=60) is not None
+
+
+def test_lock_context_manager_raises_when_held():
+    sp = _spec()
+    sp.try_lock("k1", ttl=60)
+    with pytest.raises(LockHeldError):
+        with sp.lock("k1", ttl=60):
+            pass  # pragma: no cover
+
+
+def test_different_keys_are_independent():
+    sp = _spec()
+    a = sp.try_lock("a", ttl=60)
+    b = sp.try_lock("b", ttl=60)
+    assert a is not None and b is not None


### PR DESCRIPTION
## Summary
- Adds `spec.try_lock` / `release_lock` / `renew_lock` and a `with spec.lock(key, ttl)` context manager — the cross-worker mutex that complements CAS.
- TTL is the anti-deadlock guarantee: a crashed holder can never block a key forever. After the lease expires anyone can re-acquire; the new owner's token rotates so a stale handle can't release the new owner's lock (`LockNotOwnedError`).
- In-memory single-process backend ships by default; swap via `configure(lock_backend=...)` for Redis / Postgres / etcd. `ILockBackend` is a 3-method Protocol (`try_acquire`, `release`, `renew`).

## Why this and CAS
CAS detects a stale write *after* the fact. Locks prevent the race window — useful for multi-step write workflows that need to serialize per-key without holding a DB transaction the whole way through.

## Test plan
- [x] `tests/test_lease_lock.py` — 10 tests covering acquire / held-returns-None / release / wrong-token / TTL-expiry / renew / context-manager / cross-key independence
- [x] `uv run pytest tests/test_lease_lock.py` — 10/10 green
- [x] Smoke ran against `tests/test_apply_method.py` + `tests/test_backend_config.py` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)