### PR TITLE
feat(queue): partition_key + idempotency_key (#342 #3/#4)

### DIFF
--- a/specstar/message_queue/simple.py
+++ b/specstar/message_queue/simple.py
@@ -85,14 +85,104 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
 
         return resource
 
+    def enqueue(
+        self,
+        payload: T,
+        *,
+        partition_key: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Resource[Job[T]]:
+        """Create-and-enqueue in one step, honoring optional dedup +
+        per-key serialization tags.
+
+        Why this exists alongside ``put()``:
+            ``put(resource_id)`` is the low-level "already-created" entry
+            point. ``enqueue()`` is the user-facing path that knows about
+            the new dedup/serialization semantics — it owns the
+            "is this a retry of an enqueue I already processed?" check
+            because that check must happen *before* the new resource is
+            created (otherwise dedup is a race).
+
+        Args:
+            payload: The job payload.
+            partition_key: When set, no two jobs with this same key will
+                be PROCESSING simultaneously. ``None`` = no serialization.
+            idempotency_key: When set, a prior enqueue with this key
+                returns the *original* job — including after completion —
+                so caller retries are exactly-once. Re-using a key with a
+                different payload raises :class:`ValueError` (programming
+                error, not a benign retry).
+
+        Returns:
+            The job resource (existing one on dedup, fresh one otherwise).
+        """
+        if idempotency_key is not None:
+            existing = self._find_by_idempotency_key(idempotency_key)
+            if existing is not None:
+                if existing.data.payload != payload:
+                    raise ValueError(
+                        f"idempotency_key {idempotency_key!r} was previously "
+                        "used with a different payload — refusing to dedup "
+                        "across mismatched requests. Use a fresh key or "
+                        "send the original payload."
+                    )
+                return existing
+
+        job: Job[T] = Job(
+            payload=payload,
+            partition_key=partition_key,
+            idempotency_key=idempotency_key,
+        )
+        info = self.rm.create(job)  # ty:ignore[invalid-argument-type]
+        return self.put(info.resource_id)
+
+    def _find_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> Resource[Job[T]] | None:
+        """Look up an existing job by ``idempotency_key``.
+
+        Returns ``None`` if no prior enqueue used this key. Returns the
+        resource regardless of its current status — the contract is "same
+        key → same job, forever", including after completion (otherwise a
+        late retry would re-do the work).
+        """
+        query = ResourceMetaSearchQuery(
+            conditions=[
+                DataSearchCondition(
+                    field_path="idempotency_key",
+                    operator=DataSearchOperator.equals,
+                    value=idempotency_key,
+                )
+            ],
+            limit=1,
+        )
+        metas = self.rm.search_resources(query)
+        for meta in metas:
+            try:
+                return self.rm.get(meta.resource_id)
+            except Exception:
+                return None
+        return None
+
     def pop(self) -> Resource[Job[T]] | None:
         """
         Dequeue the next pending job and mark it as processing.
 
+        Honors ``partition_key`` (#342 #3): a pending job whose partition
+        already has a PROCESSING peer is skipped — only jobs from *free*
+        partitions are eligible. Jobs without a ``partition_key`` are
+        unconstrained (the legacy behavior).
+
         Returns:
-            The job resource if one is available, None otherwise.
+            The job resource if one is eligible, None otherwise.
         """
-        # Find next pending job, ordered by retries (fewer first), then creation time (FIFO)
+        # Compute the set of partition keys currently held by PROCESSING
+        # jobs so we can skip pending peers in the same partition.
+        blocked_partitions = self._busy_partition_keys()
+
+        # Find pending jobs ordered by retries (fewer first), then creation
+        # time (FIFO). We may need to skip a few entries when partition
+        # contention is high, so pull a small batch instead of a single row.
         query = ResourceMetaSearchQuery(
             conditions=[
                 DataSearchCondition(
@@ -111,7 +201,7 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                     direction=ResourceMetaSortDirection.ascending,
                 ),
             ],
-            limit=1,
+            limit=16,
         )
 
         metas = self.rm.search_resources(query)
@@ -127,6 +217,12 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 if resource.data.status != TaskStatus.PENDING:
                     continue
 
+                # Partition serialization: skip if a peer in this partition
+                # is already PROCESSING. ``None`` means no constraint.
+                pk = resource.data.partition_key
+                if pk is not None and pk in blocked_partitions:
+                    continue
+
                 # Update status to processing
                 updated_job = resource.data
                 updated_job.status = TaskStatus.PROCESSING
@@ -139,6 +235,11 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                         status=RevisionStatus.draft,
                     )
 
+                # Claiming this job adds its partition to the blocked set
+                # for any subsequent pops in this same batch loop.
+                if pk is not None:
+                    blocked_partitions.add(pk)
+
                 # Return the updated resource
                 resource.data = updated_job
                 return resource
@@ -147,6 +248,33 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 continue
 
         return None
+
+    def _busy_partition_keys(self) -> set[str]:
+        """Return the set of ``partition_key`` values currently in flight
+        (any job with status PROCESSING).
+
+        Walks the PROCESSING set rather than maintaining a separate index
+        so the source of truth stays the job records themselves — there's
+        no second structure to keep consistent across crashes / recovery.
+        """
+        query = ResourceMetaSearchQuery(
+            conditions=[
+                DataSearchCondition(
+                    field_path="status",
+                    operator=DataSearchOperator.equals,
+                    value=TaskStatus.PROCESSING,
+                )
+            ],
+        )
+        busy: set[str] = set()
+        for meta in self.rm.search_resources(query):
+            try:
+                pk = self.rm.get(meta.resource_id).data.partition_key
+            except Exception:
+                continue
+            if pk is not None:
+                busy.add(pk)
+        return busy
 
     def _schedule_periodic_job(self, resource_id: str, interval_seconds: int) -> None:
         """

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -2327,6 +2327,29 @@ class Job(Struct, Generic[T, D]):
     last_heartbeat_at: dt.datetime | None = None
     """Timestamp of the last heartbeat. Used to detect dead workers."""
 
+    partition_key: str | None = None
+    """Per-key serialization tag (``#342 #3``).
+
+    Two jobs sharing the same ``partition_key`` never run concurrently —
+    the consumer holds back a pending job whose partition already has a
+    PROCESSING peer. ``None`` (default) means no serialization (every
+    pending job is independently eligible, matching legacy behavior).
+    Typical use: a per-tenant or per-aggregate write workflow where
+    inflight reruns would trample each other.
+    """
+
+    idempotency_key: str | None = None
+    """Exactly-once enqueue tag (``#342 #4``).
+
+    When supplied to ``enqueue()``, a second call with the same
+    ``idempotency_key`` returns the *original* job instead of creating
+    a new one — including after the original ran to completion. This is
+    the standard contract for retry-prone client paths (mobile, webhook
+    receivers, public APIs). Re-using a key with a *different* payload
+    is rejected as a programming error. ``None`` (default) disables
+    dedup.
+    """
+
 
 class IMessageQueue(ABC, Generic[T]):
     """Interface for a message queue that manages jobs as resources."""

--- a/tests/test_queue_partition_idempotency.py
+++ b/tests/test_queue_partition_idempotency.py
@@ -1,0 +1,189 @@
+"""#342 #3 + #4 — per-partition serialization & idempotent enqueue.
+
+These two queue primitives are what turn a generic job queue into one that's
+safe to drive from a public API:
+
+* ``partition_key=`` serializes work-per-key without serializing the *whole*
+  queue. Two jobs on the same partition never run concurrently; jobs on
+  different partitions still parallelize. The canonical use is "rebuild the
+  aggregate for tenant X" — multiple inflight rebuilds for one tenant would
+  trample each other, but tenants are independent.
+
+* ``idempotency_key=`` makes enqueue ``exactly-once`` from the caller's
+  point of view: a retry of an HTTP request that already enqueued a job
+  returns the *original* job, not a duplicate. Standard for retry-prone
+  client paths (mobile, webhooks).
+
+Both fields live on the ``Job`` Struct so any backend can opt in; this test
+file drives the in-process ``SimpleMessageQueue`` reference implementation.
+"""
+
+import msgspec
+import pytest
+
+from specstar.message_queue.simple import SimpleMessageQueue, SimpleMessageQueueFactory
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import (
+    IndexableField,
+    Job,
+    TaskStatus,
+)
+
+
+class Payload(msgspec.Struct):
+    task_name: str
+
+
+def _mk_queue() -> tuple[SimpleMessageQueue[Payload], ResourceManager[Job[Payload]]]:
+    """Spin up a fresh in-memory queue + ResourceManager pair."""
+    storage = SimpleStorage(MemoryMetaStore(), MemoryResourceStore())
+
+    def _noop_handler(job):  # pragma: no cover — never invoked in these tests
+        pass
+
+    factory = SimpleMessageQueueFactory()
+    rm = ResourceManager(
+        Job[Payload],
+        storage=storage,
+        message_queue=factory.build(_noop_handler),
+        indexed_fields=[
+            IndexableField(field_path="status", field_type=str),
+            IndexableField(field_path="partition_key", field_type=str),
+            IndexableField(field_path="idempotency_key", field_type=str),
+        ],
+        default_user="t",
+    )
+    return rm.message_queue, rm
+
+
+# ---------------------------------------------------------------------------
+# #342 #3 — partition_key per-key serialization
+# ---------------------------------------------------------------------------
+
+
+def test_job_struct_carries_partition_key_field():
+    job = Job(payload=Payload(task_name="x"), partition_key="tenant-7")
+    assert job.partition_key == "tenant-7"
+
+
+def test_enqueue_records_partition_key_on_the_job():
+    mq, rm = _mk_queue()
+    res = mq.enqueue(Payload(task_name="x"), partition_key="tenant-7")
+    stored = rm.get(res.info.resource_id).data
+    assert stored.partition_key == "tenant-7"
+
+
+def test_pop_serializes_jobs_in_the_same_partition():
+    # The serialization guarantee: while one job in partition P is PROCESSING,
+    # pop() must not hand out another job in P.
+    mq, _ = _mk_queue()
+    mq.enqueue(Payload(task_name="a"), partition_key="P")
+    mq.enqueue(Payload(task_name="b"), partition_key="P")
+
+    first = mq.pop()
+    assert first is not None
+    assert first.data.payload.task_name == "a"  # FIFO within partition
+
+    # 'b' is blocked while 'a' is PROCESSING
+    assert mq.pop() is None
+
+
+def test_pop_does_not_block_across_partitions():
+    # The whole point of partition_key vs. a global lock: independent
+    # partitions still parallelize.
+    mq, _ = _mk_queue()
+    mq.enqueue(Payload(task_name="a"), partition_key="P1")
+    mq.enqueue(Payload(task_name="b"), partition_key="P2")
+
+    one = mq.pop()
+    two = mq.pop()
+    assert one is not None and two is not None
+    assert {one.data.payload.task_name, two.data.payload.task_name} == {"a", "b"}
+
+
+def test_pop_unblocks_partition_after_completion():
+    mq, _ = _mk_queue()
+    a = mq.enqueue(Payload(task_name="a"), partition_key="P")
+    mq.enqueue(Payload(task_name="b"), partition_key="P")
+
+    first = mq.pop()
+    assert first is not None
+    mq.complete(a.info.resource_id)  # frees the partition
+
+    second = mq.pop()
+    assert second is not None
+    assert second.data.payload.task_name == "b"
+
+
+def test_partition_key_none_means_no_serialization():
+    # Backward-compat: without a partition_key, the queue behaves as before
+    # (every pending job is independently eligible).
+    mq, _ = _mk_queue()
+    mq.enqueue(Payload(task_name="a"))
+    mq.enqueue(Payload(task_name="b"))
+
+    one = mq.pop()
+    two = mq.pop()
+    assert one is not None and two is not None  # both pop'd, no blocking
+
+
+# ---------------------------------------------------------------------------
+# #342 #4 — idempotency_key on enqueue
+# ---------------------------------------------------------------------------
+
+
+def test_job_struct_carries_idempotency_key_field():
+    job = Job(payload=Payload(task_name="x"), idempotency_key="req-42")
+    assert job.idempotency_key == "req-42"
+
+
+def test_enqueue_with_same_idempotency_key_returns_original_job():
+    # Same key, same payload → no second job created.
+    mq, rm = _mk_queue()
+    a = mq.enqueue(Payload(task_name="x"), idempotency_key="req-42")
+    b = mq.enqueue(Payload(task_name="x"), idempotency_key="req-42")
+
+    assert a.info.resource_id == b.info.resource_id
+
+
+def test_enqueue_with_different_idempotency_keys_creates_distinct_jobs():
+    mq, _ = _mk_queue()
+    a = mq.enqueue(Payload(task_name="x"), idempotency_key="k1")
+    b = mq.enqueue(Payload(task_name="x"), idempotency_key="k2")
+
+    assert a.info.resource_id != b.info.resource_id
+
+
+def test_idempotent_replay_works_even_after_job_completes():
+    # The "exactly-once enqueue" contract: a client retry after the job
+    # already ran must still resolve to the original record, not a fresh
+    # one (otherwise the work runs twice).
+    mq, _ = _mk_queue()
+    a = mq.enqueue(Payload(task_name="x"), idempotency_key="req-42")
+    mq.complete(a.info.resource_id)
+
+    b = mq.enqueue(Payload(task_name="x"), idempotency_key="req-42")
+    assert b.info.resource_id == a.info.resource_id
+    assert b.data.status == TaskStatus.COMPLETED
+
+
+def test_idempotency_key_none_creates_independent_jobs():
+    # No key → no dedup. Two enqueues of the same payload are two jobs.
+    mq, _ = _mk_queue()
+    a = mq.enqueue(Payload(task_name="x"))
+    b = mq.enqueue(Payload(task_name="x"))
+
+    assert a.info.resource_id != b.info.resource_id
+
+
+def test_enqueue_with_idempotency_collision_rejects_payload_mismatch():
+    # If the caller re-uses an idempotency key with a *different* payload,
+    # that's not a benign retry — it's a programming error. Refuse rather
+    # than silently returning the original (the caller would never notice
+    # their second call's payload was dropped).
+    mq, _ = _mk_queue()
+    mq.enqueue(Payload(task_name="x"), idempotency_key="req-42")
+    with pytest.raises(ValueError, match="idempotency"):
+        mq.enqueue(Payload(task_name="y"), idempotency_key="req-42")


### PR DESCRIPTION
## Summary
Two queue primitives that turn the in-process queue from "best-effort fan-out" into something safe to drive from a public API:

- **`partition_key`** (#342 #3) — per-key serialization. While a job in partition P is `PROCESSING`, `pop()` refuses to hand out another pending job in P. Jobs in other partitions still parallelize. Canonical use: "rebuild aggregate for tenant X" — concurrent reruns trample each other, but tenants are independent.
- **`idempotency_key`** (#342 #4) — exactly-once enqueue. A second `enqueue()` with the same key returns the *original* job, including after completion, so client retries don't re-do the work. Re-using a key with a *different* payload raises `ValueError` instead of silently dedup'ing (caller would never notice their second payload was dropped).

## API
- New `enqueue(payload, *, partition_key=None, idempotency_key=None)` on `SimpleMessageQueue` — the user-facing path. `put(resource_id)` remains for the already-created flow.
- Two new optional fields on `Job` — both default to `None` (legacy behavior).

## Design notes
`pop()` walks the `PROCESSING` set on each call to compute blocked partitions, so the source of truth stays the job records themselves — no second structure to keep consistent across crashes.

## Test plan
- [x] `tests/test_queue_partition_idempotency.py` — 12 tests covering field plumbing, FIFO within partition, cross-partition parallelism, unblock on completion, legacy `partition_key=None`, idempotent replay after completion, payload-mismatch rejection.
- [x] `uv run pytest tests/test_message_queue/` — no regressions (29 passed)
- [x] Adjacent suites: `tests/test_lazy_job_handler.py`, `tests/test_async_create_action.py`, `tests/test_async_update_action.py`, `tests/test_start_consume_custom_update.py` — 107 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)