### PR TITLE
fix(meta-store): crash-safe create() — atomic meta commit + typed not-found

### DIFF
--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -421,6 +421,22 @@ class SimpleStorage(IStorage):
             return
         self._resource_store.save_many(items)
 
+    def collect_orphans(self) -> int:
+        """Reclaim resource/blob data left by interrupted ``create()`` calls.
+
+        The meta store is the source of truth for "what resources exist"; its
+        keys are the finalised commit markers. Any resource/blob data the
+        resource store holds that no finalised meta points at is garbage from
+        an aborted multi-file write and is removed.
+
+        Returns the number of orphaned directories removed (``0`` when the
+        resource store does not support reclamation, e.g. in-memory).
+        """
+        collect = getattr(self._resource_store, "collect_orphans", None)
+        if collect is None:
+            return 0
+        return collect(set(self._meta_store))
+
 
 class _BlobEntry(Struct, kw_only=True):
     """Internal struct for serialising blob data in dump streams."""
@@ -1642,10 +1658,15 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 eh.handle_event(context)
 
     def _get_meta_no_check_is_deleted(self, resource_id: str) -> ResourceMeta:
-        if not self.storage.exists(resource_id):
-            raise ResourceIDNotFoundError(resource_id)
-        meta = self.storage.get_meta(resource_id)
-        return meta
+        # Read straight from the store and treat a missing key as not-found.
+        # Going through get_meta (rather than an exists()-then-read pair) closes
+        # the TOCTOU window where a concurrent purge / interrupted create can
+        # delete the meta between the check and the read — that must surface as
+        # the typed ResourceIDNotFoundError, never a raw OSError/KeyError.
+        try:
+            return self.storage.get_meta(resource_id)
+        except KeyError:
+            raise ResourceIDNotFoundError(resource_id) from None
 
     def exists(self, resource_id: str) -> bool:
         """
@@ -1671,6 +1692,24 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             bool: True if the revision exists, False otherwise.
         """
         return self.storage.revision_exists(resource_id, revision_id)
+
+    def collect_orphans(self) -> int:
+        """Reclaim storage left behind by interrupted ``create()`` calls.
+
+        A ``create()`` writes revision data before the meta commit marker, so a
+        process killed mid-write leaves durable resource/blob data with no
+        finalised meta. Such data is already invisible to reads and listings
+        (the meta store is the source of truth); this call physically removes
+        it to reclaim disk space.
+
+        Safe to run at boot. Returns the number of orphaned directories
+        removed (``0`` for backends without reclaimable on-disk garbage).
+        """
+        collect = getattr(self.storage, "collect_orphans", None)
+        removed = collect() if collect is not None else 0
+        if removed:
+            logger.info("collect_orphans: reclaimed %d orphaned director(ies)", removed)
+        return removed
 
     @execute_with_events(
         (

--- a/specstar/resource_manager/meta_store/simple.py
+++ b/specstar/resource_manager/meta_store/simple.py
@@ -36,14 +36,18 @@ class MemoryMetaStore(IFastMetaStore):
         del self._store[pk]
 
     def __iter__(self) -> Generator[str]:
-        yield from self._store.keys()
+        # Snapshot: a concurrent create/delete must not raise
+        # "dictionary changed size during iteration".
+        yield from list(self._store.keys())
 
     def __len__(self) -> int:
         return len(self._store)
 
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
         results: list[ResourceMeta] = []
-        for meta_b in self._store.values():
+        # Snapshot the values: a concurrent write mid-search must not raise
+        # "dictionary changed size during iteration".
+        for meta_b in list(self._store.values()):
             meta = self._serializer.decode(meta_b)
             if is_match_query(meta, query):
                 results.append(meta)
@@ -53,7 +57,10 @@ class MemoryMetaStore(IFastMetaStore):
     @contextmanager
     def get_then_delete(self) -> Generator[Iterable[ResourceMeta]]:
         """获取所有元数据然后删除，用于快速存储的批量同步"""
-        yield (self._serializer.decode(v) for v in self._store.values())
+        # Materialise a snapshot before yielding so consumption can't race a
+        # concurrent write ("dictionary changed size during iteration").
+        decoded = [self._serializer.decode(v) for v in list(self._store.values())]
+        yield decoded
         self._store.clear()
 
 

--- a/specstar/resource_manager/meta_store/simple.py
+++ b/specstar/resource_manager/meta_store/simple.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager, suppress
 from pathlib import Path
@@ -65,7 +67,13 @@ class MemoryMetaStore(IFastMetaStore):
 
 
 class DiskMetaStore(IFastMetaStore):
-    def __init__(self, *, encoding: Encoding = Encoding.json, rootdir: Path | str):
+    def __init__(
+        self,
+        *,
+        encoding: Encoding = Encoding.json,
+        rootdir: Path | str,
+        fsync: bool = False,
+    ):
         self._serializer = MsgspecSerializer(
             encoding=encoding,
             resource_type=ResourceMeta,
@@ -73,6 +81,11 @@ class DiskMetaStore(IFastMetaStore):
         self._rootdir = Path(rootdir)
         self._rootdir.mkdir(parents=True, exist_ok=True)
         self._suffix = ".data"
+        # When True, fsync the meta file before the atomic rename so a finalised
+        # commit marker survives an OS crash / power loss, not just a process
+        # kill. Off by default: it adds a sync per write, which would throttle
+        # high-volume batch ingest (the workload most likely to be interrupted).
+        self._fsync = fsync
 
     def _get_path(self, pk: str) -> Path:
         return self._rootdir / f"{pk}{self._suffix}"
@@ -83,17 +96,45 @@ class DiskMetaStore(IFastMetaStore):
 
     def __getitem__(self, pk: str) -> ResourceMeta:
         path = self._get_path(pk)
-        with path.open("rb") as f:
-            return self._serializer.decode(f.read())
+        try:
+            with path.open("rb") as f:
+                return self._serializer.decode(f.read())
+        except FileNotFoundError:
+            # No finalised meta on disk → "resource does not exist", matching
+            # the dict-based stores' KeyError contract. An interrupted create()
+            # (resource dir written before meta) must look like a missing key,
+            # not crash with a raw OSError.
+            raise KeyError(pk) from None
 
     def __setitem__(self, pk: str, b: ResourceMeta) -> None:
         path = self._get_path(pk)
-        with path.open("wb") as f:
-            f.write(self._serializer.encode(b))
+        data = self._serializer.encode(b)
+        # Write to a temp file in the same directory, then atomically rename it
+        # into place. A finalised ``<pk>.data`` therefore always holds a
+        # complete record and acts as the "commit marker": an interrupted write
+        # leaves only the temp file (excluded by the ``*.data`` glob and never
+        # decoded), so it is invisible to the loader instead of crashing boot.
+        fd, tmp = tempfile.mkstemp(
+            dir=self._rootdir, prefix=f"{pk}.", suffix=".data.tmp"
+        )
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+                if self._fsync:
+                    f.flush()
+                    os.fsync(f.fileno())
+            os.replace(tmp, path)
+        except BaseException:
+            with suppress(FileNotFoundError):
+                os.unlink(tmp)
+            raise
 
     def __delitem__(self, pk: str) -> None:
         path = self._get_path(pk)
-        path.unlink()
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            raise KeyError(pk) from None
 
     def __iter__(self) -> Generator[str]:
         for file in self._rootdir.glob(f"*{self._suffix}"):
@@ -105,10 +146,16 @@ class DiskMetaStore(IFastMetaStore):
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
         results: list[ResourceMeta] = []
         for file in self._rootdir.glob(f"*{self._suffix}"):
-            with file.open("rb") as f:
-                meta = self._serializer.decode(f.read())
-                if is_match_query(meta, query):
-                    results.append(meta)
+            try:
+                with file.open("rb") as f:
+                    raw = f.read()
+            except FileNotFoundError:
+                # File removed (concurrent purge / aborted write) between the
+                # directory listing and the read — skip it, don't crash.
+                continue
+            meta = self._serializer.decode(raw)
+            if is_match_query(meta, query):
+                results.append(meta)
         results.sort(key=get_sort_fn([] if query.sorts is UNSET else query.sorts))
         yield from results[query.offset : query.offset + query.limit]
 

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -1,7 +1,7 @@
 import io
 import os
 from collections.abc import Generator, Iterable
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import IO
 from uuid import UUID
@@ -253,6 +253,51 @@ class DiskResourceStore(IResourceStore):
             f.write(data.read())
         with self._get_raw_info_path(str(info.uid)).open("wb") as f:
             f.write(self._info_serializer.encode(info))
+
+    def collect_orphans(self, live_resource_ids: "set[str]") -> int:
+        """Remove resource/store dirs not referenced by a finalised meta.
+
+        An interrupted ``create()`` writes ``resource/<id>/`` and
+        ``store/<uid>/`` before the meta commit marker lands, leaving durable
+        garbage on disk. Given the set of resource ids that *do* have a
+        finalised meta (the source of truth), this reclaims:
+
+        * ``resource/<id>/`` trees whose id is not in *live_resource_ids*, and
+        * ``store/<uid>/`` blobs no longer referenced by any live resource.
+
+        Returns the number of directories removed (resource trees + blobs).
+        """
+        import shutil
+
+        removed = 0
+        resource_root = self._rootdir / "resource"
+        store_root = self._rootdir / "store"
+
+        live_uids: set[str] = set()
+        if resource_root.exists():
+            for rid_dir in resource_root.iterdir():
+                if not rid_dir.is_dir():
+                    continue
+                if rid_dir.name in live_resource_ids:
+                    # Record the store blobs this live resource points at so we
+                    # don't reclaim them in the store sweep below.
+                    for rev_dir in rid_dir.iterdir():
+                        if not rev_dir.is_dir():
+                            continue
+                        for ver_link in rev_dir.iterdir():
+                            with suppress(OSError):
+                                live_uids.add(ver_link.resolve().name)
+                else:
+                    shutil.rmtree(rid_dir)
+                    removed += 1
+
+        if store_root.exists():
+            for uid_dir in store_root.iterdir():
+                if uid_dir.is_dir() and uid_dir.name not in live_uids:
+                    shutil.rmtree(uid_dir)
+                    removed += 1
+
+        return removed
 
     def purge_resource(self, resource_id: str) -> None:
         """Hard-delete all revision data for a resource from disk."""

--- a/tests/meta_store/test_disk_crash_safety.py
+++ b/tests/meta_store/test_disk_crash_safety.py
@@ -1,0 +1,298 @@
+"""Crash-safety / half-committed-write tests for the disk-backed stores.
+
+Regression tests for issue #340: an interrupted batch ``create()`` leaves a
+``data/resource/<id>/`` dir on disk *before* ``meta/<id>.data`` is written.
+The loader must treat "no finalised meta" as "resource does not exist"
+(typed ``ResourceIDNotFoundError`` / ``KeyError``), never crash with a raw
+``FileNotFoundError``.
+"""
+
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from faker import Faker
+from msgspec import Struct
+
+from specstar.resource_manager.core import (
+    ResourceManager,
+    SimpleStorage,
+)
+from specstar.resource_manager.meta_store.simple import DiskMetaStore
+from specstar.resource_manager.resource_store.simple import DiskResourceStore
+from specstar.types import ResourceIDNotFoundError, ResourceMeta
+
+faker = Faker()
+
+
+class Data(Struct):
+    name: str
+    age: int
+
+
+def new_data() -> Data:
+    return Data(name=faker.name(), age=faker.pyint(min_value=0, max_value=100))
+
+
+def _make_meta(resource_id: str, *, current_revision_id: str = "rev-1") -> ResourceMeta:
+    now = faker.date_time()
+    user = faker.user_name()
+    return ResourceMeta(
+        current_revision_id=current_revision_id,
+        resource_id=resource_id,
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by=user,
+        updated_by=user,
+    )
+
+
+def _boom(*_args, **_kwargs):
+    raise RuntimeError("simulated crash during commit")
+
+
+@pytest.fixture
+def my_tmpdir() -> Generator[Path]:
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)
+
+
+@contextmanager
+def disk_meta_store(tmpdir: Path) -> Generator[DiskMetaStore]:
+    d = tmpdir / faker.pystr()
+    d.mkdir()
+    yield DiskMetaStore(encoding="msgpack", rootdir=d)  # ty:ignore[invalid-argument-type]
+
+
+@contextmanager
+def disk_manager(tmpdir: Path) -> Generator[tuple[ResourceManager, Path, Path]]:
+    """A ResourceManager backed by disk meta + resource stores.
+
+    Yields ``(mgr, meta_dir, resource_dir)`` so tests can mutate the on-disk
+    layout to simulate an interrupted ``create()``.
+    """
+    meta_dir = tmpdir / "meta"
+    res_dir = tmpdir / "res"
+    meta_dir.mkdir()
+    res_dir.mkdir()
+    meta_store = DiskMetaStore(encoding="msgpack", rootdir=meta_dir)  # ty:ignore[invalid-argument-type]
+    resource_store = DiskResourceStore(encoding="msgpack", rootdir=res_dir)  # ty:ignore[invalid-argument-type]
+    storage = SimpleStorage(meta_store=meta_store, resource_store=resource_store)
+    mgr = ResourceManager(Data, storage=storage)
+    yield mgr, meta_dir, res_dir
+
+
+def _create(mgr: ResourceManager, data: Data | None = None):
+    data = data or new_data()
+    with mgr.using(user=faker.user_name(), now=faker.date_time()):
+        return mgr.create(data)
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1: missing key contract parity with the other meta stores
+# ---------------------------------------------------------------------------
+
+
+def test_disk_meta_store_missing_key_raises_keyerror(my_tmpdir: Path):
+    """DiskMetaStore[<missing>] raises KeyError, not raw FileNotFoundError.
+
+    Every other meta store (Memory/Redis/SQL/Postgres) raises KeyError for a
+    missing pk; the disk store must match so callers can handle it uniformly.
+    """
+    with disk_meta_store(my_tmpdir) as store:
+        with pytest.raises(KeyError):
+            store["does-not-exist:abc"]
+
+
+# ---------------------------------------------------------------------------
+# Behavior 2: interrupted create() / stale ref → typed ResourceIDNotFoundError
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_create_meta_missing_is_invisible(my_tmpdir: Path):
+    """Resource data on disk but no finalised meta == "does not exist".
+
+    Simulates an interrupted batch create() that wrote data/resource/<id>/
+    before meta/<id>.data. get()/get_meta() must raise the typed
+    ResourceIDNotFoundError, and list_resources() must not see the orphan.
+    """
+    with disk_manager(my_tmpdir) as (mgr, meta_dir, _res_dir):
+        info = _create(mgr)
+        rid = info.resource_id
+
+        # Drop only the finalised meta marker, leaving the resource dir behind
+        # — exactly the on-disk shape of an aborted create().
+        (meta_dir / f"{rid}.data").unlink()
+
+        with pytest.raises(ResourceIDNotFoundError):
+            mgr.get_meta(rid)
+        with pytest.raises(ResourceIDNotFoundError):
+            mgr.get(rid)
+        assert mgr.list_resources() == []
+
+
+def test_toctou_meta_vanishes_after_exists_check(my_tmpdir: Path, monkeypatch):
+    """exists() races a concurrent purge: meta gone between check and read.
+
+    A held Ref (or list snapshot) reports the resource exists, but the meta
+    file is removed before get_meta() reads it. The read must surface
+    ResourceIDNotFoundError, never a raw FileNotFoundError.
+    """
+    with disk_manager(my_tmpdir) as (mgr, meta_dir, _res_dir):
+        info = _create(mgr)
+        rid = info.resource_id
+
+        # Force the stale "it exists" answer, then make the file truly absent.
+        monkeypatch.setattr(mgr.storage, "exists", lambda _rid: True)
+        (meta_dir / f"{rid}.data").unlink()
+
+        with pytest.raises(ResourceIDNotFoundError):
+            mgr.get_meta(rid)
+
+
+# ---------------------------------------------------------------------------
+# Behavior 3: meta write is atomic (the commit marker is all-or-nothing)
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_meta_write_leaves_nothing_visible(my_tmpdir: Path, monkeypatch):
+    """A crash before the meta commit must leave no visible/half-written record.
+
+    A new key is written but the atomic commit step fails partway. The store
+    must look exactly as if the write never happened: the key is absent, not
+    listed, not counted, and listing/search does not crash on a truncated file.
+    """
+    from specstar.query_types import ResourceMetaSearchQuery
+    from specstar.resource_manager.meta_store import simple as simple_mod
+
+    with disk_meta_store(my_tmpdir) as store:
+        store["kept:1"] = _make_meta("kept:1")
+
+        # Blow up at the commit step of writing a brand-new key.
+        monkeypatch.setattr(simple_mod.os, "replace", _boom, raising=True)
+        with pytest.raises(RuntimeError):
+            store["orphan:2"] = _make_meta("orphan:2")
+
+        # The aborted write is completely invisible...
+        assert "orphan:2" not in store
+        assert "orphan:2" not in list(store)
+        assert len(store) == 1
+        # ...and the previously-committed value is intact and decodable.
+        assert store["kept:1"].resource_id == "kept:1"
+        searched = list(store.iter_search(ResourceMetaSearchQuery()))
+        assert [m.resource_id for m in searched] == ["kept:1"]
+
+
+def test_overwrite_interrupted_keeps_previous_value(my_tmpdir: Path, monkeypatch):
+    """An interrupted overwrite leaves the previous value uncorrupted."""
+    from specstar.resource_manager.meta_store import simple as simple_mod
+
+    with disk_meta_store(my_tmpdir) as store:
+        store["k:1"] = _make_meta("k:1", current_revision_id="rev-A")
+
+        monkeypatch.setattr(simple_mod.os, "replace", _boom, raising=True)
+        with pytest.raises(RuntimeError):
+            store["k:1"] = _make_meta("k:1", current_revision_id="rev-B")
+
+        assert store["k:1"].current_revision_id == "rev-A"
+
+
+# ---------------------------------------------------------------------------
+# Behavior 4: listing/search tolerates a file vanishing mid-iteration
+# ---------------------------------------------------------------------------
+
+
+def test_iter_search_skips_file_vanishing_mid_iteration(my_tmpdir: Path, monkeypatch):
+    """A meta file removed (concurrent purge) after glob but before open.
+
+    iter_search enumerates files lazily; a file may disappear between the
+    directory listing and the read. That must be skipped, not crash the search.
+    """
+    import pathlib
+
+    from specstar.query_types import ResourceMetaSearchQuery
+
+    with disk_meta_store(my_tmpdir) as store:
+        store["real:1"] = _make_meta("real:1")
+        store["ghost:2"] = _make_meta("ghost:2")
+
+        orig_open = pathlib.Path.open
+
+        def fake_open(self, *a, **k):
+            if self.name.startswith("ghost:2"):
+                raise FileNotFoundError(self)
+            return orig_open(self, *a, **k)
+
+        monkeypatch.setattr(pathlib.Path, "open", fake_open)
+
+        results = list(store.iter_search(ResourceMetaSearchQuery()))
+        assert [m.resource_id for m in results] == ["real:1"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #340 #4: boot-time GC reclaims orphaned resource/store dirs
+# ---------------------------------------------------------------------------
+
+
+def test_collect_orphans_removes_unreferenced_data(my_tmpdir: Path):
+    """GC removes resource + store dirs not pointed at by a finalised meta.
+
+    Simulates an interrupted batch create() (resource/store on disk, no meta).
+    collect_orphans() reclaims the orphan and reports it, while the live
+    resource remains fully readable.
+    """
+    with disk_manager(my_tmpdir) as (mgr, meta_dir, res_dir):
+        live = _create(mgr, Data(name="keep", age=1))
+        orphan = _create(mgr, Data(name="drop", age=2))
+
+        # Make `orphan` an aborted create: drop its meta, keep data/resource.
+        (meta_dir / f"{orphan.resource_id}.data").unlink()
+
+        orphan_res = res_dir / "resource" / orphan.resource_id
+        orphan_blob = res_dir / "store" / str(orphan.uid)
+        assert orphan_res.exists() and orphan_blob.exists()
+
+        removed = mgr.collect_orphans()
+
+        assert removed == 2  # one resource dir + one store blob
+        assert not orphan_res.exists()
+        assert not orphan_blob.exists()
+        # The live resource is untouched and still readable.
+        assert mgr.get(live.resource_id).data.name == "keep"
+        assert (res_dir / "store" / str(live.uid)).exists()
+
+
+def test_collect_orphans_noop_when_clean(my_tmpdir: Path):
+    """A cleanly-committed store has nothing to collect."""
+    with disk_manager(my_tmpdir) as (mgr, _meta_dir, _res_dir):
+        _create(mgr)
+        _create(mgr)
+        assert mgr.collect_orphans() == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #340 #5: optional fsync for OS-crash durability (default off)
+# ---------------------------------------------------------------------------
+
+
+def test_fsync_flag_defaults_off_and_writes_round_trip(my_tmpdir: Path):
+    """The fsync flag is opt-in; default-off keeps batch-ingest throughput.
+
+    Atomic rename (the real fix for process kills) is unconditional, so a
+    default store still survives interruption. fsync only adds OS-crash
+    durability and must not be forced on the hot path.
+    """
+    d = my_tmpdir / faker.pystr()
+    d.mkdir()
+    default = DiskMetaStore(encoding="msgpack", rootdir=d)  # ty:ignore[invalid-argument-type]
+    assert default._fsync is False
+
+    d2 = my_tmpdir / faker.pystr()
+    d2.mkdir()
+    durable = DiskMetaStore(encoding="msgpack", rootdir=d2, fsync=True)  # ty:ignore[invalid-argument-type]
+    assert durable._fsync is True
+    durable["k:1"] = _make_meta("k:1")
+    assert durable["k:1"].resource_id == "k:1"

--- a/tests/migrations/test_resource_manager_migrate.py
+++ b/tests/migrations/test_resource_manager_migrate.py
@@ -118,7 +118,8 @@ class TestResourceManagerMigrate:
         assert result == mock_meta
 
         # 驗證調用 - migrate 方法內部調用 get_meta 和 get 方法
-        mock_storage.exists.assert_called_with("test:123")
+        # exists() is no longer called: _get_meta_no_check_is_deleted now reads
+        # through get_meta and catches KeyError, closing the TOCTOU window.
         mock_storage.get_meta.assert_called_with("test:123")
         mock_storage.get_resource_revision_info.assert_called_with(
             "test:123",
@@ -181,7 +182,8 @@ class TestResourceManagerMigrate:
             result = resource_manager.migrate("test:123")
 
         # 驗證調用
-        mock_storage.exists.assert_called_once_with("test:123")
+        # exists() is no longer called: _get_meta_no_check_is_deleted reads
+        # through get_meta and catches KeyError, closing the TOCTOU window.
         mock_storage.get_meta.assert_called_once_with("test:123")
         mock_storage.get_resource_revision_info.assert_called_once_with(
             "test:123",

--- a/tests/test_meta_store_concurrent_iteration.py
+++ b/tests/test_meta_store_concurrent_iteration.py
@@ -1,0 +1,63 @@
+"""The in-memory meta store must tolerate concurrent writes during a search.
+
+``count_resources`` / ``search_resources`` iterate the meta store; another
+thread creating/deleting at the same time previously raised
+``RuntimeError: dictionary changed size during iteration`` because the store
+iterated the live dict. The store must iterate a snapshot instead.
+
+The tiny ``switchinterval`` forces frequent GIL hand-offs so the race shows up
+deterministically (it's timing-dependent otherwise).
+"""
+
+import sys
+import threading
+
+import msgspec
+
+from specstar import SpecStar
+
+
+class Item(msgspec.Struct):
+    name: str
+
+
+def test_search_and_count_tolerate_concurrent_writes():
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        sp = SpecStar()
+        sp.configure(default_user="t")
+        sp.add_model(Item, name="item")
+        rm = sp.get_resource_manager(Item)
+        for i in range(2000):
+            rm.create(Item(name=f"i{i}"))
+
+        errors: list[Exception] = []
+        stop = threading.Event()
+
+        def churn():
+            i = 0
+            while not stop.is_set():
+                try:
+                    info = rm.create(Item(name=f"w{i}"))
+                    i += 1
+                    rm.permanently_delete(info.resource_id)  # add + remove a key
+                except Exception as e:  # pragma: no cover - only on regression
+                    errors.append(e)
+                    return
+
+        writer = threading.Thread(target=churn)
+        writer.start()
+        try:
+            for _ in range(300):
+                rm.count_resources()
+                rm.search_resources()
+        except Exception as e:  # the reported RuntimeError lands here without the fix
+            errors.append(e)
+        finally:
+            stop.set()
+            writer.join()
+
+        assert not errors, repr(errors[0])
+    finally:
+        sys.setswitchinterval(old_interval)


### PR DESCRIPTION
Closes #340

A `create()` writes resource/blob data before the meta file, so a process
killed mid-write (kill -9 / Ctrl-C / OOM during batch ingest) left durable
`data/resource/` + `data/store/` entries with no matching `meta/<id>.data`.
On the next boot, reading that half-committed shape raised a raw
`FileNotFoundError` and crashed instead of treating it as "resource does
not exist".

## Changes

1. **Atomic meta commit** — `DiskMetaStore.__setitem__` now writes to a temp
   file and `os.replace()`s it into place, so a finalised `<id>.data` is
   always complete and acts as the commit marker. An interrupted write
   leaves only `*.data.tmp` (excluded by the `*.data` glob), invisible to
   the loader.

2. **Typed not-found** — `DiskMetaStore.__getitem__/__delitem__` raise
   `KeyError` (not `FileNotFoundError`) for a missing key, matching every
   other meta store. `_get_meta_no_check_is_deleted` reads through
   `get_meta` and maps `KeyError → ResourceIDNotFoundError`, closing the
   `exists()` → read TOCTOU window against concurrent purge / aborted
   create.

3. **`iter_search` race tolerance** — skips a file that vanishes between
   `glob` and `open`.

4. **Boot-time GC** — new `ResourceManager.collect_orphans()` reclaims
   `resource/` / `store/` dirs not pointed at by a finalised meta, cleaning
   up pre-existing orphans from before this fix.

5. **Optional fsync** — `DiskMetaStore(fsync=True)` for OS-crash durability;
   off by default so batch ingest throughput is unaffected.

## Test plan

- New tests added on this branch cover the crash-mid-write scenario and
  the TOCTOU window
- Existing meta-store regression should remain green
- CI will validate the full suite on push

## Notes

This branch is 65 commits ahead of `spec-dd` — most of those are
production-hardening work that's already in other branches (audit fields,
optimistic concurrency, error envelopes, etc.). The crash-safe fix is the
tip commit `adfb001`.
