### PR TITLE
feat(query): Field.source — make QB[] vs QB.foo() a real dispatch (aggregate API)

### DIFF
--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -1,5 +1,5 @@
 from specstar import defaults, id_generators
-from specstar.aggregates import Aggregate, Count, GroupRow
+from specstar.aggregates import Aggregate, Avg, Count, GroupRow, Max, Min, Sum
 from specstar.backend import (
     BackendBinding,
     BackendConfig,
@@ -67,9 +67,13 @@ __all__ = [
     "OnDuplicate",
     "OnUnindexedQuery",
     "Aggregate",
+    "Avg",
     "Count",
     "GroupRow",
+    "Max",
+    "Min",
     "QB",
+    "Sum",
     "Ref",
     "RefRevision",
     "RefType",

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -1,5 +1,14 @@
 from specstar import defaults, id_generators
-from specstar.aggregates import Aggregate, Avg, Count, GroupRow, Max, Min, Sum
+from specstar.aggregates import (
+    Aggregate,
+    Avg,
+    Count,
+    ForeignAggregate,
+    GroupRow,
+    Max,
+    Min,
+    Sum,
+)
 from specstar.backend import (
     BackendBinding,
     BackendConfig,
@@ -69,6 +78,7 @@ __all__ = [
     "Aggregate",
     "Avg",
     "Count",
+    "ForeignAggregate",
     "GroupRow",
     "Max",
     "Min",

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -1,4 +1,5 @@
 from specstar import defaults, id_generators
+from specstar.aggregates import Aggregate, Count, GroupRow
 from specstar.backend import (
     BackendBinding,
     BackendConfig,
@@ -65,6 +66,9 @@ __all__ = [
     "OnDelete",
     "OnDuplicate",
     "OnUnindexedQuery",
+    "Aggregate",
+    "Count",
+    "GroupRow",
     "QB",
     "Ref",
     "RefRevision",

--- a/specstar/aggregates.py
+++ b/specstar/aggregates.py
@@ -1,78 +1,111 @@
 """Aggregate specs for :meth:`ResourceManager.exp_aggregate_by`.
 
-Shipped: :class:`Count`, :class:`Sum`, :class:`Min`, :class:`Max`, :class:`Avg`.
-Pass several at once in the ``aggregates=`` dict — each becomes a named field
-on the returned :class:`GroupRow`. The ``exp_`` prefix on the method advertises
-that the API may still adjust before stabilising as ``aggregate_by``.
+Shipped: :class:`Count`, :class:`Sum`, :class:`Min`, :class:`Max`, :class:`Avg`
++ :class:`ForeignAggregate` for cross-RM. Aggregate fields and the foreign
+``link`` are typed as :class:`~specstar.query.Field` (i.e. you pass them as
+``QB["..."]`` for indexed data or ``QB.<name>()`` for ResourceMeta attributes)
+so the data/meta routing is unambiguous — no name-collision footgun.
+
+The ``exp_`` prefix on the method advertises that this API may still adjust
+before stabilising as ``aggregate_by``.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-import msgspec
+from specstar.query import Field
 
 
-class Aggregate(msgspec.Struct, frozen=True):
+class Aggregate:
     """Marker base for aggregate specs."""
 
+    __slots__ = ()
 
-class Count(Aggregate, frozen=True):
+
+class Count(Aggregate):
     """Count rows in the group."""
 
+    __slots__ = ()
 
-class Sum(Aggregate, frozen=True):
+
+class _FieldAggregate(Aggregate):
+    """Internal base for aggregates that reduce a single field."""
+
+    __slots__ = ("field",)
+
+    def __init__(self, field: Field) -> None:
+        if not isinstance(field, Field):
+            raise TypeError(
+                f"{type(self).__name__} requires a QB Field "
+                f"(e.g. QB[\"size\"] or QB.created_time()); "
+                f"got {type(field).__name__}."
+            )
+        self.field = field
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.field.name!r}, source={self.field.source!r})"
+
+
+class Sum(_FieldAggregate):
     """Sum a numeric field across the group; ``None`` values are skipped.
 
     Returns ``None`` if the group has no non-``None`` value (SQL semantics).
     Raises ``TypeError`` if a non-numeric value is encountered.
     """
 
-    field: str
+    __slots__ = ()
 
 
-class Min(Aggregate, frozen=True):
+class Min(_FieldAggregate):
     """Min of a field across the group (``None``-skipping). Returns ``None``
     if the group has no non-``None`` value. Uses Python ``<`` ordering, so the
     field's values must be mutually comparable (numbers, datetimes, strings).
     """
 
-    field: str
+    __slots__ = ()
 
 
-class Max(Aggregate, frozen=True):
+class Max(_FieldAggregate):
     """Max of a field across the group (``None``-skipping). Returns ``None``
     if the group has no non-``None`` value."""
 
-    field: str
+    __slots__ = ()
 
 
-class Avg(Aggregate, frozen=True):
+class Avg(_FieldAggregate):
     """Average a numeric field across the group (``None``-skipping).
 
     Returns a ``float``, or ``None`` if the group has no non-``None`` value.
     Raises ``TypeError`` if a non-numeric value is encountered.
     """
 
-    field: str
+    __slots__ = ()
 
 
 class ForeignAggregate:
     """Aggregate over another resource's rows, linked back to this resource.
 
-    Use inside :meth:`ResourceManager.exp_list_with_aggregates` to annotate each
-    parent row with a reduction over its children — e.g. *"this doc's chunk
-    count"* or *"this customer's order total"*. ``rm`` is the **child** manager,
-    ``link`` is the child field that holds the parent ``resource_id``, and
-    ``aggregate`` is what to compute over the children of each parent.
+    Use inside :meth:`ResourceManager.exp_aggregate_by` to annotate each parent
+    row with a reduction over its children — e.g. *"this doc's chunk count"*
+    or *"this customer's order total"*. ``rm`` is the **child** manager,
+    ``link`` is a :class:`~specstar.query.Field` on the child that holds the
+    parent ``resource_id`` (almost always ``QB["..."]``), and ``aggregate`` is
+    what to compute over the children of each parent.
     """
 
     __slots__ = ("rm", "link", "aggregate")
 
-    def __init__(self, rm: object, link: str, aggregate: Aggregate) -> None:
+    def __init__(self, rm: object, link: Field, aggregate: Aggregate) -> None:
+        if not isinstance(link, Field):
+            raise TypeError(
+                f"ForeignAggregate.link must be a QB Field "
+                f"(e.g. QB[\"source_doc_id\"]); got {type(link).__name__}."
+            )
         if not isinstance(aggregate, Aggregate):
             raise TypeError(
-                f"aggregate must be an Aggregate; got {type(aggregate).__name__}."
+                f"ForeignAggregate.aggregate must be an Aggregate; "
+                f"got {type(aggregate).__name__}."
             )
         self.rm = rm
         self.link = link
@@ -83,11 +116,11 @@ class GroupRow:
     """One row of an :meth:`exp_aggregate_by` result.
 
     ``.key`` is the group-by value (or ``None`` when missing). When the call
-    grouped by ``"resource_id"`` (each group is exactly one row of *this* RM),
-    ``.resource`` carries that row's :class:`~specstar.types.SearchedResource`
-    — that's the cross-RM case (e.g. *"list each doc and its chunk count"*).
-    For any other ``by``, ``.resource`` is ``None`` because a group could span
-    many rows.
+    grouped by ``QB.resource_id()`` (each group is exactly one row of *this*
+    RM), ``.resource`` carries that row's
+    :class:`~specstar.types.SearchedResource` — that's the cross-RM case
+    (e.g. *"list each doc and its chunk count"*). For any other ``by``,
+    ``.resource`` is ``None`` because a group could span many rows.
 
     Each named aggregate is exposed both as an attribute (``row.count``) and
     as an item (``row["count"]``), so a dict comp like

--- a/specstar/aggregates.py
+++ b/specstar/aggregates.py
@@ -57,19 +57,50 @@ class Avg(Aggregate, frozen=True):
     field: str
 
 
+class ForeignAggregate:
+    """Aggregate over another resource's rows, linked back to this resource.
+
+    Use inside :meth:`ResourceManager.exp_list_with_aggregates` to annotate each
+    parent row with a reduction over its children — e.g. *"this doc's chunk
+    count"* or *"this customer's order total"*. ``rm`` is the **child** manager,
+    ``link`` is the child field that holds the parent ``resource_id``, and
+    ``aggregate`` is what to compute over the children of each parent.
+    """
+
+    __slots__ = ("rm", "link", "aggregate")
+
+    def __init__(self, rm: object, link: str, aggregate: Aggregate) -> None:
+        if not isinstance(aggregate, Aggregate):
+            raise TypeError(
+                f"aggregate must be an Aggregate; got {type(aggregate).__name__}."
+            )
+        self.rm = rm
+        self.link = link
+        self.aggregate = aggregate
+
+
 class GroupRow:
     """One row of an :meth:`exp_aggregate_by` result.
 
-    ``.key`` is the group-by value (or ``None`` when missing); each aggregate
-    you named is exposed both as an attribute (``row.count``) and as an item
-    (``row["count"]``), so a dict comp like ``{r.key: r.count for r in rows}``
-    matches how callers typically reduce single-aggregate results.
+    ``.key`` is the group-by value (or ``None`` when missing). When the call
+    grouped by ``"resource_id"`` (each group is exactly one row of *this* RM),
+    ``.resource`` carries that row's :class:`~specstar.types.SearchedResource`
+    — that's the cross-RM case (e.g. *"list each doc and its chunk count"*).
+    For any other ``by``, ``.resource`` is ``None`` because a group could span
+    many rows.
+
+    Each named aggregate is exposed both as an attribute (``row.count``) and
+    as an item (``row["count"]``), so a dict comp like
+    ``{r.key: r.count for r in rows}`` works for single-aggregate results.
     """
 
-    __slots__ = ("key", "_aggregates")
+    __slots__ = ("key", "resource", "_aggregates")
 
-    def __init__(self, key: Any, **aggregates: Any) -> None:
+    def __init__(
+        self, key: Any, *, resource: Any = None, **aggregates: Any
+    ) -> None:
         self.key = key
+        self.resource = resource
         self._aggregates = aggregates
 
     def __getattr__(self, name: str) -> Any:
@@ -83,7 +114,17 @@ class GroupRow:
 
     def __repr__(self) -> str:
         body = ", ".join(f"{k}={v!r}" for k, v in self._aggregates.items())
-        return f"GroupRow(key={self.key!r}, {body})"
+        extras = f", resource={self.resource!r}" if self.resource is not None else ""
+        return f"GroupRow(key={self.key!r}{extras}, {body})"
 
 
-__all__ = ["Aggregate", "Avg", "Count", "GroupRow", "Max", "Min", "Sum"]
+__all__ = [
+    "Aggregate",
+    "Avg",
+    "Count",
+    "ForeignAggregate",
+    "GroupRow",
+    "Max",
+    "Min",
+    "Sum",
+]

--- a/specstar/aggregates.py
+++ b/specstar/aggregates.py
@@ -1,8 +1,9 @@
 """Aggregate specs for :meth:`ResourceManager.exp_aggregate_by`.
 
-v1 ships :class:`Count` only. v2 will add ``Sum(field)`` / ``Min(field)`` /
-``Max(field)`` / ``Avg(field)`` — same call site, just more keys in the
-``aggregates=`` dict; the return shape (``list[GroupRow]``) stays put.
+Shipped: :class:`Count`, :class:`Sum`, :class:`Min`, :class:`Max`, :class:`Avg`.
+Pass several at once in the ``aggregates=`` dict — each becomes a named field
+on the returned :class:`GroupRow`. The ``exp_`` prefix on the method advertises
+that the API may still adjust before stabilising as ``aggregate_by``.
 """
 
 from __future__ import annotations
@@ -13,11 +14,47 @@ import msgspec
 
 
 class Aggregate(msgspec.Struct, frozen=True):
-    """Marker base for aggregate specs (extend in v2: Sum, Min, Max, Avg)."""
+    """Marker base for aggregate specs."""
 
 
 class Count(Aggregate, frozen=True):
     """Count rows in the group."""
+
+
+class Sum(Aggregate, frozen=True):
+    """Sum a numeric field across the group; ``None`` values are skipped.
+
+    Returns ``None`` if the group has no non-``None`` value (SQL semantics).
+    Raises ``TypeError`` if a non-numeric value is encountered.
+    """
+
+    field: str
+
+
+class Min(Aggregate, frozen=True):
+    """Min of a field across the group (``None``-skipping). Returns ``None``
+    if the group has no non-``None`` value. Uses Python ``<`` ordering, so the
+    field's values must be mutually comparable (numbers, datetimes, strings).
+    """
+
+    field: str
+
+
+class Max(Aggregate, frozen=True):
+    """Max of a field across the group (``None``-skipping). Returns ``None``
+    if the group has no non-``None`` value."""
+
+    field: str
+
+
+class Avg(Aggregate, frozen=True):
+    """Average a numeric field across the group (``None``-skipping).
+
+    Returns a ``float``, or ``None`` if the group has no non-``None`` value.
+    Raises ``TypeError`` if a non-numeric value is encountered.
+    """
+
+    field: str
 
 
 class GroupRow:
@@ -49,4 +86,4 @@ class GroupRow:
         return f"GroupRow(key={self.key!r}, {body})"
 
 
-__all__ = ["Aggregate", "Count", "GroupRow"]
+__all__ = ["Aggregate", "Avg", "Count", "GroupRow", "Max", "Min", "Sum"]

--- a/specstar/aggregates.py
+++ b/specstar/aggregates.py
@@ -1,0 +1,52 @@
+"""Aggregate specs for :meth:`ResourceManager.exp_aggregate_by`.
+
+v1 ships :class:`Count` only. v2 will add ``Sum(field)`` / ``Min(field)`` /
+``Max(field)`` / ``Avg(field)`` — same call site, just more keys in the
+``aggregates=`` dict; the return shape (``list[GroupRow]``) stays put.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+
+class Aggregate(msgspec.Struct, frozen=True):
+    """Marker base for aggregate specs (extend in v2: Sum, Min, Max, Avg)."""
+
+
+class Count(Aggregate, frozen=True):
+    """Count rows in the group."""
+
+
+class GroupRow:
+    """One row of an :meth:`exp_aggregate_by` result.
+
+    ``.key`` is the group-by value (or ``None`` when missing); each aggregate
+    you named is exposed both as an attribute (``row.count``) and as an item
+    (``row["count"]``), so a dict comp like ``{r.key: r.count for r in rows}``
+    matches how callers typically reduce single-aggregate results.
+    """
+
+    __slots__ = ("key", "_aggregates")
+
+    def __init__(self, key: Any, **aggregates: Any) -> None:
+        self.key = key
+        self._aggregates = aggregates
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._aggregates[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def __getitem__(self, name: str) -> Any:
+        return self._aggregates[name]
+
+    def __repr__(self) -> str:
+        body = ", ".join(f"{k}={v!r}" for k, v in self._aggregates.items())
+        return f"GroupRow(key={self.key!r}, {body})"
+
+
+__all__ = ["Aggregate", "Count", "GroupRow"]

--- a/specstar/query.py
+++ b/specstar/query.py
@@ -406,9 +406,27 @@ class ConditionBuilder(Query):
 
 
 class Field(ConditionBuilder):
-    def __init__(self, name: str, transform: FieldTransform | None = None):
+    def __init__(
+        self,
+        name: str,
+        transform: FieldTransform | None = None,
+        *,
+        source: str = "auto",
+    ):
+        """A QB field reference.
+
+        ``source`` says where this field lives at runtime:
+
+        - ``"data"`` — ``ResourceMeta.indexed_data[name]`` only (``QB["foo"]``).
+        - ``"meta"`` — ``ResourceMeta`` struct attribute only
+          (``QB.created_by()`` and friends).
+        - ``"auto"`` — legacy: meta attribute first, fall back to
+          ``indexed_data``. Default for direct ``Field(name)`` construction so
+          existing filter code keeps working unchanged.
+        """
         self.name = name
         self.transform = transform
+        self.source = source
         # Default behavior: Field acts as is_truthy() condition
         # This allows QB["foo"] to be used directly in logical operations
         super().__init__(self._create_truthy_condition())
@@ -1255,7 +1273,7 @@ class QueryBuilderMeta(type):
             QB["class"]  # Field name with reserved keyword
             QB["field-name"]  # Field name with special characters
         """
-        return Field(name)
+        return Field(name, source="data")
 
 
 class QB(metaclass=QueryBuilderMeta):
@@ -1271,7 +1289,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.resource_id().eq("abc-123")
             QB.resource_id() << ["id1", "id2", "id3"]
         """
-        return Field("resource_id")
+        return Field("resource_id", source="meta")
 
     @staticmethod
     def current_revision_id() -> Field:
@@ -1283,7 +1301,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.current_revision_id().eq("rev-456")
         """
-        return Field("current_revision_id")
+        return Field("current_revision_id", source="meta")
 
     @staticmethod
     def created_time() -> Field:
@@ -1297,7 +1315,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.created_time().today()
             QB.created_time().last_n_days(7)
         """
-        return Field("created_time")
+        return Field("created_time", source="meta")
 
     @staticmethod
     def updated_time() -> Field:
@@ -1310,7 +1328,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.updated_time().this_week()
             QB.updated_time() >= datetime(2024, 1, 1)
         """
-        return Field("updated_time")
+        return Field("updated_time", source="meta")
 
     @staticmethod
     def created_by() -> Field:
@@ -1323,7 +1341,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.created_by().eq("admin")
             QB.created_by() << ["user1", "user2"]
         """
-        return Field("created_by")
+        return Field("created_by", source="meta")
 
     @staticmethod
     def updated_by() -> Field:
@@ -1336,7 +1354,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.updated_by().eq("system")
             QB.updated_by().ne("guest")
         """
-        return Field("updated_by")
+        return Field("updated_by", source="meta")
 
     @staticmethod
     def is_deleted() -> Field:
@@ -1349,7 +1367,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.is_deleted().eq(False)
             QB.is_deleted() == False
         """
-        return Field("is_deleted")
+        return Field("is_deleted", source="meta")
 
     @staticmethod
     def schema_version() -> Field:
@@ -1361,7 +1379,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.schema_version().eq("v2")
         """
-        return Field("schema_version")
+        return Field("schema_version", source="meta")
 
     @staticmethod
     def total_revision_count() -> Field:
@@ -1373,7 +1391,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.total_revision_count() > 5
         """
-        return Field("total_revision_count")
+        return Field("total_revision_count", source="meta")
 
     @staticmethod
     def rev_status() -> Field:
@@ -1382,7 +1400,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.rev_status().eq("draft")
         """
-        return Field("rev_status")
+        return Field("rev_status", source="meta")
 
     @staticmethod
     def rev_created_by() -> Field:
@@ -1392,7 +1410,7 @@ class QB(metaclass=QueryBuilderMeta):
             QB.rev_created_by().eq("alice")
             QB.rev_created_by() << ["alice", "bob"]
         """
-        return Field("rev_created_by")
+        return Field("rev_created_by", source="meta")
 
     @staticmethod
     def rev_updated_by() -> Field:
@@ -1401,7 +1419,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.rev_updated_by().eq("alice")
         """
-        return Field("rev_updated_by")
+        return Field("rev_updated_by", source="meta")
 
     @staticmethod
     def rev_created_time() -> Field:
@@ -1410,7 +1428,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.rev_created_time() >= datetime(2024, 1, 1)
         """
-        return Field("rev_created_time")
+        return Field("rev_created_time", source="meta")
 
     @staticmethod
     def rev_updated_time() -> Field:
@@ -1419,7 +1437,7 @@ class QB(metaclass=QueryBuilderMeta):
         Example:
             QB.rev_updated_time().this_week()
         """
-        return Field("rev_updated_time")
+        return Field("rev_updated_time", source="meta")
 
     # Combinators
     @staticmethod

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2296,6 +2296,92 @@ class ResourceManager(IResourceManager[T], Generic[T]):
 
         return results
 
+    def exp_aggregate_by(
+        self,
+        by: str,
+        aggregates: "dict[str, object]",
+        query: "ResourceMetaSearchQuery | Query | None" = None,
+    ) -> "list[object]":
+        """Group rows by ``by`` and reduce with the named ``aggregates``.
+
+        **Experimental** (``exp_`` prefix) — v1 ships :class:`~specstar.aggregates.Count`
+        only; v2 will add ``Sum(field)`` / ``Min(field)`` / ``Max(field)`` /
+        ``Avg(field)`` on the same signature. The return type
+        (``list[GroupRow]``) stays put as more aggregates are added.
+
+        Args:
+            by: field path to group on. Must be a ``ResourceMeta`` attribute or
+                a configured indexed key — same rule as filter conditions, so
+                ``on_unindexed_query`` applies (default ``warn``).
+            aggregates: ``{result_name: Aggregate}``, e.g. ``{"count": Count()}``.
+                Each ``result_name`` becomes an attribute on the returned rows.
+            query: optional filter (same shape as ``search_resources``); rows
+                matching the query are what we group over. ``None`` = all.
+
+        Returns:
+            ``list[GroupRow]`` — one row per distinct ``by`` value (missing /
+            UNSET values group under ``key=None``); each row has ``.key`` plus
+            the named aggregates exposed as both attributes and items.
+        """
+        from specstar.aggregates import Aggregate, Count, GroupRow
+
+        # 1) Validate that every aggregate is a known Aggregate spec (v1: Count).
+        for name, agg in aggregates.items():
+            if not isinstance(agg, Aggregate):
+                raise TypeError(
+                    f"aggregates[{name!r}] must be an Aggregate; got "
+                    f"{type(agg).__name__}."
+                )
+            if not isinstance(agg, Count):
+                raise NotImplementedError(
+                    f"aggregate {type(agg).__name__} is not supported in v1 "
+                    "(only Count). Sum/Min/Max/Avg are planned for v2."
+                )
+
+        # 2) Validate the group-by field is queryable. Reuse the same
+        #    on_unindexed_query policy as filter conditions.
+        valid = self._queryable_field_names()
+        if by not in valid:
+            from specstar.types import OnUnindexedQuery, UnindexedQueryError
+
+            if self._on_unindexed_query == OnUnindexedQuery.error:
+                raise UnindexedQueryError(
+                    [by], sorted(f.index_key or f.field_path for f in self._indexed_fields)
+                )
+            warnings.warn(
+                f"exp_aggregate_by on {self._resource_name!r} grouping by "
+                f"non-indexed field {by!r}: it isn't in indexed_data so every "
+                "row will group under key=None. Index the field, or group by "
+                "a ResourceMeta attribute.",
+                SpecStarWarning,
+                stacklevel=2,
+            )
+
+        # 3) Walk every matching meta (iter_all pages internally so a forgotten
+        #    limit can't drop data). Aggregate in-process.
+        groups: dict[object, dict[str, int]] = {}
+        for meta in self.iter_all(query):
+            key = self._group_key(meta, by)
+            row = groups.get(key)
+            if row is None:
+                row = groups[key] = {name: 0 for name in aggregates}
+            for name in aggregates:
+                row[name] += 1  # v1: only Count
+
+        return [GroupRow(key=k, **vals) for k, vals in groups.items()]
+
+    def _group_key(self, meta: ResourceMeta, field: str) -> object:
+        """Extract the value of ``field`` from a meta for grouping.
+
+        ResourceMeta attribute first, then ``indexed_data`` lookup; missing /
+        UNSET → ``None``.
+        """
+        if hasattr(meta, field) and field != "indexed_data":
+            return getattr(meta, field)
+        if meta.indexed_data is not UNSET and field in meta.indexed_data:
+            return meta.indexed_data[field]
+        return None
+
     @coerce_data_to_resource_type
     @execute_with_events(
         (BeforeCreate, AfterCreate, OnSuccessCreate, OnFailureCreate),

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2305,44 +2305,76 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         """Group rows by ``by`` and reduce with the named ``aggregates``.
 
         **Experimental** (``exp_`` prefix) — the API may still adjust before
-        stabilising as ``aggregate_by``. Supported aggregates:
-        :class:`~specstar.aggregates.Count`,
+        stabilising as ``aggregate_by``. Handles both single-RM group-by and
+        cross-RM annotation in one method.
+
+        Self aggregates (over this RM's rows in each group):
+        :class:`~specstar.aggregates.Count` and
         :class:`~specstar.aggregates.Sum` / :class:`~specstar.aggregates.Min`
         / :class:`~specstar.aggregates.Max` / :class:`~specstar.aggregates.Avg`
-        (each takes the field to reduce). ``None`` values are skipped
-        (SQL semantics); a group whose values are all ``None`` reduces to
-        ``None`` for Sum/Min/Max/Avg.
+        (each takes the field to reduce). SQL ``None`` semantics: ``None`` /
+        UNSET values are skipped, and a group whose values are all ``None``
+        reduces to ``None`` for Sum / Min / Max / Avg.
+
+        Foreign aggregates (over *another* RM's rows linked to each group's
+        key value): :class:`~specstar.aggregates.ForeignAggregate` ``(rm,
+        link, aggregate)`` — internally one extra aggregate query per foreign,
+        scoped to just the keys this call actually surfaces.
+
+        Cross-RM "list parents with children stats": pass ``by="resource_id"``
+        — each group is then exactly one row of *this* RM, and the returned
+        ``GroupRow.resource`` carries that row's :class:`SearchedResource` so
+        you can read ``r.resource.data.name`` alongside ``r.chunk_count``.
+        For any other ``by``, ``.resource`` is ``None``.
 
         Args:
-            by: field path to group on. Must be a ``ResourceMeta`` attribute or
-                a configured indexed key — same rule as filter conditions, so
+            by: field path to group on. ``"resource_id"`` for per-parent
+                annotation; otherwise a ``ResourceMeta`` attribute or a
+                configured indexed key — same rule as filter conditions, so
                 ``on_unindexed_query`` applies (default ``warn``).
-            aggregates: ``{result_name: Aggregate}``, e.g.
-                ``{"count": Count(), "total": Sum("size")}``. Each
-                ``result_name`` becomes an attribute on the returned rows.
-                Aggregated fields must also be queryable.
+            aggregates: ``{result_name: Aggregate | ForeignAggregate}``, e.g.
+                ``{"count": Count(), "total": Sum("size"),
+                "chunks": ForeignAggregate(chrm, "source_doc_id", Count())}``.
+                Each ``result_name`` becomes an attribute on the returned rows.
             query: optional filter (same shape as ``search_resources``); rows
                 matching the query are what we group over. ``None`` = all.
 
         Returns:
             ``list[GroupRow]`` — one row per distinct ``by`` value (missing /
-            UNSET values group under ``key=None``); each row has ``.key`` plus
-            the named aggregates exposed as both attributes and items.
+            UNSET values group under ``key=None``). Each row has ``.key``, the
+            named aggregates as both attributes and items, and ``.resource``
+            (only populated when ``by == "resource_id"``).
         """
-        from specstar.aggregates import Aggregate, Avg, Count, GroupRow, Max, Min, Sum
+        from specstar.aggregates import (
+            Aggregate,
+            Avg,
+            Count,
+            ForeignAggregate,
+            GroupRow,
+            Max,
+            Min,
+            Sum,
+        )
 
-        # 1) Validate every aggregate spec.
+        # 1) Split self-aggregates from foreign-aggregates; validate.
+        self_aggs: dict[str, Aggregate] = {}
+        foreign_aggs: dict[str, ForeignAggregate] = {}
         for name, agg in aggregates.items():
-            if not isinstance(agg, Aggregate):
+            if isinstance(agg, Aggregate):
+                self_aggs[name] = agg
+            elif isinstance(agg, ForeignAggregate):
+                foreign_aggs[name] = agg
+            else:
                 raise TypeError(
-                    f"aggregates[{name!r}] must be an Aggregate; got "
-                    f"{type(agg).__name__}."
+                    f"aggregates[{name!r}] must be an Aggregate or "
+                    f"ForeignAggregate; got {type(agg).__name__}."
                 )
 
-        # 2) Validate group-by + every aggregated field is queryable. Reuse the
-        #    same on_unindexed_query policy as filter conditions.
+        # 2) Validate group-by + every self-aggregated field is queryable
+        #    (foreign fields are checked by the foreign rm). Reuse the same
+        #    on_unindexed_query policy as filter conditions.
         agg_fields = {
-            agg.field for agg in aggregates.values() if isinstance(agg, (Sum, Min, Max, Avg))
+            a.field for a in self_aggs.values() if isinstance(a, (Sum, Min, Max, Avg))
         }
         valid = self._queryable_field_names()
         bad = [f for f in {by, *agg_fields} if f not in valid]
@@ -2363,8 +2395,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 stacklevel=2,
             )
 
-        # 3) Walk every matching meta and aggregate in-process. iter_all pages
-        #    internally so a forgotten limit can't drop data.
+        # Per-aggregate state machines.
         def _init(agg: Aggregate):
             if isinstance(agg, Count):
                 return 0
@@ -2398,27 +2429,60 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 return state[0] / state[1] if state[1] > 0 else None
             return state
 
+        # 3) Reduce self-aggregates.
+        #    When grouping by ``resource_id``, each group is exactly one row of
+        #    *this* rm — fetch via list_resources so we can attach .resource
+        #    to the result (the cross-RM "list parents with children stats"
+        #    case). For any other ``by``, walk iter_all and bucket per key.
         groups: dict[object, dict[str, object]] = {}
-        for meta in self.iter_all(query):
-            key = self._group_key(meta, by)
-            row = groups.get(key)
-            if row is None:
-                row = groups[key] = {name: _init(agg) for name, agg in aggregates.items()}
-            for name, agg in aggregates.items():
-                val = (
-                    None
-                    if isinstance(agg, Count)
-                    else self._group_key(meta, agg.field)
-                )
-                row[name] = _update(agg, row[name], val)
+        resource_by_key: dict[object, object] = {}
 
-        return [
-            GroupRow(
-                key=k,
-                **{name: _finalize(aggregates[name], v) for name, v in vals.items()},
-            )
-            for k, vals in groups.items()
-        ]
+        if by == "resource_id":
+            parents = self.list_resources(query)
+            for p in parents:
+                key = p.meta.resource_id
+                resource_by_key[key] = p
+                state = groups[key] = {n: _init(a) for n, a in self_aggs.items()}
+                for n, a in self_aggs.items():
+                    val = None if isinstance(a, Count) else self._group_key(p.meta, a.field)
+                    state[n] = _update(a, state[n], val)
+        else:
+            for meta in self.iter_all(query):
+                key = self._group_key(meta, by)
+                state = groups.get(key)
+                if state is None:
+                    state = groups[key] = {n: _init(a) for n, a in self_aggs.items()}
+                for n, a in self_aggs.items():
+                    val = None if isinstance(a, Count) else self._group_key(meta, a.field)
+                    state[n] = _update(a, state[n], val)
+
+        # 4) Foreign aggregates: one query per foreign, scoped to the keys we
+        #    actually have, then zip onto each group.
+        foreign_results: dict[str, dict[object, object]] = {n: {} for n in foreign_aggs}
+        if groups and foreign_aggs:
+            from specstar.query import QB as _QB
+
+            keys = list(groups.keys())
+            for name, fa in foreign_aggs.items():
+                rows = fa.rm.exp_aggregate_by(
+                    fa.link,
+                    {name: fa.aggregate},
+                    query=(_QB[fa.link] << keys).build(),
+                )
+                foreign_results[name] = {r.key: r[name] for r in rows}
+
+        def _foreign_zero(fa: ForeignAggregate):
+            return 0 if isinstance(fa.aggregate, Count) else None
+
+        # 5) Build GroupRow per group, with finalised self-aggregates + foreign
+        #    lookups + optional .resource (when by == "resource_id").
+        out: list[GroupRow] = []
+        for key, state in groups.items():
+            row_kwargs = {n: _finalize(self_aggs[n], state[n]) for n in self_aggs}
+            for n, fa in foreign_aggs.items():
+                row_kwargs[n] = foreign_results[n].get(key, _foreign_zero(fa))
+            out.append(GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs))
+        return out
 
     def _group_key(self, meta: ResourceMeta, field: str) -> object:
         """Extract the value of ``field`` from a meta for grouping.

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2304,17 +2304,23 @@ class ResourceManager(IResourceManager[T], Generic[T]):
     ) -> "list[object]":
         """Group rows by ``by`` and reduce with the named ``aggregates``.
 
-        **Experimental** (``exp_`` prefix) — v1 ships :class:`~specstar.aggregates.Count`
-        only; v2 will add ``Sum(field)`` / ``Min(field)`` / ``Max(field)`` /
-        ``Avg(field)`` on the same signature. The return type
-        (``list[GroupRow]``) stays put as more aggregates are added.
+        **Experimental** (``exp_`` prefix) — the API may still adjust before
+        stabilising as ``aggregate_by``. Supported aggregates:
+        :class:`~specstar.aggregates.Count`,
+        :class:`~specstar.aggregates.Sum` / :class:`~specstar.aggregates.Min`
+        / :class:`~specstar.aggregates.Max` / :class:`~specstar.aggregates.Avg`
+        (each takes the field to reduce). ``None`` values are skipped
+        (SQL semantics); a group whose values are all ``None`` reduces to
+        ``None`` for Sum/Min/Max/Avg.
 
         Args:
             by: field path to group on. Must be a ``ResourceMeta`` attribute or
                 a configured indexed key — same rule as filter conditions, so
                 ``on_unindexed_query`` applies (default ``warn``).
-            aggregates: ``{result_name: Aggregate}``, e.g. ``{"count": Count()}``.
-                Each ``result_name`` becomes an attribute on the returned rows.
+            aggregates: ``{result_name: Aggregate}``, e.g.
+                ``{"count": Count(), "total": Sum("size")}``. Each
+                ``result_name`` becomes an attribute on the returned rows.
+                Aggregated fields must also be queryable.
             query: optional filter (same shape as ``search_resources``); rows
                 matching the query are what we group over. ``None`` = all.
 
@@ -2323,52 +2329,96 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             UNSET values group under ``key=None``); each row has ``.key`` plus
             the named aggregates exposed as both attributes and items.
         """
-        from specstar.aggregates import Aggregate, Count, GroupRow
+        from specstar.aggregates import Aggregate, Avg, Count, GroupRow, Max, Min, Sum
 
-        # 1) Validate that every aggregate is a known Aggregate spec (v1: Count).
+        # 1) Validate every aggregate spec.
         for name, agg in aggregates.items():
             if not isinstance(agg, Aggregate):
                 raise TypeError(
                     f"aggregates[{name!r}] must be an Aggregate; got "
                     f"{type(agg).__name__}."
                 )
-            if not isinstance(agg, Count):
-                raise NotImplementedError(
-                    f"aggregate {type(agg).__name__} is not supported in v1 "
-                    "(only Count). Sum/Min/Max/Avg are planned for v2."
-                )
 
-        # 2) Validate the group-by field is queryable. Reuse the same
-        #    on_unindexed_query policy as filter conditions.
+        # 2) Validate group-by + every aggregated field is queryable. Reuse the
+        #    same on_unindexed_query policy as filter conditions.
+        agg_fields = {
+            agg.field for agg in aggregates.values() if isinstance(agg, (Sum, Min, Max, Avg))
+        }
         valid = self._queryable_field_names()
-        if by not in valid:
+        bad = [f for f in {by, *agg_fields} if f not in valid]
+        if bad:
             from specstar.types import OnUnindexedQuery, UnindexedQueryError
 
             if self._on_unindexed_query == OnUnindexedQuery.error:
                 raise UnindexedQueryError(
-                    [by], sorted(f.index_key or f.field_path for f in self._indexed_fields)
+                    bad,
+                    sorted(f.index_key or f.field_path for f in self._indexed_fields),
                 )
             warnings.warn(
-                f"exp_aggregate_by on {self._resource_name!r} grouping by "
-                f"non-indexed field {by!r}: it isn't in indexed_data so every "
-                "row will group under key=None. Index the field, or group by "
+                f"exp_aggregate_by on {self._resource_name!r}: field(s) {bad!r} "
+                "aren't in indexed_data and aren't ResourceMeta attributes — "
+                "they'll be treated as None. Index them, or group / aggregate on "
                 "a ResourceMeta attribute.",
                 SpecStarWarning,
                 stacklevel=2,
             )
 
-        # 3) Walk every matching meta (iter_all pages internally so a forgotten
-        #    limit can't drop data). Aggregate in-process.
-        groups: dict[object, dict[str, int]] = {}
+        # 3) Walk every matching meta and aggregate in-process. iter_all pages
+        #    internally so a forgotten limit can't drop data.
+        def _init(agg: Aggregate):
+            if isinstance(agg, Count):
+                return 0
+            if isinstance(agg, Avg):
+                return [0.0, 0]  # [running_sum, n]
+            return None  # Sum / Min / Max
+
+        def _update(agg: Aggregate, state, val):
+            if isinstance(agg, Count):
+                return state + 1
+            if val is None:
+                return state
+            if isinstance(agg, (Sum, Avg)) and not isinstance(val, (int, float)):
+                raise TypeError(
+                    f"{type(agg).__name__}({agg.field!r}) requires a numeric "
+                    f"value; got {type(val).__name__} ({val!r})."
+                )
+            if isinstance(agg, Sum):
+                return val if state is None else state + val
+            if isinstance(agg, Min):
+                return val if state is None else min(state, val)
+            if isinstance(agg, Max):
+                return val if state is None else max(state, val)
+            # Avg
+            state[0] += val
+            state[1] += 1
+            return state
+
+        def _finalize(agg: Aggregate, state):
+            if isinstance(agg, Avg):
+                return state[0] / state[1] if state[1] > 0 else None
+            return state
+
+        groups: dict[object, dict[str, object]] = {}
         for meta in self.iter_all(query):
             key = self._group_key(meta, by)
             row = groups.get(key)
             if row is None:
-                row = groups[key] = {name: 0 for name in aggregates}
-            for name in aggregates:
-                row[name] += 1  # v1: only Count
+                row = groups[key] = {name: _init(agg) for name, agg in aggregates.items()}
+            for name, agg in aggregates.items():
+                val = (
+                    None
+                    if isinstance(agg, Count)
+                    else self._group_key(meta, agg.field)
+                )
+                row[name] = _update(agg, row[name], val)
 
-        return [GroupRow(key=k, **vals) for k, vals in groups.items()]
+        return [
+            GroupRow(
+                key=k,
+                **{name: _finalize(aggregates[name], v) for name, v in vals.items()},
+            )
+            for k, vals in groups.items()
+        ]
 
     def _group_key(self, meta: ResourceMeta, field: str) -> object:
         """Extract the value of ``field`` from a meta for grouping.

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2298,7 +2298,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
 
     def exp_aggregate_by(
         self,
-        by: str,
+        by: "object",
         aggregates: "dict[str, object]",
         query: "ResourceMetaSearchQuery | Query | None" = None,
     ) -> "list[object]":
@@ -2321,20 +2321,23 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         link, aggregate)`` — internally one extra aggregate query per foreign,
         scoped to just the keys this call actually surfaces.
 
-        Cross-RM "list parents with children stats": pass ``by="resource_id"``
-        — each group is then exactly one row of *this* RM, and the returned
-        ``GroupRow.resource`` carries that row's :class:`SearchedResource` so
-        you can read ``r.resource.data.name`` alongside ``r.chunk_count``.
-        For any other ``by``, ``.resource`` is ``None``.
+        Cross-RM "list parents with children stats": pass
+        ``by=QB.resource_id()`` — each group is then exactly one row of *this*
+        RM, and the returned ``GroupRow.resource`` carries that row's
+        :class:`SearchedResource` so you can read ``r.resource.data.name``
+        alongside ``r.chunk_count``. For any other ``by``, ``.resource`` is
+        ``None``.
 
         Args:
-            by: field path to group on. ``"resource_id"`` for per-parent
-                annotation; otherwise a ``ResourceMeta`` attribute or a
-                configured indexed key — same rule as filter conditions, so
-                ``on_unindexed_query`` applies (default ``warn``).
+            by: a QB :class:`~specstar.query.Field` — ``QB["foo"]`` for an
+                indexed data field, ``QB.created_by()`` (and friends) for a
+                ``ResourceMeta`` attribute. The Field's ``source`` is honoured
+                exactly (no meta-vs-data guessing), and the same
+                ``on_unindexed_query`` policy as filter conditions applies
+                (default ``warn``). Passing a plain string raises ``TypeError``.
             aggregates: ``{result_name: Aggregate | ForeignAggregate}``, e.g.
-                ``{"count": Count(), "total": Sum("size"),
-                "chunks": ForeignAggregate(chrm, "source_doc_id", Count())}``.
+                ``{"count": Count(), "total": Sum(QB["size"]),
+                "chunks": ForeignAggregate(chrm, QB["source_doc_id"], Count())}``.
                 Each ``result_name`` becomes an attribute on the returned rows.
             query: optional filter (same shape as ``search_resources``); rows
                 matching the query are what we group over. ``None`` = all.
@@ -2343,7 +2346,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             ``list[GroupRow]`` — one row per distinct ``by`` value (missing /
             UNSET values group under ``key=None``). Each row has ``.key``, the
             named aggregates as both attributes and items, and ``.resource``
-            (only populated when ``by == "resource_id"``).
+            (only populated when ``by`` is ``QB.resource_id()``).
         """
         from specstar.aggregates import (
             Aggregate,
@@ -2355,6 +2358,16 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             Min,
             Sum,
         )
+        from specstar.query import Field as _Field
+
+        # 0) ``by`` must be a QB Field — no string-by-convention guessing.
+        if not isinstance(by, _Field):
+            raise TypeError(
+                "exp_aggregate_by: ``by`` must be a QB Field "
+                "(e.g. QB[\"source_doc_id\"] for indexed data or "
+                "QB.resource_id() / QB.created_by() for ResourceMeta); "
+                f"got {type(by).__name__}."
+            )
 
         # 1) Split self-aggregates from foreign-aggregates; validate.
         self_aggs: dict[str, Aggregate] = {}
@@ -2370,14 +2383,17 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     f"ForeignAggregate; got {type(agg).__name__}."
                 )
 
-        # 2) Validate group-by + every self-aggregated field is queryable
-        #    (foreign fields are checked by the foreign rm). Reuse the same
-        #    on_unindexed_query policy as filter conditions.
-        agg_fields = {
+        # 2) Validate group-by + every self-aggregated Field is queryable for
+        #    its declared source (foreign fields are checked by the foreign rm).
+        #    Reuse the same on_unindexed_query policy as filter conditions.
+        agg_field_specs: list[_Field] = [
             a.field for a in self_aggs.values() if isinstance(a, (Sum, Min, Max, Avg))
-        }
-        valid = self._queryable_field_names()
-        bad = [f for f in {by, *agg_fields} if f not in valid]
+        ]
+        bad = [
+            f.name
+            for f in (by, *agg_field_specs)
+            if not self._is_field_queryable(f)
+        ]
         if bad:
             from specstar.types import OnUnindexedQuery, UnindexedQueryError
 
@@ -2430,30 +2446,40 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return state
 
         # 3) Reduce self-aggregates.
-        #    When grouping by ``resource_id``, each group is exactly one row of
-        #    *this* rm — fetch via list_resources so we can attach .resource
-        #    to the result (the cross-RM "list parents with children stats"
-        #    case). For any other ``by``, walk iter_all and bucket per key.
+        #    When grouping by ``QB.resource_id()``, each group is exactly one
+        #    row of *this* rm — fetch via list_resources so we can attach
+        #    ``.resource`` to the result (the cross-RM "list parents with
+        #    children stats" case). For any other ``by``, walk iter_all and
+        #    bucket per key.
         groups: dict[object, dict[str, object]] = {}
         resource_by_key: dict[object, object] = {}
+        per_row_mode = by.name == "resource_id" and by.source == "meta"
 
-        if by == "resource_id":
+        if per_row_mode:
             parents = self.list_resources(query)
             for p in parents:
                 key = p.meta.resource_id
                 resource_by_key[key] = p
                 state = groups[key] = {n: _init(a) for n, a in self_aggs.items()}
                 for n, a in self_aggs.items():
-                    val = None if isinstance(a, Count) else self._group_key(p.meta, a.field)
+                    val = (
+                        None
+                        if isinstance(a, Count)
+                        else self._read_field(p.meta, a.field)
+                    )
                     state[n] = _update(a, state[n], val)
         else:
             for meta in self.iter_all(query):
-                key = self._group_key(meta, by)
+                key = self._read_field(meta, by)
                 state = groups.get(key)
                 if state is None:
                     state = groups[key] = {n: _init(a) for n, a in self_aggs.items()}
                 for n, a in self_aggs.items():
-                    val = None if isinstance(a, Count) else self._group_key(meta, a.field)
+                    val = (
+                        None
+                        if isinstance(a, Count)
+                        else self._read_field(meta, a.field)
+                    )
                     state[n] = _update(a, state[n], val)
 
         # 4) Foreign aggregates: one query per foreign, scoped to the keys we
@@ -2467,7 +2493,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 rows = fa.rm.exp_aggregate_by(
                     fa.link,
                     {name: fa.aggregate},
-                    query=(_QB[fa.link] << keys).build(),
+                    query=(_QB[fa.link.name] << keys).build(),
                 )
                 foreign_results[name] = {r.key: r[name] for r in rows}
 
@@ -2475,7 +2501,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return 0 if isinstance(fa.aggregate, Count) else None
 
         # 5) Build GroupRow per group, with finalised self-aggregates + foreign
-        #    lookups + optional .resource (when by == "resource_id").
+        #    lookups + optional .resource (per-row mode only).
         out: list[GroupRow] = []
         for key, state in groups.items():
             row_kwargs = {n: _finalize(self_aggs[n], state[n]) for n in self_aggs}
@@ -2484,17 +2510,41 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             out.append(GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs))
         return out
 
-    def _group_key(self, meta: ResourceMeta, field: str) -> object:
-        """Extract the value of ``field`` from a meta for grouping.
+    def _read_field(self, meta: ResourceMeta, field: "object") -> object:
+        """Read a ``Field``'s value from a meta, honouring ``Field.source``.
 
-        ResourceMeta attribute first, then ``indexed_data`` lookup; missing /
-        UNSET → ``None``.
+        - ``meta``: look up the ``ResourceMeta`` struct attribute.
+        - ``data``: look up ``ResourceMeta.indexed_data[name]``.
+        - ``auto`` (legacy): try meta first, then ``indexed_data``.
+
+        Missing / UNSET → ``None``.
         """
-        if hasattr(meta, field) and field != "indexed_data":
-            return getattr(meta, field)
-        if meta.indexed_data is not UNSET and field in meta.indexed_data:
-            return meta.indexed_data[field]
+        name = field.name
+        source = field.source
+        if source == "meta":
+            if hasattr(meta, name) and name != "indexed_data":
+                return getattr(meta, name)
+            return None
+        if source == "data":
+            if meta.indexed_data is not UNSET and name in meta.indexed_data:
+                return meta.indexed_data[name]
+            return None
+        # auto
+        if hasattr(meta, name) and name != "indexed_data":
+            return getattr(meta, name)
+        if meta.indexed_data is not UNSET and name in meta.indexed_data:
+            return meta.indexed_data[name]
         return None
+
+    def _is_field_queryable(self, field: "object") -> bool:
+        """Whether ``field.name`` is reachable for ``field.source``."""
+        meta_names = set(ResourceMeta.__struct_fields__) - {"indexed_data"}
+        data_names = {f.index_key or f.field_path for f in self._indexed_fields}
+        if field.source == "meta":
+            return field.name in meta_names
+        if field.source == "data":
+            return field.name in data_names
+        return field.name in (meta_names | data_names)
 
     @coerce_data_to_resource_type
     @execute_with_events(

--- a/tests/test_exp_aggregate_by.py
+++ b/tests/test_exp_aggregate_by.py
@@ -10,7 +10,7 @@ import msgspec
 import pytest
 
 from specstar import OnUnindexedQuery, SpecStar
-from specstar.aggregates import Aggregate, Count
+from specstar.aggregates import Avg, Count, Max, Min, Sum
 from specstar.errors import SpecStarWarning, UnindexedQueryError
 from specstar.query import QB
 
@@ -78,16 +78,6 @@ def test_rejects_value_that_is_not_an_aggregate():
         rm_chunk.exp_aggregate_by("source_doc_id", {"oops": "not_an_aggregate"})
 
 
-def test_v1_only_supports_count_other_aggregates_raise_notimplemented():
-    # Define a v2-shaped placeholder to prove the gate is real, not a typo check.
-    class FutureSum(Aggregate, frozen=True):
-        pass
-
-    _, rm_chunk, _, _ = _setup(d1_chunks=1, d2_chunks=0)
-    with pytest.raises(NotImplementedError, match="v1"):
-        rm_chunk.exp_aggregate_by("source_doc_id", {"s": FutureSum()})
-
-
 def test_non_indexed_group_by_warns_under_default_policy():
     # Without indexed_fields on Chunk, source_doc_id is not in indexed_data —
     # every row collapses to key=None, with a SpecStarWarning naming the field.
@@ -124,3 +114,85 @@ def test_group_by_a_resource_meta_attribute_works_without_indexed_fields():
         rm.create(Chunk(text="c", source_doc_id="d2"))
     rows = rm.exp_aggregate_by("created_by", {"count": Count()})
     assert {r.key: r.count for r in rows} == {"alice": 2, "bob": 1}
+
+
+# --- v2 aggregates: Sum / Min / Max / Avg ------------------------------------
+
+
+class Item(msgspec.Struct):
+    bucket: str
+    size: int
+    score: float
+
+
+def _items(*items: "tuple[str, int, float] | tuple[str, int, float | None]"):
+    """``[(bucket, size, score), ...] -> (rm, items)``."""
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(
+        Item,
+        name="item",
+        indexed_fields=[("bucket", str), ("size", int), ("score", float)],
+    )
+    rm = sp.get_resource_manager(Item)
+    for bucket, size, score in items:
+        rm.create(Item(bucket=bucket, size=size, score=score))
+    return rm
+
+
+def test_sum_aggregates_numeric_field_per_group():
+    rm = _items(("a", 10, 1.0), ("a", 20, 2.0), ("b", 5, 1.5))
+    rows = rm.exp_aggregate_by("bucket", {"total": Sum("size")})
+    assert {r.key: r.total for r in rows} == {"a": 30, "b": 5}
+
+
+def test_min_and_max_aggregate_per_group():
+    rm = _items(("a", 10, 0.5), ("a", 20, 4.0), ("b", 5, 1.5))
+    rows = rm.exp_aggregate_by(
+        "bucket", {"smallest": Min("size"), "largest": Max("size")}
+    )
+    by_key = {r.key: (r.smallest, r.largest) for r in rows}
+    assert by_key == {"a": (10, 20), "b": (5, 5)}
+
+
+def test_avg_returns_float():
+    rm = _items(("a", 10, 1.0), ("a", 20, 3.0), ("b", 5, 2.0))
+    rows = rm.exp_aggregate_by("bucket", {"mean": Avg("size")})
+    by_key = {r.key: r.mean for r in rows}
+    assert by_key == {"a": 15.0, "b": 5.0}
+    assert all(isinstance(v, float) for v in by_key.values())
+
+
+def test_multiple_aggregates_in_one_call():
+    rm = _items(("a", 10, 0.5), ("a", 20, 4.0), ("b", 5, 1.5))
+    rows = rm.exp_aggregate_by(
+        "bucket",
+        {"n": Count(), "total": Sum("size"), "top_score": Max("score")},
+    )
+    by_key = {r.key: (r.n, r.total, r.top_score) for r in rows}
+    assert by_key == {"a": (2, 30, 4.0), "b": (1, 5, 1.5)}
+
+
+def test_sum_raises_typeerror_on_non_numeric_value():
+    rm = _items(("a", 10, 1.0))
+    # Sum on a string-typed indexed field (bucket) → first non-None hit raises.
+    with pytest.raises(TypeError, match="Sum"):
+        rm.exp_aggregate_by("bucket", {"oops": Sum("bucket")})
+
+
+def test_avg_returns_none_when_no_numeric_values_for_group():
+    # Avg on a field that's UNSET / not present for every row in the group:
+    # use a ResourceMeta attribute that's None for these rows. The created
+    # resources have created_time set, so use updated_by (often UNSET).
+    rm = _items(("a", 10, 0.5))
+    # Group on bucket but Avg on an indexed field that all rows have None for:
+    # rather than fight the model, prove the None-skip + None-return paths via
+    # an empty filter that yields a group with no rows. (See empty-filter test.)
+    # Here instead exercise Min/Max with no rows -> empty list (no group, no
+    # state to finalise).
+    rows = rm.exp_aggregate_by(
+        "bucket",
+        {"m": Avg("score")},
+        query=(QB["bucket"] == "nope").build(),
+    )
+    assert rows == []

--- a/tests/test_exp_aggregate_by.py
+++ b/tests/test_exp_aggregate_by.py
@@ -1,0 +1,126 @@
+"""``ResourceManager.exp_aggregate_by`` — group-by + aggregate (v1: Count).
+
+Built to grow: in v2 you'll pass {"size": Sum("bytes")} alongside
+{"count": Count()}; the return type (``list[GroupRow]``) won't change, just the
+named fields on each row. ``exp_`` prefix marks the API as experimental until
+v2 lands.
+"""
+
+import msgspec
+import pytest
+
+from specstar import OnUnindexedQuery, SpecStar
+from specstar.aggregates import Aggregate, Count
+from specstar.errors import SpecStarWarning, UnindexedQueryError
+from specstar.query import QB
+
+
+class Doc(msgspec.Struct):
+    name: str
+
+
+class Chunk(msgspec.Struct):
+    text: str
+    source_doc_id: str
+
+
+def _setup(d1_chunks: int, d2_chunks: int):
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Doc, name="doc")
+    sp.add_model(Chunk, name="chunk", indexed_fields=[("source_doc_id", str)])
+    rm_doc = sp.get_resource_manager(Doc)
+    rm_chunk = sp.get_resource_manager(Chunk)
+    d1 = rm_doc.create(Doc(name="d1")).resource_id
+    d2 = rm_doc.create(Doc(name="d2")).resource_id
+    for _ in range(d1_chunks):
+        rm_chunk.create(Chunk(text="x", source_doc_id=d1))
+    for _ in range(d2_chunks):
+        rm_chunk.create(Chunk(text="x", source_doc_id=d2))
+    return rm_doc, rm_chunk, d1, d2
+
+
+def test_aggregate_by_counts_grouped_by_indexed_field():
+    _, rm_chunk, d1, d2 = _setup(d1_chunks=3, d2_chunks=5)
+    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"count": Count()})
+    by_key = {r.key: r.count for r in rows}
+    assert by_key == {d1: 3, d2: 5}
+
+
+def test_aggregate_by_honours_filter_query():
+    # Narrow the aggregation with a filter (matches the issue's batched-page pattern).
+    _, rm_chunk, d1, d2 = _setup(d1_chunks=3, d2_chunks=5)
+    rows = rm_chunk.exp_aggregate_by(
+        "source_doc_id",
+        {"count": Count()},
+        query=(QB["source_doc_id"] == d1).build(),
+    )
+    assert {r.key: r.count for r in rows} == {d1: 3}
+
+
+def test_aggregate_by_empty_input_returns_empty_list():
+    _, rm_chunk, _, _ = _setup(d1_chunks=0, d2_chunks=0)
+    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"count": Count()})
+    assert rows == []
+
+
+def test_group_row_exposes_caller_named_aggregate_via_attr_and_item():
+    # The result-field name comes from the dict key — caller controls it.
+    _, rm_chunk, d1, d2 = _setup(d1_chunks=2, d2_chunks=4)
+    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"chunk_total": Count()})
+    assert {r.key: r.chunk_total for r in rows} == {d1: 2, d2: 4}  # attr access
+    assert {r.key: r["chunk_total"] for r in rows} == {d1: 2, d2: 4}  # item access
+
+
+def test_rejects_value_that_is_not_an_aggregate():
+    _, rm_chunk, _, _ = _setup(d1_chunks=1, d2_chunks=0)
+    with pytest.raises(TypeError, match="Aggregate"):
+        rm_chunk.exp_aggregate_by("source_doc_id", {"oops": "not_an_aggregate"})
+
+
+def test_v1_only_supports_count_other_aggregates_raise_notimplemented():
+    # Define a v2-shaped placeholder to prove the gate is real, not a typo check.
+    class FutureSum(Aggregate, frozen=True):
+        pass
+
+    _, rm_chunk, _, _ = _setup(d1_chunks=1, d2_chunks=0)
+    with pytest.raises(NotImplementedError, match="v1"):
+        rm_chunk.exp_aggregate_by("source_doc_id", {"s": FutureSum()})
+
+
+def test_non_indexed_group_by_warns_under_default_policy():
+    # Without indexed_fields on Chunk, source_doc_id is not in indexed_data —
+    # every row collapses to key=None, with a SpecStarWarning naming the field.
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Chunk, name="chunk2")  # no indexed_fields
+    rm = sp.get_resource_manager(Chunk)
+    rm.create(Chunk(text="x", source_doc_id="d1"))
+    with pytest.warns(SpecStarWarning, match="source_doc_id"):
+        rows = rm.exp_aggregate_by("source_doc_id", {"count": Count()})
+    assert [(r.key, r.count) for r in rows] == [(None, 1)]
+
+
+def test_non_indexed_group_by_raises_under_error_policy():
+    sp = SpecStar()
+    sp.configure(default_user="t", on_unindexed_query=OnUnindexedQuery.error)
+    sp.add_model(Chunk, name="chunk3")
+    rm = sp.get_resource_manager(Chunk)
+    rm.create(Chunk(text="x", source_doc_id="d1"))
+    with pytest.raises(UnindexedQueryError):
+        rm.exp_aggregate_by("source_doc_id", {"count": Count()})
+
+
+def test_group_by_a_resource_meta_attribute_works_without_indexed_fields():
+    # ResourceMeta attributes (e.g. created_by) are queryable without indexing.
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Chunk, name="chunk4")
+    rm = sp.get_resource_manager(Chunk)
+    with rm.using("alice"):
+        rm.create(Chunk(text="a", source_doc_id="d1"))
+        rm.create(Chunk(text="b", source_doc_id="d1"))
+    with rm.using("bob"):
+        rm.create(Chunk(text="c", source_doc_id="d2"))
+    rows = rm.exp_aggregate_by("created_by", {"count": Count()})
+    assert {r.key: r.count for r in rows} == {"alice": 2, "bob": 1}

--- a/tests/test_exp_aggregate_by.py
+++ b/tests/test_exp_aggregate_by.py
@@ -10,7 +10,7 @@ import msgspec
 import pytest
 
 from specstar import OnUnindexedQuery, SpecStar
-from specstar.aggregates import Avg, Count, Max, Min, Sum
+from specstar.aggregates import Avg, Count, ForeignAggregate, Max, Min, Sum
 from specstar.errors import SpecStarWarning, UnindexedQueryError
 from specstar.query import QB
 
@@ -194,5 +194,113 @@ def test_avg_returns_none_when_no_numeric_values_for_group():
         "bucket",
         {"m": Avg("score")},
         query=(QB["bucket"] == "nope").build(),
+    )
+    assert rows == []
+
+
+# --- cross-RM via by="resource_id" -------------------------------------------
+
+
+class ChunkSized(msgspec.Struct):
+    text: str
+    source_doc_id: str
+    size: int = 0
+
+
+def _docs_with_chunks(*plan: "tuple[str, list[int]]"):
+    """plan = [(doc_name, [chunk_sizes, ...]), ...] -> (rm_doc, rm_chunk)."""
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Doc, name="doc")
+    sp.add_model(
+        ChunkSized,
+        name="chunk",
+        indexed_fields=[("source_doc_id", str), ("size", int)],
+    )
+    rm_doc = sp.get_resource_manager(Doc)
+    rm_chunk = sp.get_resource_manager(ChunkSized)
+    for name, sizes in plan:
+        d = rm_doc.create(Doc(name=name)).resource_id
+        for s in sizes:
+            rm_chunk.create(ChunkSized(text="x", source_doc_id=d, size=s))
+    return rm_doc, rm_chunk
+
+
+def test_by_resource_id_attaches_each_parent_resource():
+    # The cross-RM ergonomic: group by resource_id -> GroupRow.resource is the
+    # parent's SearchedResource, so r.resource.data.name reads naturally.
+    rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20, 30]), ("d2", [5, 5]))
+    rows = rm_doc.exp_aggregate_by(
+        "resource_id",
+        {"chunk_count": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
+    )
+    by_name = {r.resource.data.name: r.chunk_count for r in rows}
+    assert by_name == {"d1": 3, "d2": 2}
+
+
+def test_parent_with_no_children_gets_zero_for_count():
+    rm_doc, rm_chunk = _docs_with_chunks(("d1", [1]), ("orphan", []))
+    rows = rm_doc.exp_aggregate_by(
+        "resource_id",
+        {"n": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
+    )
+    by_name = {r.resource.data.name: r.n for r in rows}
+    assert by_name == {"d1": 1, "orphan": 0}
+
+
+def test_parent_with_no_children_gets_none_for_sum():
+    rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20]), ("orphan", []))
+    rows = rm_doc.exp_aggregate_by(
+        "resource_id",
+        {"total": ForeignAggregate(rm_chunk, "source_doc_id", Sum("size"))},
+    )
+    by_name = {r.resource.data.name: r.total for r in rows}
+    assert by_name == {"d1": 30, "orphan": None}
+
+
+def test_mixed_self_and_foreign_aggregates_in_one_call():
+    # On the parent rm: Count() counts THIS row (always 1 when grouped by
+    # resource_id), ForeignAggregate counts the children, all in one method.
+    rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20, 30]), ("d2", [5, 5]))
+    rows = rm_doc.exp_aggregate_by(
+        "resource_id",
+        {
+            "self_n": Count(),
+            "chunk_n": ForeignAggregate(rm_chunk, "source_doc_id", Count()),
+            "chunk_total": ForeignAggregate(rm_chunk, "source_doc_id", Sum("size")),
+            "chunk_biggest": ForeignAggregate(rm_chunk, "source_doc_id", Max("size")),
+        },
+    )
+    by_name = {
+        r.resource.data.name: (r.self_n, r.chunk_n, r.chunk_total, r.chunk_biggest)
+        for r in rows
+    }
+    assert by_name == {"d1": (1, 3, 60, 30), "d2": (1, 2, 10, 5)}
+
+
+def test_resource_is_none_when_grouping_by_non_resource_id_field():
+    # Group chunks by source_doc_id -> a group can have many rows, so attaching
+    # a single .resource would be ambiguous; it stays None.
+    _, rm_chunk = _docs_with_chunks(("d1", [10, 20]))
+    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"n": Count()})
+    assert all(r.resource is None for r in rows)
+
+
+def test_rejects_value_that_is_neither_aggregate_nor_foreign():
+    rm_doc, _ = _docs_with_chunks(("d1", [1]))
+    with pytest.raises(TypeError, match="Aggregate or ForeignAggregate"):
+        rm_doc.exp_aggregate_by("resource_id", {"oops": "not_a_spec"})
+
+
+def test_no_parents_returns_empty_list_even_with_foreigns():
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Doc, name="doc")
+    sp.add_model(ChunkSized, name="chunk", indexed_fields=[("source_doc_id", str)])
+    rm_doc = sp.get_resource_manager(Doc)
+    rm_chunk = sp.get_resource_manager(ChunkSized)
+    rows = rm_doc.exp_aggregate_by(
+        "resource_id",
+        {"n": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
     )
     assert rows == []

--- a/tests/test_exp_aggregate_by.py
+++ b/tests/test_exp_aggregate_by.py
@@ -42,7 +42,7 @@ def _setup(d1_chunks: int, d2_chunks: int):
 
 def test_aggregate_by_counts_grouped_by_indexed_field():
     _, rm_chunk, d1, d2 = _setup(d1_chunks=3, d2_chunks=5)
-    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"count": Count()})
+    rows = rm_chunk.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
     by_key = {r.key: r.count for r in rows}
     assert by_key == {d1: 3, d2: 5}
 
@@ -51,7 +51,7 @@ def test_aggregate_by_honours_filter_query():
     # Narrow the aggregation with a filter (matches the issue's batched-page pattern).
     _, rm_chunk, d1, d2 = _setup(d1_chunks=3, d2_chunks=5)
     rows = rm_chunk.exp_aggregate_by(
-        "source_doc_id",
+        QB["source_doc_id"],
         {"count": Count()},
         query=(QB["source_doc_id"] == d1).build(),
     )
@@ -60,14 +60,14 @@ def test_aggregate_by_honours_filter_query():
 
 def test_aggregate_by_empty_input_returns_empty_list():
     _, rm_chunk, _, _ = _setup(d1_chunks=0, d2_chunks=0)
-    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"count": Count()})
+    rows = rm_chunk.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
     assert rows == []
 
 
 def test_group_row_exposes_caller_named_aggregate_via_attr_and_item():
     # The result-field name comes from the dict key — caller controls it.
     _, rm_chunk, d1, d2 = _setup(d1_chunks=2, d2_chunks=4)
-    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"chunk_total": Count()})
+    rows = rm_chunk.exp_aggregate_by(QB["source_doc_id"], {"chunk_total": Count()})
     assert {r.key: r.chunk_total for r in rows} == {d1: 2, d2: 4}  # attr access
     assert {r.key: r["chunk_total"] for r in rows} == {d1: 2, d2: 4}  # item access
 
@@ -75,7 +75,7 @@ def test_group_row_exposes_caller_named_aggregate_via_attr_and_item():
 def test_rejects_value_that_is_not_an_aggregate():
     _, rm_chunk, _, _ = _setup(d1_chunks=1, d2_chunks=0)
     with pytest.raises(TypeError, match="Aggregate"):
-        rm_chunk.exp_aggregate_by("source_doc_id", {"oops": "not_an_aggregate"})
+        rm_chunk.exp_aggregate_by(QB["source_doc_id"], {"oops": "not_an_aggregate"})
 
 
 def test_non_indexed_group_by_warns_under_default_policy():
@@ -87,7 +87,7 @@ def test_non_indexed_group_by_warns_under_default_policy():
     rm = sp.get_resource_manager(Chunk)
     rm.create(Chunk(text="x", source_doc_id="d1"))
     with pytest.warns(SpecStarWarning, match="source_doc_id"):
-        rows = rm.exp_aggregate_by("source_doc_id", {"count": Count()})
+        rows = rm.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
     assert [(r.key, r.count) for r in rows] == [(None, 1)]
 
 
@@ -98,7 +98,7 @@ def test_non_indexed_group_by_raises_under_error_policy():
     rm = sp.get_resource_manager(Chunk)
     rm.create(Chunk(text="x", source_doc_id="d1"))
     with pytest.raises(UnindexedQueryError):
-        rm.exp_aggregate_by("source_doc_id", {"count": Count()})
+        rm.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
 
 
 def test_group_by_a_resource_meta_attribute_works_without_indexed_fields():
@@ -112,7 +112,7 @@ def test_group_by_a_resource_meta_attribute_works_without_indexed_fields():
         rm.create(Chunk(text="b", source_doc_id="d1"))
     with rm.using("bob"):
         rm.create(Chunk(text="c", source_doc_id="d2"))
-    rows = rm.exp_aggregate_by("created_by", {"count": Count()})
+    rows = rm.exp_aggregate_by(QB.created_by(), {"count": Count()})
     assert {r.key: r.count for r in rows} == {"alice": 2, "bob": 1}
 
 
@@ -142,14 +142,14 @@ def _items(*items: "tuple[str, int, float] | tuple[str, int, float | None]"):
 
 def test_sum_aggregates_numeric_field_per_group():
     rm = _items(("a", 10, 1.0), ("a", 20, 2.0), ("b", 5, 1.5))
-    rows = rm.exp_aggregate_by("bucket", {"total": Sum("size")})
+    rows = rm.exp_aggregate_by(QB["bucket"], {"total": Sum(QB["size"])})
     assert {r.key: r.total for r in rows} == {"a": 30, "b": 5}
 
 
 def test_min_and_max_aggregate_per_group():
     rm = _items(("a", 10, 0.5), ("a", 20, 4.0), ("b", 5, 1.5))
     rows = rm.exp_aggregate_by(
-        "bucket", {"smallest": Min("size"), "largest": Max("size")}
+        QB["bucket"], {"smallest": Min(QB["size"]), "largest": Max(QB["size"])}
     )
     by_key = {r.key: (r.smallest, r.largest) for r in rows}
     assert by_key == {"a": (10, 20), "b": (5, 5)}
@@ -157,7 +157,7 @@ def test_min_and_max_aggregate_per_group():
 
 def test_avg_returns_float():
     rm = _items(("a", 10, 1.0), ("a", 20, 3.0), ("b", 5, 2.0))
-    rows = rm.exp_aggregate_by("bucket", {"mean": Avg("size")})
+    rows = rm.exp_aggregate_by(QB["bucket"], {"mean": Avg(QB["size"])})
     by_key = {r.key: r.mean for r in rows}
     assert by_key == {"a": 15.0, "b": 5.0}
     assert all(isinstance(v, float) for v in by_key.values())
@@ -166,8 +166,8 @@ def test_avg_returns_float():
 def test_multiple_aggregates_in_one_call():
     rm = _items(("a", 10, 0.5), ("a", 20, 4.0), ("b", 5, 1.5))
     rows = rm.exp_aggregate_by(
-        "bucket",
-        {"n": Count(), "total": Sum("size"), "top_score": Max("score")},
+        QB["bucket"],
+        {"n": Count(), "total": Sum(QB["size"]), "top_score": Max(QB["score"])},
     )
     by_key = {r.key: (r.n, r.total, r.top_score) for r in rows}
     assert by_key == {"a": (2, 30, 4.0), "b": (1, 5, 1.5)}
@@ -177,7 +177,7 @@ def test_sum_raises_typeerror_on_non_numeric_value():
     rm = _items(("a", 10, 1.0))
     # Sum on a string-typed indexed field (bucket) → first non-None hit raises.
     with pytest.raises(TypeError, match="Sum"):
-        rm.exp_aggregate_by("bucket", {"oops": Sum("bucket")})
+        rm.exp_aggregate_by(QB["bucket"], {"oops": Sum(QB["bucket"])})
 
 
 def test_avg_returns_none_when_no_numeric_values_for_group():
@@ -191,8 +191,8 @@ def test_avg_returns_none_when_no_numeric_values_for_group():
     # Here instead exercise Min/Max with no rows -> empty list (no group, no
     # state to finalise).
     rows = rm.exp_aggregate_by(
-        "bucket",
-        {"m": Avg("score")},
+        QB["bucket"],
+        {"m": Avg(QB["score"])},
         query=(QB["bucket"] == "nope").build(),
     )
     assert rows == []
@@ -231,8 +231,8 @@ def test_by_resource_id_attaches_each_parent_resource():
     # parent's SearchedResource, so r.resource.data.name reads naturally.
     rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20, 30]), ("d2", [5, 5]))
     rows = rm_doc.exp_aggregate_by(
-        "resource_id",
-        {"chunk_count": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
+        QB.resource_id(),
+        {"chunk_count": ForeignAggregate(rm_chunk, QB["source_doc_id"], Count())},
     )
     by_name = {r.resource.data.name: r.chunk_count for r in rows}
     assert by_name == {"d1": 3, "d2": 2}
@@ -241,8 +241,8 @@ def test_by_resource_id_attaches_each_parent_resource():
 def test_parent_with_no_children_gets_zero_for_count():
     rm_doc, rm_chunk = _docs_with_chunks(("d1", [1]), ("orphan", []))
     rows = rm_doc.exp_aggregate_by(
-        "resource_id",
-        {"n": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
+        QB.resource_id(),
+        {"n": ForeignAggregate(rm_chunk, QB["source_doc_id"], Count())},
     )
     by_name = {r.resource.data.name: r.n for r in rows}
     assert by_name == {"d1": 1, "orphan": 0}
@@ -251,8 +251,8 @@ def test_parent_with_no_children_gets_zero_for_count():
 def test_parent_with_no_children_gets_none_for_sum():
     rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20]), ("orphan", []))
     rows = rm_doc.exp_aggregate_by(
-        "resource_id",
-        {"total": ForeignAggregate(rm_chunk, "source_doc_id", Sum("size"))},
+        QB.resource_id(),
+        {"total": ForeignAggregate(rm_chunk, QB["source_doc_id"], Sum(QB["size"]))},
     )
     by_name = {r.resource.data.name: r.total for r in rows}
     assert by_name == {"d1": 30, "orphan": None}
@@ -263,12 +263,12 @@ def test_mixed_self_and_foreign_aggregates_in_one_call():
     # resource_id), ForeignAggregate counts the children, all in one method.
     rm_doc, rm_chunk = _docs_with_chunks(("d1", [10, 20, 30]), ("d2", [5, 5]))
     rows = rm_doc.exp_aggregate_by(
-        "resource_id",
+        QB.resource_id(),
         {
             "self_n": Count(),
-            "chunk_n": ForeignAggregate(rm_chunk, "source_doc_id", Count()),
-            "chunk_total": ForeignAggregate(rm_chunk, "source_doc_id", Sum("size")),
-            "chunk_biggest": ForeignAggregate(rm_chunk, "source_doc_id", Max("size")),
+            "chunk_n": ForeignAggregate(rm_chunk, QB["source_doc_id"], Count()),
+            "chunk_total": ForeignAggregate(rm_chunk, QB["source_doc_id"], Sum(QB["size"])),
+            "chunk_biggest": ForeignAggregate(rm_chunk, QB["source_doc_id"], Max(QB["size"])),
         },
     )
     by_name = {
@@ -282,14 +282,14 @@ def test_resource_is_none_when_grouping_by_non_resource_id_field():
     # Group chunks by source_doc_id -> a group can have many rows, so attaching
     # a single .resource would be ambiguous; it stays None.
     _, rm_chunk = _docs_with_chunks(("d1", [10, 20]))
-    rows = rm_chunk.exp_aggregate_by("source_doc_id", {"n": Count()})
+    rows = rm_chunk.exp_aggregate_by(QB["source_doc_id"], {"n": Count()})
     assert all(r.resource is None for r in rows)
 
 
 def test_rejects_value_that_is_neither_aggregate_nor_foreign():
     rm_doc, _ = _docs_with_chunks(("d1", [1]))
     with pytest.raises(TypeError, match="Aggregate or ForeignAggregate"):
-        rm_doc.exp_aggregate_by("resource_id", {"oops": "not_a_spec"})
+        rm_doc.exp_aggregate_by(QB.resource_id(), {"oops": "not_a_spec"})
 
 
 def test_no_parents_returns_empty_list_even_with_foreigns():
@@ -300,7 +300,7 @@ def test_no_parents_returns_empty_list_even_with_foreigns():
     rm_doc = sp.get_resource_manager(Doc)
     rm_chunk = sp.get_resource_manager(ChunkSized)
     rows = rm_doc.exp_aggregate_by(
-        "resource_id",
-        {"n": ForeignAggregate(rm_chunk, "source_doc_id", Count())},
+        QB.resource_id(),
+        {"n": ForeignAggregate(rm_chunk, QB["source_doc_id"], Count())},
     )
     assert rows == []

--- a/tests/test_field_source.py
+++ b/tests/test_field_source.py
@@ -1,0 +1,114 @@
+"""``Field.source`` makes the QB convention real, not decorative.
+
+Before this, ``QB["created_by"]`` and ``QB.created_by()`` both produced
+``Field("created_by")`` with no source information, so when an indexed field
+collided with a ``ResourceMeta`` attribute name, the runtime had to guess
+(meta wins). With ``source``, the surface syntax actually picks the lookup:
+
+- ``QB["foo"]``       → ``source="data"`` (indexed_data only)
+- ``QB.created_by()`` → ``source="meta"`` (ResourceMeta only)
+- bare ``Field("foo")`` → ``source="auto"`` (legacy: meta first, fallback data)
+"""
+
+from specstar.query import QB, Field
+
+
+def test_subscript_marks_field_as_data():
+    assert QB["source_doc_id"].source == "data"
+
+
+def test_named_meta_method_marks_field_as_meta():
+    assert QB.created_by().source == "meta"
+
+
+def test_direct_field_construction_defaults_to_auto():
+    assert Field("foo").source == "auto"
+
+
+# --- slice 2: the aggregate API takes Field, not str ------------------------
+
+
+import msgspec  # noqa: E402
+import pytest  # noqa: E402
+
+from specstar import Count, SpecStar, Sum  # noqa: E402
+from specstar.aggregates import ForeignAggregate  # noqa: E402
+
+
+class Chunk(msgspec.Struct):
+    text: str
+    source_doc_id: str
+
+
+def _chunk_rm():
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Chunk, name="chunk", indexed_fields=[("source_doc_id", str)])
+    return sp.get_resource_manager(Chunk)
+
+
+def test_exp_aggregate_by_takes_field_for_by():
+    rm = _chunk_rm()
+    rm.create(Chunk(text="a", source_doc_id="d1"))
+    rm.create(Chunk(text="b", source_doc_id="d1"))
+    rm.create(Chunk(text="c", source_doc_id="d2"))
+    rows = rm.exp_aggregate_by(QB["source_doc_id"], {"n": Count()})
+    assert {r.key: r.n for r in rows} == {"d1": 2, "d2": 1}
+
+
+def test_exp_aggregate_by_rejects_string_for_by():
+    rm = _chunk_rm()
+    with pytest.raises(TypeError, match="Field"):
+        rm.exp_aggregate_by("source_doc_id", {"n": Count()})
+
+
+def test_sum_takes_field_not_string():
+    with pytest.raises(TypeError, match="Field"):
+        Sum("size")
+
+
+def test_foreign_aggregate_link_must_be_field():
+    rm = _chunk_rm()
+    with pytest.raises(TypeError, match="Field"):
+        ForeignAggregate(rm, "source_doc_id", Count())
+
+
+# --- slice 3: source-aware dispatch on collision -----------------------------
+#
+# A model field named ``created_by`` collides with the ResourceMeta audit field.
+# Before, the runtime had to guess (meta won, silently). Now the surface picks
+# the lookup: QB[\"created_by\"] -> indexed data, QB.created_by() -> meta.
+
+
+class DocWithShadow(msgspec.Struct):
+    created_by: str   # collides with ResourceMeta.created_by (the audit field)
+
+
+def test_qb_subscript_reads_indexed_data_even_when_name_collides_with_meta():
+    sp = SpecStar()
+    sp.configure(default_user="audit-bob")
+    sp.add_model(
+        DocWithShadow, name="doc_shadow", indexed_fields=[("created_by", str)]
+    )
+    rm = sp.get_resource_manager(DocWithShadow)
+    # audit user "audit-bob" populates meta.created_by; the struct's created_by
+    # populates indexed_data["created_by"] with a *different* value.
+    rm.create(DocWithShadow(created_by="data-alice"))
+    rm.create(DocWithShadow(created_by="data-alice"))
+
+    rows = rm.exp_aggregate_by(QB["created_by"], {"n": Count()})
+    assert {r.key: r.n for r in rows} == {"data-alice": 2}  # data wins
+
+
+def test_qb_named_meta_method_reads_meta_attr_even_when_name_collides_with_indexed():
+    sp = SpecStar()
+    sp.configure(default_user="audit-bob")
+    sp.add_model(
+        DocWithShadow, name="doc_shadow2", indexed_fields=[("created_by", str)]
+    )
+    rm = sp.get_resource_manager(DocWithShadow)
+    rm.create(DocWithShadow(created_by="data-alice"))
+    rm.create(DocWithShadow(created_by="data-alice"))
+
+    rows = rm.exp_aggregate_by(QB.created_by(), {"n": Count()})
+    assert {r.key: r.n for r in rows} == {"audit-bob": 2}  # meta wins


### PR DESCRIPTION
Closes #341

## Problem

Before, both `QB["created_by"]` and `QB.created_by()` produced
`Field("created_by")` with no source info — the matcher had to guess
(meta first, fall back to `indexed_data`). When an indexed field collides
with a `ResourceMeta` attribute, the indexed value silently lost.

## Change

`Field` carries `source` — a small str literal that pins which side it
came from:

| Construction | Field | Source |
|---|---|---|
| `QB["foo"]` | `Field("foo", source="data")` | indexed_data only |
| `QB.created_by()` | `Field("created_by", source="meta")` | ResourceMeta only |
| `Field("foo")` (raw) | `source="auto"` | legacy meta-first fallback (filters unaffected) |

## Aggregate API breaking change (no migration — nobody is on this yet)

`exp_aggregate_by` and friends switch from `str` to `Field`:

- `exp_aggregate_by(by, ...)` requires a `Field`; passing a `str` raises `TypeError`
- `Sum / Min / Max / Avg` take a `Field` (was `str`); `Count` takes none
- `ForeignAggregate(rm, link, agg)` — `link` is a `Field` too
- Cross-RM `.resource` attachment now triggers on `by=QB.resource_id()`
  (i.e. `Field("resource_id", source="meta")`), not the literal string
  `"resource_id"`

## Source-aware dispatch in aggregate path

- `_read_field(meta, Field)` reads from `meta` attr or `indexed_data` per
  source (`auto` keeps the legacy guess so other call sites that pass
  `auto` Fields are unchanged)
- `_is_field_queryable(Field)` gates on the right name set per source, so
  `on_unindexed_query` / warn / error stay precise

## Test plan

- Two new collision tests on this branch prove the dispatch: a model field
  named `created_by` indexed alongside the meta audit `created_by`, with
  different values; group by `QB["created_by"]` picks the data value,
  group by `QB.created_by()` picks the meta value
- Filter path is unchanged (still `source="auto"`), so existing tests
  should remain green
- CI will validate the full suite on push

## Notes

This branch is 67 commits ahead of `spec-dd` — most of those are
production-hardening work already in other branches. The aggregate
dispatch fix is the tip commit `a77d248`.