### PR TITLE
ci: enable branch coverage + verify Codecov upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,10 @@ jobs:
       # also excluded. ``coverage run`` uses [tool.coverage.run] from pyproject
       # (measures the ``specstar`` package); ``-x`` still fails fast.
       - name: Unit + route tests (no external services)
-        run: uv run coverage run -m pytest -m "not integration and not benchmark and not slow" -q -x
+        # TEMP: trimmed to tests/test_specstar.py for fast iteration on the
+        # Codecov upload config — revert to the full `-m "not integration..."`
+        # marker selection before merging.
+        run: uv run coverage run -m pytest tests/test_specstar.py -q -x
 
       # Print a summary in the log and emit coverage.xml for Codecov. These run
       # only when the test step above succeeded (no ``if: always()``), so a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,7 @@ jobs:
       # also excluded. ``coverage run`` uses [tool.coverage.run] from pyproject
       # (measures the ``specstar`` package); ``-x`` still fails fast.
       - name: Unit + route tests (no external services)
-        # TEMP: trimmed to tests/test_specstar.py for fast iteration on the
-        # Codecov upload config — revert to the full `-m "not integration..."`
-        # marker selection before merging.
-        run: uv run coverage run -m pytest tests/test_specstar.py -q -x
+        run: uv run coverage run -m pytest -m "not integration and not benchmark and not slow" -q -x
 
       # Print a summary in the log and emit coverage.xml for Codecov. These run
       # only when the test step above succeeded (no ``if: always()``), so a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ exclude_also = [
     "warnings.warn.*SpecStarWarning",
 ]
 [tool.coverage.run]
+branch = true
 omit = [
     "tests/*",
     "benchmark/*",


### PR DESCRIPTION
Two changes:

1. **`[tool.coverage.run] branch = true`** in `pyproject.toml` — enables branch coverage (equivalent to pytest-cov's `--cov-branch`). Reflected in the next `coverage xml` output Codecov receives.

2. **Smoke-tested the Codecov upload pipeline** after setting `CODECOV_TOKEN` — verified by temporarily trimming the test scope and watching the upload step go from `Token length: 0 / Token required` → `Token length: 36 / Upload queued for processing complete`. The trim has been reverted in commit `4e95a5c`; the workflow is back to the full `-m "not integration and not benchmark and not slow"` selection.

Net diff after both commits: one new line in `pyproject.toml`. Workflow file unchanged from master.