### PR TITLE
ci(codecov): disable_search so wizard JS reports don't dilute coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,12 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          # disable_search keeps the action from auto-uploading the
+          # frontend reports under ``wizard/coverage/*`` (clover.xml +
+          # coverage-final.json) alongside the Python ``coverage.xml``,
+          # which drags the dashboard headline number to 0%.
           files: ./coverage.xml
+          disable_search: true
           slug: HYChou0515/specstar
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
Follow-up to #350.

codecov-action v5 auto-discovers every coverage-shaped file by default, which pulled the two 0%-coverage frontend reports under `wizard/coverage/` into the upload alongside the real Python `coverage.xml`. Result: dashboard headline shows **0%** even when the Python suite reports **~79%** locally.

`disable_search: true` makes the action only upload the file explicitly listed in `files:`. One-line config change.

## Why the previous PR didn't catch this

#350 was merged at `4e95a5c` before this fix landed on the branch (commits `26d6e0b` + `a142be0` were post-merge), so master needs this second tiny PR to finish the job.