### PR TITLE
fix(fs): harden disk stores against ESTALE + local-FS races (#352)

### DIFF
--- a/specstar/resource_manager/blob_store/simple.py
+++ b/specstar/resource_manager/blob_store/simple.py
@@ -1,7 +1,8 @@
 import fcntl
+import os
 import threading
 import uuid
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -17,6 +18,22 @@ from specstar.types import (
     BlobUploadSession,
 )
 from specstar.util.fs_retry import retry_on_estale
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write *data* to *path* atomically (tmp file in same dir + ``os.replace``).
+
+    Concurrent readers either see the previous complete file or the new
+    complete file — never a half-written prefix. See #352.
+    """
+    tmp = path.with_name(f"{path.name}.tmp.{uuid.uuid4().hex}")
+    try:
+        tmp.write_bytes(data)
+        os.replace(tmp, path)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            tmp.unlink()
+        raise
 
 
 def _fallback_content_type_guesser(data: bytes) -> UnsetType:
@@ -430,10 +447,15 @@ class DiskBlobStore(BasicBlobStore):
     def _load_session_meta(self, upload_id: str) -> _DiskSessionMeta:
         """Load session metadata from disk, raising ``FileNotFoundError``."""
         path = self._session_meta_path(upload_id)
-        if not path.exists():
-            raise FileNotFoundError(f"Upload session {upload_id} not found")
-        # ESTALE-tolerant read for NFS-shared session dirs. See #352.
-        return self._session_meta_decoder.decode(retry_on_estale(path.read_bytes))
+        # No exists() guard — it would TOCTOU against a concurrent abort and
+        # leak a raw "[Errno 2] No such file or directory: '/abs/path'"
+        # message. Read straight and translate ENOENT to the controlled
+        # "Upload session {upload_id} not found" surface. See #352.
+        try:
+            raw = retry_on_estale(path.read_bytes)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Upload session {upload_id} not found") from None
+        return self._session_meta_decoder.decode(raw)
 
     # -- Blob put / get / exists ------------------------------------------
 
@@ -456,15 +478,19 @@ class DiskBlobStore(BasicBlobStore):
         final_content_type = self.guess_content_type(data, content_type)
         # When key is caller-specified, always overwrite; for hash keys skip if exists
         if key is not None or not file_path.exists():
-            # Store raw bytes — no msgpack encoding, no 4 GB size limit
-            file_path.write_bytes(data)
-            # Write metadata sidecar (tiny msgpack — metadata only, not data)
+            # Atomic write: dump bytes into a uniquely-named tmp file in the
+            # same directory, then ``os.replace`` it onto the final path. A
+            # concurrent reader either sees the previous complete file or the
+            # new complete file — never a truncated mid-write prefix.
+            # See #352 (local-FS half).
             blob_meta = _DiskBlobMeta(
                 file_id=file_id,
                 size=len(data),
                 content_type=final_content_type,
             )
-            self._blob_meta_path(safe_name).write_bytes(self.encoder.encode(blob_meta))
+            meta_path = self._blob_meta_path(safe_name)
+            _atomic_write_bytes(file_path, data)
+            _atomic_write_bytes(meta_path, self.encoder.encode(blob_meta))
         return Binary(
             file_id=file_id,
             size=len(data),
@@ -475,25 +501,28 @@ class DiskBlobStore(BasicBlobStore):
     def get(self, file_id: str) -> Binary:
         safe_name = file_id.replace("/", "_").replace("..", "_")
         file_path = self.root_path / safe_name
-        if not file_path.exists():
-            raise FileNotFoundError(f"Blob {file_id} not found")
-        # ESTALE-tolerant read — see #352. A concurrent rename of the blob
-        # on another NFS client must not crash an in-flight get().
-        data = retry_on_estale(file_path.read_bytes)
+        # Skip the exists() guard: it would race against a concurrent purge
+        # and leak the raw "[Errno 2] No such file or directory: '/abs/path'"
+        # message to the caller. Read straight and translate ENOENT into the
+        # same controlled "Blob {file_id} not found" surface. See #352.
+        try:
+            data = retry_on_estale(file_path.read_bytes)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Blob {file_id} not found") from None
         meta_path = self._blob_meta_path(safe_name)
-        if meta_path.exists():
-            # New format: raw bytes + sidecar metadata
-            blob_meta = self._blob_meta_decoder.decode(
-                retry_on_estale(meta_path.read_bytes)
-            )
-            return Binary(
-                file_id=blob_meta.file_id,
-                size=blob_meta.size,
-                data=data,
-                content_type=blob_meta.content_type,
-            )
-        # Legacy fallback: msgpack-encoded Binary
-        return self.decoder.decode(data)
+        try:
+            meta_bytes = retry_on_estale(meta_path.read_bytes)
+        except FileNotFoundError:
+            # Legacy fallback: pre-sidecar format had the Binary msgpack-encoded
+            # inside the data file itself.
+            return self.decoder.decode(data)
+        blob_meta = self._blob_meta_decoder.decode(meta_bytes)
+        return Binary(
+            file_id=blob_meta.file_id,
+            size=blob_meta.size,
+            data=data,
+            content_type=blob_meta.content_type,
+        )
 
     def exists(self, file_id: str) -> bool:
         safe_name = file_id.replace("/", "_").replace("..", "_")
@@ -505,16 +534,22 @@ class DiskBlobStore(BasicBlobStore):
 
         safe_name = file_id.replace("/", "_").replace("..", "_")
         file_path = self.root_path / safe_name
-        if not file_path.exists():
-            raise FileNotFoundError(f"Blob {file_id} not found")
-
-        size = retry_on_estale(file_path.stat).st_size
+        # Race-tolerant stat: an ``exists()`` guard here would TOCTOU against
+        # a concurrent purge and leak a raw "[Errno 2] ..." path to the
+        # caller. Catch ENOENT from stat() and translate to the controlled
+        # surface. See #352.
+        try:
+            size = retry_on_estale(file_path.stat).st_size
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Blob {file_id} not found") from None
         content_type = UNSET
         meta_path = self._blob_meta_path(safe_name)
-        if meta_path.exists():
-            blob_meta = self._blob_meta_decoder.decode(
-                retry_on_estale(meta_path.read_bytes)
-            )
+        try:
+            meta_bytes = retry_on_estale(meta_path.read_bytes)
+        except FileNotFoundError:
+            meta_bytes = None
+        if meta_bytes is not None:
+            blob_meta = self._blob_meta_decoder.decode(meta_bytes)
             content_type = blob_meta.content_type
 
         def _iterate():

--- a/specstar/resource_manager/blob_store/simple.py
+++ b/specstar/resource_manager/blob_store/simple.py
@@ -16,6 +16,7 @@ from specstar.types import (
     BlobStreamInfo,
     BlobUploadSession,
 )
+from specstar.util.fs_retry import retry_on_estale
 
 
 def _fallback_content_type_guesser(data: bytes) -> UnsetType:
@@ -431,7 +432,8 @@ class DiskBlobStore(BasicBlobStore):
         path = self._session_meta_path(upload_id)
         if not path.exists():
             raise FileNotFoundError(f"Upload session {upload_id} not found")
-        return self._session_meta_decoder.decode(path.read_bytes())
+        # ESTALE-tolerant read for NFS-shared session dirs. See #352.
+        return self._session_meta_decoder.decode(retry_on_estale(path.read_bytes))
 
     # -- Blob put / get / exists ------------------------------------------
 
@@ -475,11 +477,15 @@ class DiskBlobStore(BasicBlobStore):
         file_path = self.root_path / safe_name
         if not file_path.exists():
             raise FileNotFoundError(f"Blob {file_id} not found")
-        data = file_path.read_bytes()
+        # ESTALE-tolerant read — see #352. A concurrent rename of the blob
+        # on another NFS client must not crash an in-flight get().
+        data = retry_on_estale(file_path.read_bytes)
         meta_path = self._blob_meta_path(safe_name)
         if meta_path.exists():
             # New format: raw bytes + sidecar metadata
-            blob_meta = self._blob_meta_decoder.decode(meta_path.read_bytes())
+            blob_meta = self._blob_meta_decoder.decode(
+                retry_on_estale(meta_path.read_bytes)
+            )
             return Binary(
                 file_id=blob_meta.file_id,
                 size=blob_meta.size,
@@ -502,20 +508,27 @@ class DiskBlobStore(BasicBlobStore):
         if not file_path.exists():
             raise FileNotFoundError(f"Blob {file_id} not found")
 
-        size = file_path.stat().st_size
+        size = retry_on_estale(file_path.stat).st_size
         content_type = UNSET
         meta_path = self._blob_meta_path(safe_name)
         if meta_path.exists():
-            blob_meta = self._blob_meta_decoder.decode(meta_path.read_bytes())
+            blob_meta = self._blob_meta_decoder.decode(
+                retry_on_estale(meta_path.read_bytes)
+            )
             content_type = blob_meta.content_type
 
         def _iterate():
-            with open(file_path, "rb") as f:
+            # The open itself can ESTALE on NFS even when the parent dir
+            # listing said the file is present. See #352.
+            f = retry_on_estale(open, file_path, "rb")
+            try:
                 while True:
                     chunk = f.read(8 * 1024 * 1024)  # 8 MB
                     if not chunk:
                         break
                     yield chunk
+            finally:
+                f.close()
 
         return BlobStreamInfo(
             _iterate(), size=size, content_type=content_type, file_id=file_id

--- a/specstar/resource_manager/meta_store/simple.py
+++ b/specstar/resource_manager/meta_store/simple.py
@@ -16,6 +16,7 @@ from specstar.resource_manager.basic import (
     is_match_query,
 )
 from specstar.types import ResourceMeta
+from specstar.util.fs_retry import is_transient_fs_error, retry_on_estale
 
 T = TypeVar("T")
 
@@ -96,15 +97,19 @@ class DiskMetaStore(IFastMetaStore):
 
     def __getitem__(self, pk: str) -> ResourceMeta:
         path = self._get_path(pk)
-        try:
+
+        def _read() -> bytes:
             with path.open("rb") as f:
-                return self._serializer.decode(f.read())
+                return f.read()
+
+        try:
+            # ESTALE retried inside; ENOENT still maps to KeyError so the
+            # "resource does not exist" contract matches every other meta
+            # store. See #352.
+            raw = retry_on_estale(_read)
         except FileNotFoundError:
-            # No finalised meta on disk → "resource does not exist", matching
-            # the dict-based stores' KeyError contract. An interrupted create()
-            # (resource dir written before meta) must look like a missing key,
-            # not crash with a raw OSError.
             raise KeyError(pk) from None
+        return self._serializer.decode(raw)
 
     def __setitem__(self, pk: str, b: ResourceMeta) -> None:
         path = self._get_path(pk)
@@ -123,7 +128,9 @@ class DiskMetaStore(IFastMetaStore):
                 if self._fsync:
                     f.flush()
                     os.fsync(f.fileno())
-            os.replace(tmp, path)
+            # ESTALE here means another NFS client invalidated our dirfd
+            # mid-replace; retry sees a fresh inode and the commit lands.
+            retry_on_estale(os.replace, tmp, path)
         except BaseException:
             with suppress(FileNotFoundError):
                 os.unlink(tmp)
@@ -146,13 +153,24 @@ class DiskMetaStore(IFastMetaStore):
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
         results: list[ResourceMeta] = []
         for file in self._rootdir.glob(f"*{self._suffix}"):
+
+            def _read(p: Path = file) -> bytes:
+                with p.open("rb") as f:
+                    return f.read()
+
             try:
-                with file.open("rb") as f:
-                    raw = f.read()
+                raw = retry_on_estale(_read)
             except FileNotFoundError:
                 # File removed (concurrent purge / aborted write) between the
                 # directory listing and the read — skip it, don't crash.
                 continue
+            except OSError as exc:
+                # A persistently-stale handle (after retries) for a single
+                # file is treated like a missing file: skip rather than crash
+                # the entire search. See #352.
+                if is_transient_fs_error(exc):
+                    continue
+                raise
             meta = self._serializer.decode(raw)
             if is_match_query(meta, query):
                 results.append(meta)

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -1,5 +1,6 @@
 import io
 import os
+import uuid as uuid_module
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager, suppress
 from pathlib import Path
@@ -247,17 +248,24 @@ class DiskResourceStore(IResourceStore):
         )
         reald = self._get_uid_store_realdir(str(info.uid))
 
-        # Create real directory if it doesn't exist
-        if not reald.exists():
-            reald.mkdir(parents=True, exist_ok=True)
-
-        # Create symlink directory structure
+        # mkdir(exist_ok=True) is already race-tolerant.
+        reald.mkdir(parents=True, exist_ok=True)
         symd.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing symlink if it exists and create new one
-        if symd.exists():
-            symd.unlink()
-        symd.symlink_to(relative_walk_up(reald, symd.parent), target_is_directory=True)
+        # Atomic symlink swap: the previous code did exists()→unlink()→symlink_to(),
+        # which TOCTOU-races concurrent writers and crashes with either
+        # FileExistsError or FileNotFoundError on local FS (see #352). Create a
+        # uniquely-named tmp symlink, then ``os.replace`` it onto ``symd`` —
+        # POSIX guarantees rename of a symlink onto an existing symlink is atomic.
+        target = relative_walk_up(reald, symd.parent)
+        tmp_link = symd.with_name(f"{symd.name}.tmp.{uuid_module.uuid4().hex}")
+        try:
+            tmp_link.symlink_to(target, target_is_directory=True)
+            os.replace(tmp_link, symd)
+        except BaseException:
+            with suppress(FileNotFoundError):
+                tmp_link.unlink()
+            raise
 
         # Write data and info
         with self._get_raw_data_path(str(info.uid)).open("wb") as f:

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -12,6 +12,7 @@ from specstar.resource_manager.basic import (
     MsgspecSerializer,
 )
 from specstar.types import RevisionInfo
+from specstar.util.fs_retry import retry_on_estale
 
 UID = UUID
 UIDStr = str
@@ -214,8 +215,14 @@ class DiskResourceStore(IResourceStore):
             self._get_uid_store_symdir(resource_id, revision_id, schema_version)
             / "data"
         )
-        with data_path.open("rb") as f:
+        # ESTALE on NFS — a concurrent rename invalidated our inode cache.
+        # Bounded retry resolves it without surfacing OSError to the caller.
+        # See #352.
+        f = retry_on_estale(data_path.open, "rb")
+        try:
             yield f
+        finally:
+            f.close()
 
     def get_revision_info(
         self,
@@ -227,8 +234,12 @@ class DiskResourceStore(IResourceStore):
             self._get_uid_store_symdir(resource_id, revision_id, schema_version)
             / "info"
         )
-        with info_path.open("rb") as f:
-            return self._info_serializer.decode(f.read())
+
+        def _read() -> bytes:
+            with info_path.open("rb") as f:
+                return f.read()
+
+        return self._info_serializer.decode(retry_on_estale(_read))
 
     def save(self, info: RevisionInfo, data: DataIO) -> None:
         symd = self._get_uid_store_symdir(

--- a/specstar/util/fs_retry.py
+++ b/specstar/util/fs_retry.py
@@ -22,7 +22,6 @@ import errno
 import random
 import time
 from collections.abc import Callable
-from contextlib import contextmanager
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -78,20 +77,3 @@ def retry_on_estale(
             time.sleep(delay * (0.5 + random.random()))
     assert last is not None
     raise last
-
-
-@contextmanager
-def estale_retry_context(
-    *,
-    attempts: int = DEFAULT_ATTEMPTS,
-    base_delay: float = DEFAULT_BASE_DELAY,
-    max_delay: float = DEFAULT_MAX_DELAY,
-):
-    """Context-manager flavour for ``with`` blocks that wrap a single read.
-
-    Note: a ``with`` block can't restart the body, so this only catches an
-    ESTALE *raised by the setup* of an inner context-manager — i.e. the
-    file-open call — and re-raises it. Callers that need true retry must
-    use :func:`retry_on_estale` around the open itself.
-    """
-    yield

--- a/specstar/util/fs_retry.py
+++ b/specstar/util/fs_retry.py
@@ -1,0 +1,97 @@
+"""Bounded-retry helpers for transient filesystem errors.
+
+Issue #352: on NFS, a concurrent rename/unlink on another client invalidates
+the inode the kernel handed us. The next syscall raises
+``OSError(errno=ESTALE)`` — a *transient* signal that the right answer is
+"re-stat and try again", not "crash the request".
+
+Local filesystems normally surface the same race as ``FileNotFoundError``
+(ENOENT), which the disk stores already handle as "the key is genuinely
+gone". ESTALE is different: the file usually still exists, just under a
+new inode after an atomic rename. A short bounded retry resolves it
+without the caller noticing.
+
+The helpers here intentionally only treat ESTALE as transient — ENOENT
+and other ``OSError`` subclasses keep their existing semantics so we don't
+mask real "missing file" / "permission denied" bugs.
+"""
+
+from __future__ import annotations
+
+import errno
+import random
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import TypeVar
+
+T = TypeVar("T")
+
+_TRANSIENT_ERRNOS = frozenset({errno.ESTALE})
+
+# Tunable defaults — small enough that we don't add measurable latency to
+# the happy path (the loop runs once on success), big enough that a real
+# NFS rename storm has time to settle.
+DEFAULT_ATTEMPTS = 5
+DEFAULT_BASE_DELAY = 0.005  # 5 ms
+DEFAULT_MAX_DELAY = 0.2  # 200 ms cap on a single backoff
+
+
+def is_transient_fs_error(exc: BaseException) -> bool:
+    """True if *exc* is an OSError whose errno is treated as retry-worthy.
+
+    Currently only ``errno.ESTALE`` qualifies. ENOENT is *not* transient —
+    callers that need "skip missing files" already handle it explicitly.
+    """
+    return isinstance(exc, OSError) and exc.errno in _TRANSIENT_ERRNOS
+
+
+def retry_on_estale(
+    fn: Callable[..., T],
+    *args,
+    attempts: int = DEFAULT_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    **kwargs,
+) -> T:
+    """Run *fn(*args, **kwargs)* with bounded retries on ESTALE.
+
+    Backoff grows exponentially from *base_delay* (clamped to *max_delay*)
+    and is jittered by a uniform [0.5, 1.5) multiplier so concurrent
+    workers don't all retry in lock-step.
+
+    Non-ESTALE exceptions propagate immediately. After *attempts* tries the
+    last ESTALE is re-raised so callers can still log / surface a clear
+    "filesystem is genuinely broken" signal.
+    """
+    last: OSError | None = None
+    for attempt in range(attempts):
+        try:
+            return fn(*args, **kwargs)
+        except OSError as exc:
+            if not is_transient_fs_error(exc):
+                raise
+            last = exc
+            if attempt == attempts - 1:
+                break
+            delay = min(max_delay, base_delay * (2**attempt))
+            time.sleep(delay * (0.5 + random.random()))
+    assert last is not None
+    raise last
+
+
+@contextmanager
+def estale_retry_context(
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+):
+    """Context-manager flavour for ``with`` blocks that wrap a single read.
+
+    Note: a ``with`` block can't restart the body, so this only catches an
+    ESTALE *raised by the setup* of an inner context-manager — i.e. the
+    file-open call — and re-raises it. Callers that need true retry must
+    use :func:`retry_on_estale` around the open itself.
+    """
+    yield

--- a/tests/test_fs_retry.py
+++ b/tests/test_fs_retry.py
@@ -487,3 +487,59 @@ def test_load_session_meta_translates_toctou_race_to_controlled_error(
     with pytest.raises(FileNotFoundError) as exc_info:
         store._load_session_meta(upload_id)
     assert f"Upload session {upload_id} not found" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write helpers: tmp file is cleaned up when the rename step fails
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_bytes_cleans_up_tmp_on_replace_failure(
+    tmpdir_path: Path, monkeypatch
+):
+    """``_atomic_write_bytes`` removes the tmp file when ``os.replace`` fails.
+
+    A failed atomic rename must not leave a half-written ``*.tmp.<uuid>``
+    sidecar on disk — otherwise concurrent ``glob`` patterns and orphan
+    sweeps see leftover garbage. Patches ``os.replace`` to raise and
+    asserts the directory has no tmp files afterwards.
+    """
+    from specstar.resource_manager.blob_store import simple as blob_mod
+
+    store = DiskBlobStore(tmpdir_path)
+
+    def boom(src, dst):
+        raise RuntimeError("simulated rename failure")
+
+    monkeypatch.setattr(blob_mod.os, "replace", boom)
+    with pytest.raises(RuntimeError):
+        store.put(b"payload", key="will-fail")
+
+    leftover = list(tmpdir_path.glob("will-fail.tmp.*"))
+    assert leftover == [], f"tmp file leaked: {leftover!r}"
+
+
+def test_resource_store_save_cleans_up_tmp_symlink_on_replace_failure(
+    tmpdir_path: Path, monkeypatch
+):
+    """``save()`` removes the tmp symlink when ``os.replace`` fails.
+
+    Same invariant as ``_atomic_write_bytes``, but for the symlink-swap
+    path in ``DiskResourceStore.save``: a failed rename must not leak a
+    dangling ``*.tmp.<uuid>`` symlink in the parent directory.
+    """
+    from specstar.resource_manager.resource_store import simple as res_mod
+
+    store = DiskResourceStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    info = _make_info("res:tmp")
+
+    def boom(src, dst):
+        raise RuntimeError("simulated rename failure")
+
+    monkeypatch.setattr(res_mod.os, "replace", boom)
+    with pytest.raises(RuntimeError):
+        store.save(info, io.BytesIO(b"x"))
+
+    sym_parent = tmpdir_path / "resource" / info.resource_id / info.revision_id
+    leftover = list(sym_parent.glob("*.tmp.*")) if sym_parent.exists() else []
+    assert leftover == [], f"tmp symlink leaked: {leftover!r}"

--- a/tests/test_fs_retry.py
+++ b/tests/test_fs_retry.py
@@ -1,0 +1,226 @@
+"""ESTALE / transient FS-error tolerance for the disk-backed stores.
+
+Issue #352: on NFS, a concurrent rename/unlink on another client invalidates
+the inode the kernel handed us, and the next syscall raises
+``OSError(errno=116, "Stale file handle")``. The same race on a local
+filesystem normally surfaces as ``FileNotFoundError`` (already handled), but
+on NFS-mounted root dirs the same code path crashes with a raw ESTALE.
+
+These tests prove the three disk stores treat ESTALE as transient: retry
+with bounded backoff, succeed on next attempt, never bubble the raw OSError
+out of the public API.
+"""
+
+from __future__ import annotations
+
+import errno
+import pathlib
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from faker import Faker
+
+from specstar.query_types import ResourceMetaSearchQuery
+from specstar.resource_manager.blob_store.simple import DiskBlobStore
+from specstar.resource_manager.meta_store.simple import DiskMetaStore
+from specstar.resource_manager.resource_store.simple import DiskResourceStore
+from specstar.types import ResourceMeta, RevisionInfo, RevisionStatus
+
+faker = Faker()
+
+
+def _stale_fh() -> OSError:
+    err = OSError(errno.ESTALE, "Stale file handle")
+    err.errno = errno.ESTALE
+    return err
+
+
+@pytest.fixture
+def tmpdir_path() -> Generator[Path]:
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)
+
+
+def _make_meta(pk: str) -> ResourceMeta:
+    now = faker.date_time()
+    user = faker.user_name()
+    return ResourceMeta(
+        current_revision_id="rev-1",
+        resource_id=pk,
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by=user,
+        updated_by=user,
+    )
+
+
+def _make_info(pk: str) -> RevisionInfo:
+    now = faker.date_time()
+    user = faker.user_name()
+    return RevisionInfo(
+        uid="uid-1",  # ty:ignore[invalid-argument-type]
+        resource_id=pk,
+        revision_id=f"{pk}:1",
+        schema_version=None,
+        data_hash="h",
+        status=RevisionStatus.stable,
+        created_time=now,
+        updated_time=now,
+        created_by=user,
+        updated_by=user,
+    )
+
+
+def make_flaky_open(target_name_contains: str, fail_times: int):
+    """Return ``(flaky_fn, state)``.
+
+    ``flaky_fn`` is suitable for ``monkeypatch.setattr(pathlib.Path, "open", flaky_fn)``
+    — a *function* (not an instance) so the descriptor protocol binds ``self``
+    correctly. ``state["calls"]`` counts how many times we faked ESTALE.
+    """
+    orig = pathlib.Path.open
+    state = {"calls": 0}
+
+    def flaky(self, *args, **kwargs):
+        if target_name_contains in self.name and state["calls"] < fail_times:
+            state["calls"] += 1
+            raise _stale_fh()
+        return orig(self, *args, **kwargs)
+
+    return flaky, state
+
+
+# ---------------------------------------------------------------------------
+# DiskMetaStore
+# ---------------------------------------------------------------------------
+
+
+def test_meta_store_getitem_retries_estale(tmpdir_path: Path, monkeypatch):
+    """Reading a meta file retries when the kernel returns ESTALE.
+
+    Simulates an NFS stale-handle race: the meta exists on disk but our
+    cached inode was invalidated by another client. The first open syscall
+    fails with ESTALE; the retry sees a fresh inode and succeeds.
+    """
+    store = DiskMetaStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    store["k:1"] = _make_meta("k:1")
+
+    flaky, state = make_flaky_open("k:1", fail_times=2)
+    monkeypatch.setattr(pathlib.Path, "open", flaky)
+
+    result = store["k:1"]
+    assert result.resource_id == "k:1"
+    assert state["calls"] == 2  # proves we actually retried
+
+
+def test_meta_store_getitem_persistent_estale_still_raises(
+    tmpdir_path: Path, monkeypatch
+):
+    """A truly persistent ESTALE eventually surfaces — we do not loop forever."""
+    store = DiskMetaStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    store["k:1"] = _make_meta("k:1")
+
+    def always_estale(self, *a, **k):
+        raise _stale_fh()
+
+    monkeypatch.setattr(pathlib.Path, "open", always_estale)
+
+    with pytest.raises(OSError) as exc_info:
+        store["k:1"]
+    assert exc_info.value.errno == errno.ESTALE
+
+
+def test_meta_store_iter_search_skips_estale_file(tmpdir_path: Path, monkeypatch):
+    """One stale-handle file mid-iteration must not crash the whole search.
+
+    Matches the existing FileNotFoundError-skip behavior: a transient ESTALE
+    on a single file is treated as "skip this file" once retries are
+    exhausted, never as "fail the entire search".
+    """
+    store = DiskMetaStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    store["real:1"] = _make_meta("real:1")
+    store["ghost:2"] = _make_meta("ghost:2")
+
+    orig_open = pathlib.Path.open
+
+    def fake_open(self, *a, **k):
+        if self.name.startswith("ghost:2"):
+            raise _stale_fh()
+        return orig_open(self, *a, **k)
+
+    monkeypatch.setattr(pathlib.Path, "open", fake_open)
+
+    results = list(store.iter_search(ResourceMetaSearchQuery()))
+    assert [m.resource_id for m in results] == ["real:1"]
+
+
+def test_meta_store_setitem_retries_estale_on_replace(tmpdir_path: Path, monkeypatch):
+    """An ESTALE on the atomic ``os.replace`` commit step is retried."""
+    from specstar.resource_manager.meta_store import simple as simple_mod
+
+    store = DiskMetaStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+
+    orig_replace = simple_mod.os.replace
+    state = {"calls": 0}
+
+    def flaky_replace(src, dst):
+        if state["calls"] == 0:
+            state["calls"] += 1
+            raise _stale_fh()
+        return orig_replace(src, dst)
+
+    monkeypatch.setattr(simple_mod.os, "replace", flaky_replace, raising=True)
+
+    store["k:1"] = _make_meta("k:1")
+    assert store["k:1"].resource_id == "k:1"
+    assert state["calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# DiskResourceStore
+# ---------------------------------------------------------------------------
+
+
+def test_resource_store_get_data_bytes_retries_estale(tmpdir_path: Path, monkeypatch):
+    """Opening the data file retries when the first open returns ESTALE."""
+    import io
+
+    store = DiskResourceStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    info = _make_info("res:1")
+    store.save(info, io.BytesIO(b"hello"))
+
+    flaky, state = make_flaky_open("data", fail_times=1)
+    monkeypatch.setattr(pathlib.Path, "open", flaky)
+
+    with store.get_data_bytes(info.resource_id, info.revision_id, None) as f:
+        assert f.read() == b"hello"
+    assert state["calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# DiskBlobStore
+# ---------------------------------------------------------------------------
+
+
+def test_blob_store_get_retries_estale(tmpdir_path: Path, monkeypatch):
+    """Blob get() retries when the kernel returns ESTALE on the data read."""
+    store = DiskBlobStore(tmpdir_path)
+    stored = store.put(b"payload", key="hash-1")
+
+    orig_read_bytes = pathlib.Path.read_bytes
+    state = {"calls": 0}
+
+    def flaky_read_bytes(self):
+        if self.name == "hash-1" and state["calls"] == 0:
+            state["calls"] += 1
+            raise _stale_fh()
+        return orig_read_bytes(self)
+
+    monkeypatch.setattr(pathlib.Path, "read_bytes", flaky_read_bytes)
+
+    result = store.get(stored.file_id)
+    assert result.data == b"payload"
+    assert state["calls"] == 1

--- a/tests/test_fs_retry.py
+++ b/tests/test_fs_retry.py
@@ -1,21 +1,26 @@
-"""ESTALE / transient FS-error tolerance for the disk-backed stores.
+"""ESTALE / FS-race tolerance for the disk-backed stores (issue #352).
 
-Issue #352: on NFS, a concurrent rename/unlink on another client invalidates
-the inode the kernel handed us, and the next syscall raises
-``OSError(errno=116, "Stale file handle")``. The same race on a local
-filesystem normally surfaces as ``FileNotFoundError`` (already handled), but
-on NFS-mounted root dirs the same code path crashes with a raw ESTALE.
+Two classes of race are covered:
 
-These tests prove the three disk stores treat ESTALE as transient: retry
-with bounded backoff, succeed on next attempt, never bubble the raw OSError
-out of the public API.
+* **NFS ESTALE** — a concurrent rename/unlink on another client invalidates
+  the inode the kernel handed us, and the next syscall raises
+  ``OSError(errno=116, "Stale file handle")``. Bounded retry resolves it.
+* **Local-FS TOCTOU** — even on a single-host POSIX filesystem, the
+  ``exists() → unlink()/open()`` patterns inside ``DiskResourceStore.save``
+  and ``DiskBlobStore`` race against concurrent writers/deleters and can
+  raise ``FileExistsError`` or ``FileNotFoundError``. The fix uses atomic
+  ``os.replace`` (tmp + rename) so concurrent operations never observe a
+  half-written file or fail to swap a symlink.
 """
 
 from __future__ import annotations
 
 import errno
+import io
 import pathlib
+import sys
 import tempfile
+import threading
 from collections.abc import Generator
 from pathlib import Path
 
@@ -224,3 +229,261 @@ def test_blob_store_get_retries_estale(tmpdir_path: Path, monkeypatch):
     result = store.get(stored.file_id)
     assert result.data == b"payload"
     assert state["calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Local-FS race: DiskResourceStore.save() symlink swap
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_save_does_not_crash(tmpdir_path: Path):
+    """Two threads racing save() on the same logical key must not crash.
+
+    Regression for #352 (local-FS half). The original symlink swap was
+    ``exists() → unlink() → symlink_to()`` — a classic TOCTOU. Concurrent
+    saves of the same ``(resource_id, revision_id, schema_version)`` raced
+    on the symlink and surfaced as either:
+
+    * ``FileExistsError`` — both threads passed ``exists()=False`` and one
+      symlinked first;
+    * ``FileNotFoundError`` — both passed ``exists()=True`` and one
+      unlinked first.
+
+    The atomic-replace fix swaps via a tmp symlink + ``os.replace``, so a
+    racing save always sees a complete symlink atomically.
+    """
+    store = DiskResourceStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    errors: list[BaseException] = []
+    iterations = 200
+
+    def saver(thread_idx: int) -> None:
+        try:
+            for i in range(iterations):
+                info = RevisionInfo(
+                    uid=f"uid-{thread_idx}-{i}",  # ty:ignore[invalid-argument-type]
+                    resource_id="shared:1",
+                    revision_id="shared:1:1",
+                    schema_version=None,
+                    data_hash="h",
+                    status=RevisionStatus.stable,
+                    created_time=faker.date_time(),
+                    updated_time=faker.date_time(),
+                    created_by="u",
+                    updated_by="u",
+                )
+                store.save(info, io.BytesIO(f"data-{thread_idx}-{i}".encode()))
+        except BaseException as exc:
+            errors.append(exc)
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=saver, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    assert not errors, f"concurrent save() crashed: {errors[0]!r}"
+
+
+def test_concurrent_save_leaves_consistent_winner(tmpdir_path: Path):
+    """After racing saves, the symlink resolves to exactly one valid uid.
+
+    Reader-side consistency: under the atomic-replace fix the symlink is
+    always either the old target or the new one — never a dangling link, a
+    half-written link, or absent. A subsequent ``get_data_bytes`` must
+    return one of the writers' payloads intact, byte-for-byte.
+    """
+    store = DiskResourceStore(encoding="msgpack", rootdir=tmpdir_path)  # ty:ignore[invalid-argument-type]
+    saves_per_thread = 200
+    payloads_written: set[bytes] = set()
+    lock = threading.Lock()
+
+    def saver(thread_idx: int) -> None:
+        for i in range(saves_per_thread):
+            payload = f"data-{thread_idx}-{i}".encode()
+            with lock:
+                payloads_written.add(payload)
+            info = RevisionInfo(
+                uid=f"uid-{thread_idx}-{i}",  # ty:ignore[invalid-argument-type]
+                resource_id="shared:2",
+                revision_id="shared:2:1",
+                schema_version=None,
+                data_hash="h",
+                status=RevisionStatus.stable,
+                created_time=faker.date_time(),
+                updated_time=faker.date_time(),
+                created_by="u",
+                updated_by="u",
+            )
+            store.save(info, io.BytesIO(payload))
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=saver, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    # The final symlink must resolve to a complete payload that one of the
+    # writers actually wrote — never garbage, never an empty file.
+    with store.get_data_bytes("shared:2", "shared:2:1", None) as f:
+        observed = f.read()
+    assert observed in payloads_written, (
+        f"reader observed payload not written by any thread: {observed!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Local-FS race: DiskBlobStore.put() must be atomic w.r.t. readers
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_blob_put_readers_never_see_partial_bytes(tmpdir_path: Path):
+    """A reader's get() must see the full payload or nothing — never a prefix.
+
+    Two writers ``put`` the same content-addressed blob (key=None, same
+    payload → same hash). The original code did ``file_path.write_bytes``
+    directly, so a reader hitting the file mid-write would see a truncated
+    payload. The atomic fix writes to a tmp file and ``os.replace``-s it
+    into place, so readers always see the complete prior bytes or the
+    complete new bytes.
+    """
+    store = DiskBlobStore(tmpdir_path)
+    # Use a large-enough payload that a mid-write read would catch a prefix.
+    payload = b"x" * (256 * 1024)  # 256 KB
+    file_id = "shared-hash"
+
+    # Pre-seed so reader's get() always finds *something*.
+    store.put(payload, key=file_id)
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+    iterations = 100
+
+    def writer() -> None:
+        for _ in range(iterations):
+            if stop.is_set():
+                return
+            try:
+                store.put(payload, key=file_id)
+            except BaseException as exc:
+                errors.append(exc)
+                return
+
+    def reader() -> None:
+        for _ in range(iterations):
+            try:
+                got = store.get(file_id)
+                if got.data != payload:
+                    errors.append(
+                        AssertionError(
+                            f"reader saw partial bytes: len={len(got.data)} "
+                            f"expected={len(payload)}"
+                        )
+                    )
+                    return
+            except BaseException as exc:
+                errors.append(exc)
+                return
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        stop.set()
+        sys.setswitchinterval(old_interval)
+
+    assert not errors, f"concurrent put/get failed: {errors[0]!r}"
+
+
+# ---------------------------------------------------------------------------
+# Local-FS race: DiskBlobStore.get() TOCTOU translation
+# ---------------------------------------------------------------------------
+
+
+def test_blob_get_translates_toctou_race_to_controlled_error(
+    tmpdir_path: Path, monkeypatch
+):
+    """A blob unlinked between exists() and read() raises the typed message.
+
+    Race: ``DiskBlobStore.get`` calls ``file_path.exists()`` then
+    ``file_path.read_bytes()``. A concurrent purge in the window leaves
+    ``read_bytes`` to raise a raw ``FileNotFoundError`` with the kernel's
+    "[Errno 2] No such file or directory: '/abs/path'" message — leaking
+    a filesystem path to the API caller. The fix removes the TOCTOU guard
+    and translates ENOENT from the read into the same controlled
+    "Blob {file_id} not found" surface as the non-race path.
+    """
+    store = DiskBlobStore(tmpdir_path)
+    stored = store.put(b"payload", key="race-key")
+
+    # Force the exists() check to lie, then make the file truly absent.
+    monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
+    (tmpdir_path / "race-key").unlink()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        store.get(stored.file_id)
+    assert "Blob race-key not found" in str(exc_info.value)
+
+
+def test_blob_get_stream_translates_toctou_race_to_controlled_error(
+    tmpdir_path: Path, monkeypatch
+):
+    """``get_stream`` matches ``get`` — controlled "Blob not found" on race.
+
+    Same window: ``exists()`` says yes, the file is purged before ``stat``
+    or ``open``. Without the fix the caller gets a raw pathlib ENOENT with
+    an absolute path; with the fix it gets the same controlled message as
+    the missing-file path.
+    """
+    store = DiskBlobStore(tmpdir_path)
+    stored = store.put(b"payload", key="race-stream-key")
+
+    monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
+    (tmpdir_path / "race-stream-key").unlink()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        store.get_stream(stored.file_id)
+    assert "Blob race-stream-key not found" in str(exc_info.value)
+
+
+def test_load_session_meta_translates_toctou_race_to_controlled_error(
+    tmpdir_path: Path, monkeypatch
+):
+    """Session metadata read raises the typed "Upload session not found" surface.
+
+    Race: ``_load_session_meta`` does ``path.exists()`` then
+    ``path.read_bytes()``. A concurrent ``abort_upload_session`` or cleanup
+    in the window leaves the read to surface a raw ``FileNotFoundError``
+    with an absolute filesystem path. The fix translates ENOENT from the
+    read into the same controlled "Upload session {upload_id} not found"
+    surface as the missing-session path.
+    """
+    store = DiskBlobStore(tmpdir_path)
+    session = store.create_upload_session(key="any")
+    upload_id = session.upload_id
+
+    monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
+    (tmpdir_path / "_sessions" / f"{upload_id}.meta").unlink()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        store._load_session_meta(upload_id)
+    assert f"Upload session {upload_id} not found" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Closes #352. Two commits, layered:

- **`e75f54b`** — NFS ESTALE half. Bounded retry helper (`specstar/util/fs_retry.py`) wired into every disk read/write on the three disk stores so a concurrent rename/unlink on another NFS client no longer crashes with raw \`OSError(errno=116)\`.
- **`573bd46`** — Local-FS race half. Atomic tmp + \`os.replace\` for \`DiskResourceStore.save()\` symlink swap and \`DiskBlobStore.put()\` writes; TOCTOU \`exists() → read\` patterns in \`DiskBlobStore.get / get_stream / _load_session_meta\` replaced with read-then-translate so callers get the typed \"Blob {file_id} not found\" surface instead of a leaked absolute path.

## Why both halves

The original framing was \"NFS stale file handle\", but local POSIX filesystems also race — \`DiskResourceStore.save()\`'s \`exists() → unlink() → symlink_to()\` reliably crashes with \`FileExistsError\` or \`FileNotFoundError\` under concurrent writers, no NFS required.

## Test plan

12 new tests in \`tests/test_fs_retry.py\` — all pass.

ESTALE half (monkey-patched OSError injection):
- [x] meta_store getitem retries ESTALE
- [x] meta_store persistent ESTALE eventually raises
- [x] meta_store iter_search skips stale file mid-iteration
- [x] meta_store setitem retries ESTALE on \`os.replace\`
- [x] resource_store get_data_bytes retries ESTALE
- [x] blob_store get retries ESTALE

Local-FS race half (real concurrency under \`sys.setswitchinterval(1e-6)\`):
- [x] 200 saves × 2 threads on same key → no crash
- [x] reader observes one of the actually-written payloads
- [x] 2 writers + 2 readers on 256 KB blob → readers never see partial bytes
- [x] \`get()\` after concurrent unlink → \"Blob {id} not found\" (no raw path)
- [x] same for \`get_stream()\`
- [x] same for \`_load_session_meta()\`

CI fast suite: **3033 passed, 0 failed**. Lint + format clean.

## Related

- #352 — the bug
- #353 — umbrella tracking the remaining 6 concurrency-hardening items uncovered while auditing this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)