### PR TITLE
fix(pg): contains on list-typed indexed fields uses JSONB @> (#362)

### DIFF
--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -1588,6 +1588,21 @@ class SpecStar:
                     distance=vinfo.marker.distance or "cosine",
                 )
 
+        # Tell the meta store which indexed fields are list-typed so that
+        # ``contains`` can dispatch to JSONB ``@>`` instead of substring LIKE.
+        # See #362. Only PostgresMetaStore currently implements
+        # ``register_list_field``; the call is a no-op on other backends.
+        if meta_store is not None and hasattr(meta_store, "register_list_field"):
+            from typing import get_origin
+
+            for field in resource_manager.indexed_fields:
+                ft = field.field_type
+                if ft is UNSET:
+                    continue
+                origin = get_origin(ft) or ft
+                if origin is list or origin is tuple or origin is set:
+                    meta_store.register_list_field(field.index_key or field.field_path)
+
         # Scan Ref / RefRevision annotations and collect relationships
         refs = extract_refs(resolved_model, model_name)
         self.relationships.extend(refs)
@@ -1645,9 +1660,7 @@ class SpecStar:
     def _install_ref_integrity_handlers(self) -> None:
         install_ref_integrity_handlers(self.relationships, self.resource_managers)
         if self.validate_refs:
-            install_ref_existence_validators(
-                self.relationships, self.resource_managers
-            )
+            install_ref_existence_validators(self.relationships, self.resource_managers)
 
     @staticmethod
     def _inline_embedded_schema_ref(schema_extra: dict, source_type: Any) -> dict:

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -59,6 +59,9 @@ class PostgresMetaStore(ISlowMetaStore):
         self.table_name = table_name
         # field_path → (indexed_dim, distance) for pgvector columns
         self._vec_columns: dict[str, tuple[int, str]] = {}
+        # Field paths registered as list-typed. ``contains`` on these uses
+        # JSONB ``@>`` instead of the substring-based ``LIKE``. See #362.
+        self._list_fields: set[str] = set()
 
         # 初始化 PostgreSQL 表
         self._init_postgres_table()
@@ -89,6 +92,18 @@ class PostgresMetaStore(ISlowMetaStore):
     @property
     def supports_native_vector_search(self) -> bool:
         return self._has_pgvector
+
+    def register_list_field(self, field_path: str) -> None:
+        """Declare *field_path* as a list-typed indexed field.
+
+        Routes ``DataSearchOperator.contains`` on this field through JSONB
+        ``@>`` (true element containment) instead of the default ``LIKE``
+        substring match. Idempotent — safe to call from ``add_model`` on
+        every registration.
+
+        See #362.
+        """
+        self._list_fields.add(field_path)
 
     # ------------------------------------------------------------------
     # Vector / pgvector DDL helpers
@@ -180,9 +195,7 @@ class PostgresMetaStore(ISlowMetaStore):
             [vec_literal, float(condition.threshold)],
         )
 
-    def _build_vector_order(
-        self, sort: "VectorDistanceSort"
-    ) -> tuple[str, list]:
+    def _build_vector_order(self, sort: "VectorDistanceSort") -> tuple[str, list]:
         if sort.field_path not in self._vec_columns:
             return "", []
         if not isinstance(sort.query_vector, list):
@@ -471,10 +484,20 @@ class PostgresMetaStore(ISlowMetaStore):
     def _upsert_sql(self) -> str:
         vec_cols = [self._vec_col_name(fp) for fp in self._vec_columns]
         base_cols = [
-            "resource_id", "data", "created_time", "updated_time",
-            "created_by", "updated_by", "is_deleted", "schema_version",
-            "indexed_data", "rev_status", "rev_created_by", "rev_updated_by",
-            "rev_created_time", "rev_updated_time",
+            "resource_id",
+            "data",
+            "created_time",
+            "updated_time",
+            "created_by",
+            "updated_by",
+            "is_deleted",
+            "schema_version",
+            "indexed_data",
+            "rev_status",
+            "rev_created_by",
+            "rev_updated_by",
+            "rev_created_time",
+            "rev_updated_time",
         ]
         all_cols = base_cols + vec_cols
         col_list = ", ".join(f'"{c}"' for c in all_cols)
@@ -487,8 +510,8 @@ class PostgresMetaStore(ISlowMetaStore):
         )
         return (
             f'INSERT INTO "{self.table_name}" ({col_list}) '
-            f'VALUES ({placeholders}) '
-            f'ON CONFLICT (resource_id) DO UPDATE SET {update_clause}'
+            f"VALUES ({placeholders}) "
+            f"ON CONFLICT (resource_id) DO UPDATE SET {update_clause}"
         )
 
     def save_many(self, metas: Iterable[ResourceMeta]) -> None:
@@ -859,6 +882,18 @@ class PostgresMetaStore(ISlowMetaStore):
         if operator == DataSearchOperator.less_than_or_equal:
             return f"{jsonb_numeric_extract} <= %s", [value]
         if operator == DataSearchOperator.contains:
+            # List-typed fields use JSONB ``@>`` so ``contains`` is true
+            # element containment, not a substring on the serialised JSON
+            # (which produced false-positives like ``"c1"`` matching
+            # ``["c10"]``). The default keeps ``LIKE`` for string fields.
+            # See #362.
+            if field_path in self._list_fields:
+                import json
+
+                return (
+                    f"indexed_data->'{field_path}' @> %s::jsonb",
+                    [json.dumps(value)],
+                )
             return f"{jsonb_text_extract} LIKE %s", [f"%{value}%"]
         if operator == DataSearchOperator.starts_with:
             return f"{jsonb_text_extract} LIKE %s", [f"{value}%"]

--- a/tests/test_contains_list_pushdown.py
+++ b/tests/test_contains_list_pushdown.py
@@ -124,6 +124,7 @@ def test_add_model_auto_registers_list_typed_indexed_fields(monkeypatch):
 
     class Doc(Struct):
         title: str
+        note: str = ""
         tags: list[str] = []
 
     registered: list[str] = []
@@ -139,14 +140,41 @@ def test_add_model_auto_registers_list_typed_indexed_fields(monkeypatch):
     sp.add_model(
         Doc,
         indexed_fields=[
-            IndexableField(field_path="title", field_type=str),
-            IndexableField(field_path="tags", field_type=list[str]),
+            IndexableField(field_path="title", field_type=str),  # str → not registered
+            IndexableField(field_path="note"),  # field_type UNSET → skipped
+            IndexableField(field_path="tags", field_type=list[str]),  # list → registered
         ],
     )
 
     assert "tags" in registered, (
         f"register_list_field not invoked for list-typed field; got {registered!r}"
     )
-    assert "title" not in registered, (
-        f"register_list_field called on non-list field; got {registered!r}"
+    # A string field and an untyped (UNSET) field must both be left alone.
+    assert "title" not in registered and "note" not in registered, (
+        f"register_list_field called on a non-list field; got {registered!r}"
     )
+
+
+def test_add_model_is_a_noop_on_backends_without_register_list_field():
+    """The auto-wiring is guarded by ``hasattr(meta_store, "register_list_field")``.
+
+    On the default in-memory backend (no such method) ``add_model`` must skip
+    the wiring silently — list-field ``contains`` just stays on the shared path.
+    """
+    from msgspec import Struct
+
+    from specstar import SpecStar
+    from specstar.types import IndexableField
+
+    class Doc(Struct):
+        tags: list[str] = []
+
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    # No monkeypatch: MemoryMetaStore has no register_list_field, so the guard
+    # is False and the loop is skipped — this must not raise.
+    sp.add_model(
+        Doc,
+        indexed_fields=[IndexableField(field_path="tags", field_type=list[str])],
+    )
+    assert sp.get_resource_manager(Doc) is not None

--- a/tests/test_postgres_contains_list.py
+++ b/tests/test_postgres_contains_list.py
@@ -1,0 +1,152 @@
+"""Postgres ``contains`` SQL pushdown must respect list-typed indexed fields.
+
+Issue #362. The in-process backends already do the right thing
+(``basic.py:369-376`` — ``compare_value in field_value`` for list-typed
+``field_value``). The Postgres backend's ``_build_condition`` does not —
+it always emits ``LIKE '%v%'`` against the JSONB column's text
+serialisation, which admits substring false-positives whenever list
+elements share substrings (e.g. ``"c1"`` matches a row whose list is
+``["c10", "c20"]`` because the literal substring ``c1`` appears).
+
+The fix routes list-typed indexed fields through JSONB ``@>`` and leaves
+string / numeric fields on ``LIKE`` so that:
+
+* ``QB["str_field"].contains("substr")`` keeps its substring semantics;
+* ``QB["list_field"].contains(element)`` becomes a true element-of test.
+
+These tests pin the SQL emitted by ``_build_condition`` directly so they
+don't require a live Postgres — they run inside the fast (no-services)
+gate.
+"""
+
+from __future__ import annotations
+
+from specstar.query_types import DataSearchCondition, DataSearchOperator
+from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+
+
+def _make_store() -> PostgresMetaStore:
+    """Build a PostgresMetaStore without touching the network.
+
+    ``__init__`` opens a connection pool and probes pgvector — both
+    require a live server. Bypassing via ``__new__`` lets us exercise the
+    pure SQL builder (``_build_condition``) in the fast gate. The
+    attributes set below are the only ones the builder reads.
+    """
+    s = PostgresMetaStore.__new__(PostgresMetaStore)
+    s.table_name = "resource_meta"
+    s._vec_columns = {}
+    s._list_fields = set()
+    return s
+
+
+def test_contains_on_list_field_emits_jsonb_containment():
+    """A field registered as list-typed must use JSONB ``@>``, not LIKE.
+
+    Without the fix the row ``source_chunk_ids = ["c10", "c20"]`` would
+    match ``contains("c1")`` because ``LIKE '%c1%'`` matches the literal
+    substring inside ``"c10"``. The ``@>`` form rejects that row because
+    ``"c1"`` is not an element of the array.
+    """
+    store = _make_store()
+    store.register_list_field("source_chunk_ids")
+
+    cond = DataSearchCondition(
+        field_path="source_chunk_ids",
+        operator=DataSearchOperator.contains,
+        value="c1",
+    )
+    sql, params = store._build_condition(cond)
+    assert "@>" in sql, f"expected JSONB containment for list field, got: {sql!r}"
+    assert "LIKE" not in sql, f"list-field contains must not fall back to LIKE: {sql!r}"
+    # The parameter is JSON-encoded so PG can compare arrays of strings.
+    assert params == ['"c1"'], f"expected JSON-encoded element, got: {params!r}"
+
+
+def test_contains_on_unregistered_field_falls_back_to_like():
+    """A field that was *not* registered as list-typed keeps ``LIKE`` semantics.
+
+    ``QB["description"].contains("urgent")`` is the canonical
+    string-substring use; the fix must not regress it.
+    """
+    store = _make_store()
+    # No register_list_field call — same as today's behaviour.
+
+    cond = DataSearchCondition(
+        field_path="description",
+        operator=DataSearchOperator.contains,
+        value="urgent",
+    )
+    sql, params = store._build_condition(cond)
+    assert "LIKE" in sql, f"string field must use LIKE, got: {sql!r}"
+    assert "@>" not in sql, f"string field must not use JSONB containment: {sql!r}"
+    assert params == ["%urgent%"]
+
+
+def test_register_list_field_is_idempotent():
+    """Re-registering the same field is a no-op (callers may register on every add_model).
+
+    Mirrors the ``add_indexed_field`` contract on the resource manager
+    (``core.py:1393-1401``).
+    """
+    store = _make_store()
+    store.register_list_field("tags")
+    store.register_list_field("tags")  # second call should not raise
+    cond = DataSearchCondition(
+        field_path="tags",
+        operator=DataSearchOperator.contains,
+        value="x",
+    )
+    sql, _ = store._build_condition(cond)
+    assert "@>" in sql
+
+
+# ---------------------------------------------------------------------------
+# Auto-wiring from ``add_model``
+# ---------------------------------------------------------------------------
+
+
+def test_add_model_auto_registers_list_typed_indexed_fields(monkeypatch):
+    """``add_model`` calls ``register_list_field`` on the meta store for list-typed fields.
+
+    Mirrors the existing ``ensure_vector_column`` auto-wiring (``crud/core.py:1583``):
+    a user declaring ``IndexableField(field_path="tags", field_type=list[str])``
+    should get correct Postgres ``contains`` semantics without manually
+    calling ``register_list_field``. Verified by monkey-patching the
+    in-memory meta store to expose ``register_list_field`` and asserting
+    that ``add_model`` invokes it with the right field path.
+    """
+    from msgspec import Struct
+
+    from specstar import SpecStar
+    from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+    from specstar.types import IndexableField
+
+    class Doc(Struct):
+        title: str
+        tags: list[str] = []
+
+    registered: list[str] = []
+    monkeypatch.setattr(
+        MemoryMetaStore,
+        "register_list_field",
+        lambda self, fp: registered.append(fp),
+        raising=False,
+    )
+
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(
+        Doc,
+        indexed_fields=[
+            IndexableField(field_path="title", field_type=str),
+            IndexableField(field_path="tags", field_type=list[str]),
+        ],
+    )
+
+    assert "tags" in registered, (
+        f"register_list_field not invoked for list-typed field; got {registered!r}"
+    )
+    assert "title" not in registered, (
+        f"register_list_field called on non-list field; got {registered!r}"
+    )


### PR DESCRIPTION
## Summary

Closes #362. `PostgresMetaStore._build_condition` emitted `LIKE '%v%'` for every `contains` query regardless of whether the indexed value was a string or a JSON array. For list-typed fields that meant false positives whenever elements shared substrings — e.g. `contains("c1")` matched a row whose list was `["c10", "c20"]` because the literal substring `c1` appears in the JSON serialisation.

The in-process backends already do the right thing (`basic.py:369-376` — `compare_value in field_value` for list-typed values), so the bug was a Postgres-vs-Memory semantic drift.

## Change

- Add `PostgresMetaStore.register_list_field(field_path)` to mark a field as list-typed. Stores into a per-instance `_list_fields` set.
- `_build_condition` on the data-field path dispatches: list-typed → `indexed_data->'f' @> %s::jsonb` (true element containment, GIN-index friendly); other → existing `LIKE` (preserves string substring use).
- `SpecStar.add_model` auto-calls `register_list_field` for any indexed field whose declared `field_type` is a `list[...]` / `tuple[...]` / `set[...]`. Mirrors the existing `ensure_vector_column` auto-wiring at `crud/core.py:1583`.

No public API change. `QB[\"str_field\"].contains(\"substr\")` keeps its substring semantics; `QB[\"list_field\"].contains(element)` becomes a true element-of test on Postgres (it already was on Memory/Disk).

## Test plan

- [x] `tests/test_postgres_contains_list.py` — 4 tests, run in the fast (no-services) gate via `__new__` bypass of `__init__`
  - list field → JSONB `@>` with JSON-encoded param
  - unregistered field → `LIKE` (string substring preserved)
  - `register_list_field` is idempotent
  - `add_model` end-to-end auto-registers list-typed indexed fields
- [x] Full fast suite: 3035 passed, 0 failed
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)