### PR TITLE
feat(meta-store): push exp_aggregate_by Count group-by down to SQLite + Postgres

### DIFF
--- a/specstar/query_types.py
+++ b/specstar/query_types.py
@@ -238,10 +238,39 @@ class ResourceMetaSearchQuery(Struct, kw_only=True):
     """Sorting criteria for the search results."""
 
 
+class AggKeyRef(Struct, frozen=True):
+    """Storage-facing reference to the field a pushed-down aggregate groups by.
+
+    ``source`` mirrors a QB ``Field.source`` — ``"meta"`` for a ResourceMeta
+    column, ``"data"`` for an ``indexed_data`` JSON field — so a metastore can
+    build the right key expression without importing the high-level QB / query
+    layer. This is the narrow contract between ``ResourceManager`` and an
+    ``IMetaWithAgg`` store.
+    """
+
+    source: Literal["meta", "data"]
+    name: str
+
+
+class AggSpec(Struct, frozen=True):
+    """Storage-facing description of one aggregate in a group-by pushdown.
+
+    ``op`` is the reducer and ``result_name`` is the caller's label (echoed
+    back per group). v1 ships ``"count"`` only; ``field`` is unused for count
+    and reserved for ``sum``/``min``/``max``/``avg`` when they push down.
+    """
+
+    result_name: str
+    op: Literal["count"]
+    field: AggKeyRef | None = None
+
+
 __all__ = [
     "DEFAULT_QUERY_LIMIT",
     "DEFAULT_QUERY_LIMIT_ENV_VAR",
     "DEFAULT_QUERY_LIMIT_FALLBACK",
+    "AggKeyRef",
+    "AggSpec",
     "DataSearchCondition",
     "DataSearchFilter",
     "DataSearchGroup",

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -12,6 +12,8 @@ import msgspec
 from msgspec import UNSET, Struct, UnsetType
 
 from specstar.query_types import (
+    AggKeyRef,
+    AggSpec,
     DataSearchCondition,
     DataSearchGroup,
     DataSearchLogicOperator,
@@ -747,6 +749,41 @@ class ISlowMetaStore(IMetaStore):
         """
 
 
+class IMetaWithAgg(IMetaStore, ABC):
+    """Meta stores that can push a group-by aggregate down to their engine.
+
+    Mixed into a concrete store ALONGSIDE its base — e.g.
+    ``class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore)``. The abstract
+    ``aggregate_by`` forces an implementation, so ``isinstance(ms,
+    IMetaWithAgg)`` is a typed, typo-proof capability check (no ``hasattr``
+    sniffing): :meth:`ResourceManager.exp_aggregate_by` uses it to decide
+    whether to push the aggregation down or fall back to its in-process Python
+    reduction.
+
+    Contract: every implementation MUST return results identical to that
+    Python fallback — enforced cross-backend by
+    ``tests/meta_store/test_aggregate_by.py``.
+    """
+
+    @abstractmethod
+    def aggregate_by(
+        self,
+        query: ResourceMetaSearchQuery,
+        by: AggKeyRef,
+        aggregates: list[AggSpec],
+    ) -> list[tuple[object, dict[str, object]]]:
+        """Group rows matching ``query`` by ``by`` and reduce each aggregate
+        per group, pushed down to the store's engine.
+
+        Aggregates over the WHOLE filtered set — ``query``'s ``limit`` /
+        ``offset`` are ignored (paging an aggregate is meaningless), matching
+        the ResourceManager's ``iter_all`` semantics. Returns one
+        ``(key, {result_name: value})`` per distinct ``by`` value; a missing /
+        NULL key groups under ``key=None`` to match the Python reference path.
+        """
+        ...
+
+
 class IBlobStore(ABC):
     """Interface for storing and retrieving binary blobs.
 
@@ -1196,6 +1233,17 @@ class IStorage(ABC):
     between separate metadata and resource stores, providing a unified view
     while optimizing for different access patterns and performance requirements.
     """
+
+    @property
+    def meta_store(self) -> "IMetaStore | None":
+        """The single underlying metadata store, when this storage has one.
+
+        ``SimpleStorage`` returns its meta store; composite / cached storages
+        may return ``None``. Lets the ResourceManager reach a capability like
+        :class:`IMetaWithAgg` via ``isinstance`` without sniffing attributes.
+        Default ``None`` so existing storages need no change.
+        """
+        return None
 
     @abstractmethod
     def exists(self, resource_id: str) -> bool:

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -20,6 +20,7 @@ from typing import (
     NamedTuple,
     TypedDict,
     TypeVar,
+    cast,
 )
 from uuid import uuid4
 
@@ -154,6 +155,7 @@ from specstar.resource_manager.basic import (
     Encoding,
     IBlobStore,
     IMetaStore,
+    IMetaWithAgg,
     IResourceStore,
     IStorage,
     MsgspecSerializer,
@@ -259,6 +261,12 @@ class SimpleStorage(IStorage):
     def __init__(self, meta_store: IMetaStore, resource_store: IResourceStore):
         self._meta_store = meta_store
         self._resource_store = resource_store
+
+    @property
+    def meta_store(self) -> IMetaStore:
+        """Expose the underlying meta store so the ResourceManager can detect
+        capabilities like :class:`IMetaWithAgg` (aggregate push-down)."""
+        return self._meta_store
 
     def exists(self, resource_id: str) -> bool:
         return resource_id in self._meta_store
@@ -2347,6 +2355,15 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         stabilising as ``aggregate_by``. Handles both single-RM group-by and
         cross-RM annotation in one method.
 
+        **Push-down:** a single-key, ``Count``-only group-by is pushed to the
+        store's engine when the meta store implements
+        :class:`~specstar.resource_manager.basic.IMetaWithAgg` (SQLite today) —
+        a real ``GROUP BY`` instead of streaming every matching row into
+        Python. Results are identical to the in-process path (enforced
+        cross-backend); it's scan-fast, not O(1) — for a genuinely hot,
+        high-fan-out count prefer a denormalised counter maintained on write.
+        Sum/Min/Max/Avg and ForeignAggregate still reduce in Python.
+
         Self aggregates (over this RM's rows in each group):
         :class:`~specstar.aggregates.Count` and
         :class:`~specstar.aggregates.Sum` / :class:`~specstar.aggregates.Min`
@@ -2508,18 +2525,53 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     )
                     state[n] = _update(a, state[n], val)
         else:
-            for meta in self.iter_all(query):
-                key = self._read_field(meta, by)
-                state = groups.get(key)
-                if state is None:
-                    state = groups[key] = {n: _init(a) for n, a in self_aggs.items()}
-                for n, a in self_aggs.items():
-                    val = (
-                        None
-                        if isinstance(a, Count)
-                        else self._read_field(meta, a.field)
-                    )
-                    state[n] = _update(a, state[n], val)
+            # Push a pure-``Count`` group-by down to the metastore engine when
+            # it advertises the capability (typed ``isinstance``, not
+            # ``hasattr``). Sum/Min/Max/Avg and ForeignAggregate stay on the
+            # Python path below; a pushed result MUST equal it (enforced
+            # cross-backend by tests/meta_store/test_aggregate_by.py).
+            ms = self.storage.meta_store
+            if (
+                self_aggs
+                and not foreign_aggs
+                and by.source in ("meta", "data")
+                and all(isinstance(a, Count) for a in self_aggs.values())
+                and isinstance(ms, IMetaWithAgg)
+            ):
+                from specstar.query_types import AggKeyRef, AggSpec
+                from specstar.query_types import ResourceMetaSearchQuery as _RMSQ
+
+                if query is None:
+                    q = _RMSQ()
+                elif isinstance(query, Query):
+                    q = query.build()
+                else:
+                    q = query
+                rows = ms.aggregate_by(
+                    q,
+                    # ``by.source`` is narrowed to meta/data by the guard above;
+                    # Field.source is typed ``str`` so spell the Literal out.
+                    AggKeyRef(
+                        source=cast(Literal["meta", "data"], by.source), name=by.name
+                    ),
+                    [AggSpec(result_name=n, op="count") for n in self_aggs],
+                )
+                groups = {key: dict(state) for key, state in rows}
+            else:
+                for meta in self.iter_all(query):
+                    key = self._read_field(meta, by)
+                    state = groups.get(key)
+                    if state is None:
+                        state = groups[key] = {
+                            n: _init(a) for n, a in self_aggs.items()
+                        }
+                    for n, a in self_aggs.items():
+                        val = (
+                            None
+                            if isinstance(a, Count)
+                            else self._read_field(meta, a.field)
+                        )
+                        state[n] = _update(a, state[n], val)
 
         # 4) Foreign aggregates: one query per foreign, scoped to the keys we
         #    actually have, then zip onto each group.

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -7,6 +7,8 @@ from typing import Any
 from msgspec import UNSET
 
 from specstar.query_types import (
+    AggKeyRef,
+    AggSpec,
     DataSearchFilter,
     DataSearchGroup,
     DataSearchLogicOperator,
@@ -20,6 +22,7 @@ from specstar.query_types import (
 )
 from specstar.resource_manager.basic import (
     Encoding,
+    IMetaWithAgg,
     ISlowMetaStore,
     MsgspecSerializer,
 )
@@ -36,7 +39,7 @@ except ImportError:  # pragma: no cover
     execute_batch = None  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
 
 
-class PostgresMetaStore(ISlowMetaStore):
+class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
     def __init__(
         self,
         pg_dsn: str,
@@ -574,10 +577,15 @@ class PostgresMetaStore(ISlowMetaStore):
             cur.execute(f'SELECT COUNT(*) FROM "{self.table_name}"')
             return cur.fetchone()[0]
 
-    def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
-        # 直接从 PostgreSQL 查询
+    def _build_where(self, query: ResourceMetaSearchQuery) -> tuple[str, list]:
+        """Translate a search query into a SQL ``WHERE`` clause + params.
 
-        # 构建查询条件
+        Shared by :meth:`iter_search` and :meth:`aggregate_by` so a pushed-down
+        aggregate filters exactly like a search — meta columns + ``indexed_data``
+        JSONB conditions + vector conditions, built ONE way. Returns the
+        ``"WHERE ..."`` string (``""`` when unfiltered) and its params;
+        ordering / paging stay with the caller.
+        """
         conditions = []
         params = []
 
@@ -661,10 +669,13 @@ class PostgresMetaStore(ISlowMetaStore):
                     conditions.append(json_condition)
                     params.extend(json_params)
 
-        # 构建 WHERE 子句
         where_clause = ""
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)
+        return where_clause, params
+
+    def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+        where_clause, params = self._build_where(query)
 
         # 构建排序子句
         order_clause = ""
@@ -705,6 +716,44 @@ class PostgresMetaStore(ISlowMetaStore):
             cur.execute(sql, params)
             for row in cur:
                 yield self._serializer.decode(row["data"])
+
+    def aggregate_by(
+        self,
+        query: ResourceMetaSearchQuery,
+        by: AggKeyRef,
+        aggregates: list[AggSpec],
+    ) -> list[tuple[object, dict[str, object]]]:
+        """Push a ``Count`` group-by down to PostgreSQL — ``GROUP BY`` over the
+        filtered set, never materialising one row per match.
+
+        The group key is a real column for ``source="meta"`` or
+        ``indexed_data->>'field'`` (JSONB text) for ``source="data"`` (a missing
+        field yields SQL ``NULL`` → ``None``, matching the Python path). The
+        ``WHERE`` is built by the SAME :meth:`_build_where` as
+        :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
+        aggregate spans the whole filtered set.
+        """
+        # v1 supports Count only; the ResourceManager's dispatch predicate
+        # guarantees this, so the assert is a defensive guard, not control flow.
+        assert all(a.op == "count" for a in aggregates), (
+            "PostgresMetaStore.aggregate_by v1 supports Count only"
+        )
+        if by.source == "meta":
+            key_expr = by.name  # a real column
+        else:
+            key_expr = f"indexed_data->>'{by.name}'"
+        where_clause, params = self._build_where(query)
+        select_aggs = ", ".join(f"COUNT(*) AS a{i}" for i in range(len(aggregates)))
+        sql = (
+            f"SELECT {key_expr} AS k, {select_aggs} "
+            f'FROM "{self.table_name}" {where_clause} GROUP BY {key_expr}'
+        )
+        with self.stream_cursor() as cur:
+            cur.execute(sql, params)
+            return [
+                (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
+                for row in cur
+            ]
 
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 PostgreSQL 查詢條件 (支援 Meta 欄位與 JSONB 欄位)"""

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -13,6 +13,8 @@ from typing import TypeVar
 from msgspec import UNSET
 
 from specstar.query_types import (
+    AggKeyRef,
+    AggSpec,
     DataSearchFilter,
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
@@ -20,6 +22,7 @@ from specstar.query_types import (
 )
 from specstar.resource_manager.basic import (
     Encoding,
+    IMetaWithAgg,
     ISlowMetaStore,
     MsgspecSerializer,
 )
@@ -28,7 +31,7 @@ from specstar.types import ResourceMeta
 T = TypeVar("T")
 
 
-class SqliteMetaStore(ISlowMetaStore):
+class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
     def __init__(
         self,
         *,
@@ -267,7 +270,15 @@ class SqliteMetaStore(ISlowMetaStore):
         """
         self._list_fields.add(field_path)
 
-    def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+    def _build_where(self, query: ResourceMetaSearchQuery) -> tuple[str, list]:
+        """Translate a search query into a SQL ``WHERE`` clause + params.
+
+        Shared by :meth:`iter_search` and :meth:`aggregate_by` so filtering
+        (meta columns + ``indexed_data`` JSON conditions) is built ONE way —
+        a pushed-down aggregate filters exactly like a search. Returns the
+        ``"WHERE ..."`` string (``""`` when unfiltered) and its param list;
+        ordering / paging are the caller's concern.
+        """
         conditions = []
         params = []
 
@@ -345,10 +356,13 @@ class SqliteMetaStore(ISlowMetaStore):
                     conditions.append(json_condition)
                     params.extend(json_params)
 
-        # 構建 WHERE 子句
         where_clause = ""
         if conditions:
             where_clause = "WHERE " + " AND ".join(conditions)
+        return where_clause, params
+
+    def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+        where_clause, params = self._build_where(query)
 
         # 構建排序子句
         order_clause = ""
@@ -384,6 +398,43 @@ class SqliteMetaStore(ISlowMetaStore):
 
         for row in cursor:
             yield self._serializer.decode(row[0])
+
+    def aggregate_by(
+        self,
+        query: ResourceMetaSearchQuery,
+        by: AggKeyRef,
+        aggregates: list[AggSpec],
+    ) -> list[tuple[object, dict[str, object]]]:
+        """Push a ``Count`` group-by down to SQLite — ``GROUP BY`` over the
+        filtered set, never materialising one row per match.
+
+        The group key is a real column for ``source="meta"`` or a
+        ``json_extract`` of ``indexed_data`` for ``source="data"`` (a missing
+        field yields SQL ``NULL`` → ``None``, matching the Python path). The
+        ``WHERE`` is built by the SAME :meth:`_build_where` as
+        :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
+        aggregate spans the whole filtered set.
+        """
+        # v1 supports Count only; the ResourceManager's dispatch predicate
+        # guarantees this, so the assert is a defensive guard, not control flow.
+        assert all(a.op == "count" for a in aggregates), (
+            "SqliteMetaStore.aggregate_by v1 supports Count only"
+        )
+        if by.source == "meta":
+            key_expr = by.name  # a real resource_meta column
+        else:
+            key_expr = f"json_extract(indexed_data, '$.\"{by.name}\"')"
+        where_clause, params = self._build_where(query)
+        select_aggs = ", ".join(f"COUNT(*) AS a{i}" for i in range(len(aggregates)))
+        sql = (
+            f"SELECT {key_expr} AS k, {select_aggs} "
+            f"FROM resource_meta {where_clause} GROUP BY {key_expr}"
+        )
+        cursor = self._conns[threading.get_ident()].execute(sql, params)
+        return [
+            (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
+            for row in cursor
+        ]
 
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 SQLite 查詢條件 (支援 Meta 欄位與 JSON 欄位)"""

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -1,0 +1,172 @@
+"""Cross-backend behaviour parity for ``ResourceManager.exp_aggregate_by``.
+
+Every metastore implementation MUST return identical results from
+``exp_aggregate_by`` — whether it pushes the group-by down to its engine
+(SQLite) or falls back to the core Python reduction (memory / disk / …).
+This file is the contract: the SAME parametrized tests run over
+``ALL_META_STORE_TYPES`` and assert the SAME results, so a pushed-down path
+can never silently disagree with the reference Python path.
+
+Scope (v1): ``Count`` group-by. Sum/Min/Max/Avg + ForeignAggregate stay
+covered by ``tests/test_exp_aggregate_by.py`` (memory) until they push down too.
+"""
+
+import msgspec
+import pytest
+
+from specstar.aggregates import Count
+from specstar.errors import SpecStarWarning
+from specstar.query import QB
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField
+
+from .common import ALL_META_STORE_TYPES, get_meta_store
+
+
+class Chunk(msgspec.Struct):
+    text: str
+    source_doc_id: str
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestAggregateByCountParity:
+    """Each test builds a ResourceManager over the parametrized metastore and
+    asserts the exp_aggregate_by(Count()) result — identical across backends."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self._meta_store_type = meta_store_type
+        self._tmpdir = my_tmpdir
+        yield
+
+    def _mgr(self, *, indexed: bool = True):
+        meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        return ResourceManager(
+            Chunk,
+            storage=storage,
+            name="chunk",
+            default_user="t",
+            indexed_fields=(
+                [IndexableField(field_path="source_doc_id", field_type=str)]
+                if indexed
+                else None
+            ),
+        )
+
+    def _seed(self, mgr, plan: dict[str, int]):
+        """plan = {source_doc_id: n_chunks}."""
+        for sid, n in plan.items():
+            for _ in range(n):
+                mgr.create(Chunk(text="x", source_doc_id=sid))
+
+    # -- core result-consistency cases ------------------------------------
+
+    def test_counts_grouped_by_indexed_field(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5})
+        rows = mgr.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
+        assert {r.key: r.count for r in rows} == {"d1": 3, "d2": 5}
+
+    def test_in_filter_is_the_page_pattern(self):
+        # The real document-list case: count chunks for just THIS page's docs.
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5, "d3": 2})
+        rows = mgr.exp_aggregate_by(
+            QB["source_doc_id"],
+            {"count": Count()},
+            query=QB["source_doc_id"].in_(["d1", "d2"]).build(),
+        )
+        assert {r.key: r.count for r in rows} == {"d1": 3, "d2": 5}
+
+    def test_equality_filter(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5})
+        rows = mgr.exp_aggregate_by(
+            QB["source_doc_id"],
+            {"count": Count()},
+            query=(QB["source_doc_id"] == "d1").build(),
+        )
+        assert {r.key: r.count for r in rows} == {"d1": 3}
+
+    def test_empty_returns_empty_list(self):
+        mgr = self._mgr()
+        rows = mgr.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
+        assert rows == []
+
+    def test_caller_named_aggregate_via_attr_and_item(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 2, "d2": 4})
+        rows = mgr.exp_aggregate_by(QB["source_doc_id"], {"chunk_total": Count()})
+        assert {r.key: r.chunk_total for r in rows} == {"d1": 2, "d2": 4}
+        assert {r.key: r["chunk_total"] for r in rows} == {"d1": 2, "d2": 4}
+
+    def test_group_by_resource_meta_attribute(self):
+        # created_by is a ResourceMeta attribute — queryable without indexing.
+        mgr = self._mgr(indexed=False)
+        with mgr.using("alice"):
+            mgr.create(Chunk(text="a", source_doc_id="d1"))
+            mgr.create(Chunk(text="b", source_doc_id="d1"))
+        with mgr.using("bob"):
+            mgr.create(Chunk(text="c", source_doc_id="d2"))
+        rows = mgr.exp_aggregate_by(QB.created_by(), {"count": Count()})
+        assert {r.key: r.count for r in rows} == {"alice": 2, "bob": 1}
+
+    def test_non_indexed_field_collapses_to_none_group(self):
+        # Without indexing source_doc_id, every row's key is None — and the
+        # None group must be the SAME None on every backend (SQLite NULL too).
+        mgr = self._mgr(indexed=False)
+        self._seed(mgr, {"d1": 2, "d2": 1})
+        with pytest.warns(SpecStarWarning, match="source_doc_id"):
+            rows = mgr.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
+        assert [(r.key, r.count) for r in rows] == [(None, 3)]
+
+
+def test_sqlite_count_groupby_is_pushed_down_not_iterated():
+    """On SQLite the Count group-by must reach ``aggregate_by``, NOT walk
+    ``iter_all`` (that IS the push-down). Spying on ``iter_all`` proves the
+    fast path is taken rather than silently falling back to the row scan."""
+    meta_store = get_meta_store("sql3-mem")
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    mgr = ResourceManager(
+        Chunk,
+        storage=storage,
+        name="chunk",
+        default_user="t",
+        indexed_fields=[IndexableField(field_path="source_doc_id", field_type=str)],
+    )
+    for sid, n in {"d1": 3, "d2": 2}.items():
+        for _ in range(n):
+            mgr.create(Chunk(text="x", source_doc_id=sid))
+
+    called = False
+    orig_iter_all = mgr.iter_all
+
+    def spy(*a, **k):
+        nonlocal called
+        called = True
+        return orig_iter_all(*a, **k)
+
+    mgr.iter_all = spy
+    rows = mgr.exp_aggregate_by(QB["source_doc_id"], {"count": Count()})
+
+    assert {r.key: r.count for r in rows} == {"d1": 3, "d2": 2}
+    assert called is False, (
+        "exp_aggregate_by walked iter_all on SQLite — push-down not taken"
+    )
+
+
+@pytest.fixture
+def my_tmpdir():
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -126,11 +126,12 @@ class TestAggregateByCountParity:
         assert [(r.key, r.count) for r in rows] == [(None, 3)]
 
 
-def test_sqlite_count_groupby_is_pushed_down_not_iterated():
-    """On SQLite the Count group-by must reach ``aggregate_by``, NOT walk
-    ``iter_all`` (that IS the push-down). Spying on ``iter_all`` proves the
-    fast path is taken rather than silently falling back to the row scan."""
-    meta_store = get_meta_store("sql3-mem")
+@pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
+def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):
+    """On a push-down backend (``IMetaWithAgg``) the Count group-by must reach
+    ``aggregate_by``, NOT walk ``iter_all`` (that IS the push-down). Spying on
+    ``iter_all`` proves the fast path is taken, not a silent fallback."""
+    meta_store = get_meta_store(meta_store_type)
     storage = SimpleStorage(
         meta_store=meta_store,
         resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
@@ -159,7 +160,7 @@ def test_sqlite_count_groupby_is_pushed_down_not_iterated():
 
     assert {r.key: r.count for r in rows} == {"d1": 3, "d2": 2}
     assert called is False, (
-        "exp_aggregate_by walked iter_all on SQLite — push-down not taken"
+        f"exp_aggregate_by walked iter_all on {meta_store_type} — push-down not taken"
     )
 
 


### PR DESCRIPTION
## What

Push a single-key, **Count-only** `exp_aggregate_by` group-by down to the meta store's engine (SQLite, then Postgres), instead of streaming one meta row per matching record into a Python reduction.

Before: `exp_aggregate_by` walked `for meta in iter_all(query)` — a Count over N matching rows materialised one `ResourceMeta` per row (paged 1000 at a time). The WHERE was pushed to the engine; the COUNT/GROUP BY were not.

## How

- **`IMetaWithAgg(IMetaStore, ABC)`** — a typed capability interface with an abstract `aggregate_by`. Mixed into a concrete store alongside its base (`class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore)`); the ResourceManager dispatches via `isinstance(ms, IMetaWithAgg)` (no `hasattr` sniffing), and the abstract method makes "claims the capability but doesn't implement it" fail at construction.
- **`AggKeyRef` / `AggSpec`** (`query_types`) — storage-facing specs so a meta store builds the SQL without importing the QB / aggregate layer.
- **`IStorage.meta_store`** accessor (default `None`; `SimpleStorage` exposes its store) so the RM reaches the capability without touching internals.
- **SQLite & Postgres `aggregate_by`** — a real `GROUP BY` (meta column, or `json_extract` / `->>'…'` of `indexed_data`) over the filtered set, no `LIMIT`/`OFFSET`, built on a shared `_build_where` extracted from `iter_search` so a pushed aggregate filters exactly like a search.
- Falls back to the in-process Python reduction for Sum/Min/Max/Avg, ForeignAggregate, `by=resource_id`, and non-capable backends. Public `exp_aggregate_by` name/signature/return type unchanged.

## Notes

- **Cross-backend parity is the contract**: `tests/meta_store/test_aggregate_by.py` runs the same Count cases over `ALL_META_STORE_TYPES` and asserts identical results — SQLite/Postgres via push-down, memory/disk via fallback — plus a spy test proving the SQL backends do **not** walk `iter_all`.
- Scan-fast, **not** O(1): the JSON-extracted group key has no expression index, so it's a fast DB-side scan, not a stored counter. For a genuinely hot, high-fan-out count, denormalise a counter on write.

## Tests

Non-integration suite green (3035 passed); cross-impl parity green on memory/disk/sql3-mem/postgres; ty clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
