### PR TITLE
fix(crud): auto-register list indexed fields from model annotations (#378)

### DIFF
--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -1602,18 +1602,48 @@ class SpecStar:
                 )
 
         # Tell the meta store which indexed fields are list-typed so that
-        # ``contains`` can dispatch to JSONB ``@>`` instead of substring LIKE.
-        # See #362. Only PostgresMetaStore currently implements
-        # ``register_list_field``; the call is a no-op on other backends.
+        # ``contains`` does true element membership (PG ``@>``, SQLite
+        # ``json_each``, ...) instead of substring ``LIKE``. The type is taken
+        # from the ``IndexableField`` when given, else resolved from the model's
+        # own annotation — so the idiomatic bare-string declaration
+        # ``indexed_fields=["norm_keys"]`` is registered without the caller
+        # repeating ``list[str]`` (otherwise a list field silently degrades to
+        # substring matching on every SQL backend). ``Annotated``/``Optional``
+        # wrappers are unwrapped. See #362, #378. The call is a no-op on
+        # backends without ``register_list_field``.
         if meta_store is not None and hasattr(meta_store, "register_list_field"):
-            from typing import get_origin
+            from types import UnionType
+            from typing import Annotated, Union, get_args, get_origin
+
+            import msgspec as _msgspec
+
+            def _is_list_type(tp) -> bool:
+                if tp is UNSET or tp is None:
+                    return False
+                if get_origin(tp) is Annotated:
+                    tp = get_args(tp)[0]
+                if get_origin(tp) in (Union, UnionType):
+                    return any(
+                        _is_list_type(a) for a in get_args(tp) if a is not type(None)
+                    )
+                origin = get_origin(tp) or tp
+                return origin in (list, tuple, set)
+
+            # Top-level field name -> declared annotation, used to backfill an
+            # UNSET field_type. Dotted / transformed paths are not resolvable
+            # this way and keep their explicit type (if any).
+            try:
+                annotations = {
+                    f.name: f.type for f in _msgspec.structs.fields(resolved_model)
+                }
+            except TypeError:
+                annotations = {}
 
             for field in resource_manager.indexed_fields:
                 ft = field.field_type
                 if ft is UNSET:
-                    continue
-                origin = get_origin(ft) or ft
-                if origin is list or origin is tuple or origin is set:
+                    ft = annotations.get(field.field_path, UNSET)
+                if _is_list_type(ft):
                     meta_store.register_list_field(field.index_key or field.field_path)
 
         # If the meta store supports native SetIndex acceleration, create the

--- a/tests/test_contains_list_autoregister.py
+++ b/tests/test_contains_list_autoregister.py
@@ -1,0 +1,164 @@
+"""``add_model`` must auto-register list-typed indexed fields from the model's
+own annotations — issue #378.
+
+The in-process backends define ``contains`` on a list field as element
+membership; the SQL backends only honour that for fields the meta store was
+told are list-typed via ``register_list_field`` (wired from ``add_model``).
+That wiring keyed solely on an *explicit* ``IndexableField.field_type`` whose
+``get_origin`` was exactly ``list``/``tuple``/``set`` — so the idiomatic
+bare-string declaration ``indexed_fields=["norm_keys"]`` (``field_type`` UNSET)
+was never registered, and a list field silently degraded to substring ``LIKE``
+on every SQL backend (e.g. ``contains("m4")`` matching ``["m40"]``). Optional
+list annotations (``list[str] | None``) slipped through the same gap.
+
+These tests drive the public API end-to-end on an in-process SQLite backend
+(which, unlike the Memory backend, actually distinguishes substring from
+membership), so they survive any refactor of *how* ``add_model`` informs the
+store — they only assert *what* a search returns.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from msgspec import Struct, field
+
+from specstar import SpecStar
+from specstar.query_types import (
+    DataSearchCondition,
+    DataSearchOperator,
+    ResourceMetaSearchQuery,
+)
+from specstar.resource_manager.core import SimpleStorage
+from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.resource_manager.storage_factory import IStorageFactory
+
+_NOW = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+
+class _SqliteMemFactory(IStorageFactory):
+    """In-process SQL backend: SQLite meta store + memory resource store.
+
+    The Memory meta store always does element membership, so it cannot surface
+    the substring bug; the SQLite meta store can (it is the same lowering path
+    as Postgres for ``contains``).
+    """
+
+    def build(self, model_name: str) -> SimpleStorage:
+        return SimpleStorage(MemorySqliteMetaStore(), MemoryResourceStore())
+
+
+class Card(Struct):
+    title: str
+    norm_keys: list[str] = field(default_factory=list)
+
+
+class OptCard(Struct):
+    title: str
+    norm_keys: list[str] | None = None
+
+
+def _managed(model_cls, indexed_fields, rows):
+    sp = SpecStar(storage_factory=_SqliteMemFactory())
+    sp.add_model(model_cls, name="card", indexed_fields=indexed_fields)
+    mgr = sp.resource_managers["card"]
+    with mgr.using(user="t", now=_NOW) as op:
+        for row in rows:
+            op.create(row)
+    return mgr
+
+
+def _contains(mgr, field_path, value):
+    with mgr.using(user="t", now=_NOW):
+        q = ResourceMetaSearchQuery(
+            data_conditions=[
+                DataSearchCondition(
+                    field_path=field_path,
+                    operator=DataSearchOperator.contains,
+                    value=value,
+                )
+            ]
+        )
+        return sorted(m.indexed_data["title"] for m in mgr.search_resources(q))
+
+
+def test_contains_on_bare_string_list_index_is_element_membership():
+    """The idiomatic ``indexed_fields=["norm_keys"]`` must give membership.
+
+    ``"m4"`` is a substring of ``"m40"`` but not an element of ``["m40"]``;
+    only the card whose list actually contains ``"m4"`` may match.
+    """
+    mgr = _managed(
+        Card,
+        ["title", "norm_keys"],
+        [
+            Card(title="forty", norm_keys=["m40"]),
+            Card(title="four", norm_keys=["m4", "capping"]),
+        ],
+    )
+    assert _contains(mgr, "norm_keys", "m4") == ["four"]
+
+
+def test_contains_on_bare_string_scalar_index_keeps_substring():
+    """The fix must not over-register: a scalar field stays substring ``contains``.
+
+    ``"our"`` is a substring of ``"four"`` but not of ``"forty"`` — scalar
+    string ``contains`` is intentionally substring, and must be left alone.
+    """
+    mgr = _managed(
+        Card,
+        ["title", "norm_keys"],
+        [
+            Card(title="four"),
+            Card(title="forty"),
+        ],
+    )
+    assert _contains(mgr, "title", "our") == ["four"]
+
+
+def test_contains_on_optional_list_index_is_element_membership():
+    """``norm_keys: list[str] | None`` (Optional) must also get membership.
+
+    The ``Union`` wrapper previously hid the ``list`` origin, so even an
+    explicitly-typed Optional list degraded to substring. Unwrapping the
+    Optional restores membership.
+    """
+    mgr = _managed(
+        OptCard,
+        ["title", "norm_keys"],
+        [
+            OptCard(title="forty", norm_keys=["m40"]),
+            OptCard(title="four", norm_keys=["m4", "capping"]),
+        ],
+    )
+    assert _contains(mgr, "norm_keys", "m4") == ["four"]
+
+
+def test_add_model_registers_bare_string_list_field_not_scalar(monkeypatch):
+    """Pinpoint the mechanism: ``add_model`` calls ``register_list_field`` for a
+    bare-string list field (type resolved from the model) and not for a scalar.
+
+    Mirrors ``test_add_model_auto_registers_list_typed_indexed_fields`` but for
+    the idiomatic ``indexed_fields=["norm_keys"]`` form (no explicit type).
+    """
+    from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+
+    registered: list[str] = []
+    monkeypatch.setattr(
+        MemoryMetaStore,
+        "register_list_field",
+        lambda self, fp: registered.append(fp),
+        raising=False,
+    )
+
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Card, name="card", indexed_fields=["title", "norm_keys"])
+
+    assert "norm_keys" in registered, (
+        f"bare-string list field not registered; got {registered!r}"
+    )
+    assert "title" not in registered, (
+        f"scalar field wrongly registered as list; got {registered!r}"
+    )


### PR DESCRIPTION
## Problem (#378)

`QB[field].contains(v)` on an indexed **list** field is element membership in the in-process backends, but on the SQL backends it only honors that if the meta store was told the field is list-typed via `register_list_field` (wired from `add_model`). That wiring only fired when the caller passed an **explicit** `IndexableField.field_type` whose `get_origin` was exactly `list`/`tuple`/`set`.

The idiomatic, documented bare-string declaration —

```python
spec.add_model(ContextCard, indexed_fields=["collection_id", "norm_keys"])
```

— leaves `field_type` UNSET, so the model's own `norm_keys: list[str]` annotation was ignored and the field **silently degraded to substring `LIKE`** on every SQL backend (Postgres included): `contains("m4")` wrongly matched `["m40"]`, and `shared_with` membership leaked across users. `Optional[list[...]]` slipped through the same gap (its `get_origin` is `Union`, not `list`).

This is why a PostgreSQL deployment still hit #378 after the #367/#374 pushdown fixes — the pushdown was correct but **never engaged**, because registration never fired for bare-string / Optional declarations.

## Fix

In `add_model`'s `register_list_field` wiring:
- Resolve an UNSET `field_type` from the model annotation (`msgspec.structs.fields(resolved_model)`, top-level field names).
- Judge "is list" by unwrapping `Annotated` → `Optional`/`Union` → `get_origin in (list, tuple, set)`, so bare-string, Optional, and explicit-Optional list fields all register.
- Local-only: compute list-ness for the registration decision; do **not** write back `field_type` (minimal blast radius). Dotted/transformed paths and non-struct models fall back to current behavior (no resolution, no error).

## Tests

End-to-end through the public `add_model` + `search_resources` API on an in-process SQLite backend (the Memory backend always does membership and cannot surface the bug):
- bare-string list → element membership (`contains("m4")` over `["m40"]` / `["m4",…]` → only the real match);
- scalar string → substring preserved (no over-registration);
- `Optional[list[str]]` → membership;
- registration-level pinpoint asserting `add_model` registers the bare-string list field and not the scalar.

## Scope

This PR is **only** the `crud/core.py` registration root cause — the part that fixes the reported PostgreSQL behavior. The separate SQLAlchemy-backend `contains` semantic alignment is handled independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)