### PR TITLE
fix(sqlalchemy): contains on list-typed indexed fields uses element membership (#378)

### DIFF
--- a/specstar/resource_manager/meta_store/sqlalchemy.py
+++ b/specstar/resource_manager/meta_store/sqlalchemy.py
@@ -19,9 +19,11 @@ from sqlalchemy import (
     Text,
     and_,
     case,
+    cast,
     create_engine,
     delete,
     func,
+    literal,
     literal_column,
     not_,
     or_,
@@ -151,6 +153,12 @@ class SQLAlchemyMetaStore(ISlowMetaStore):
             table_name, self._metadata, dialect=self._get_dialect()
         )
         self._Session = sessionmaker(bind=self._engine)
+
+        # Field paths registered as list-typed. ``contains`` on these uses true
+        # element membership (per-dialect: PG ``@>``, SQLite ``json_each``,
+        # MySQL ``JSON_CONTAINS``, Oracle ``JSON_EXISTS``) instead of the
+        # substring ``LIKE`` used for scalar string fields. See #362, #378.
+        self._list_fields: set[str] = set()
 
         # Create tables
         self._metadata.create_all(self._engine)
@@ -483,6 +491,18 @@ class SQLAlchemyMetaStore(ISlowMetaStore):
             rows = session.execute(stmt).fetchall()
             for row in rows:
                 yield self._serializer.decode(row[0])
+
+    def register_list_field(self, field_path: str) -> None:
+        """Declare *field_path* as a list-typed indexed field.
+
+        Routes ``DataSearchOperator.contains`` on this field through true
+        element membership instead of the default substring ``LIKE``, so the
+        SQL backends agree with the in-process backends' ``value in list``
+        semantics (``basic.py``) rather than matching substrings of the
+        serialised JSON array. Idempotent — safe to call from ``add_model`` on
+        every registration. See #362, #378.
+        """
+        self._list_fields.add(field_path)
 
     # ------------------------------------------------------------------
     # Dialect-aware helpers for JSONB / JSON extraction
@@ -898,6 +918,77 @@ class SQLAlchemyMetaStore(ISlowMetaStore):
 
         return None
 
+    def _list_contains(self, field_path: str, value):
+        """Build a true element-membership predicate for a list-typed field.
+
+        Mirrors the in-process backends (``value in field_value``) and the raw
+        psycopg / sqlite3 meta stores, per SQL dialect:
+
+        * PostgreSQL: ``indexed_data -> 'f' @> '<json scalar>'::jsonb``
+        * SQLite:     ``EXISTS (SELECT 1 FROM json_each(indexed_data, '$.f')
+          WHERE value = :v)``
+        * MySQL:      ``JSON_CONTAINS(indexed_data, '<json scalar>', '$.f') = 1``
+        * Oracle:     ``JSON_EXISTS(indexed_data, '$.f[*]?(@ == <value>)')``
+
+        Unknown dialects fall back to substring ``LIKE`` (membership cannot be
+        expressed portably). See #362, #378.
+        """
+        t = self._table
+        dialect = self._get_dialect()
+
+        if dialect == DialectType.postgresql:
+            # JSONB containment: the array contains the JSON-encoded scalar.
+            # The encoded string is bound as plain text and cast to JSONB in
+            # SQL (``'"v"'::jsonb``). Casting a *String*-typed literal — not a
+            # JSONB-typed one — avoids the JSONB bind processor re-running
+            # ``json.dumps`` on the already-encoded value (double-encoding).
+            return self._jsonb_element(field_path).op("@>")(
+                cast(literal(json.dumps(value), String), JSONB)
+            )
+
+        if dialect == DialectType.mysql:
+            # JSON_CONTAINS(target, candidate, path): candidate must itself be
+            # valid JSON, so the scalar is JSON-encoded (a string becomes "v").
+            return (
+                func.JSON_CONTAINS(
+                    t.c.indexed_data,
+                    json.dumps(value),
+                    self._json_path(field_path),
+                )
+                == 1
+            )
+
+        if dialect == DialectType.oracle:
+            path = self._json_path(field_path).replace("'", "''")
+            # Strip the leading "$." for the array path expression.
+            array_path = path[2:] if path.startswith("$.") else path
+            if isinstance(value, bool):
+                json_value = "true" if value else "false"
+            elif isinstance(value, str):
+                json_value = f'"{value}"'
+            else:
+                json_value = str(value)
+            return literal_column(
+                f"JSON_EXISTS(indexed_data, '$.{array_path}[*]?(@ == {json_value})')"
+            )
+
+        if dialect == DialectType.sqlite:
+            # Unnest the JSON array (json_each) and test element equality. The
+            # bound value is auto-named/uniquified by SQLAlchemy, so several
+            # list-contains conditions can coexist in one query, and the
+            # correlated subquery references the outer ``indexed_data``.
+            return (
+                select(literal_column("1"))
+                .select_from(
+                    func.json_each(t.c.indexed_data, self._json_path(field_path))
+                )
+                .where(literal_column("value") == value)
+                .exists()
+            )
+
+        # Unknown dialect: best-effort substring fallback.
+        return self._jsonb_text(field_path).contains(str(value))
+
     # ------------------------------------------------------------------
     # Data (indexed_data) field conditions
     # ------------------------------------------------------------------
@@ -1004,30 +1095,20 @@ class SQLAlchemyMetaStore(ISlowMetaStore):
             return jsonb_numeric <= value
 
         if operator == DataSearchOperator.contains:
-            # Oracle: Use JSON_EXISTS for array member check, LIKE for string substring
+            # List-typed fields use true element membership so ``contains``
+            # agrees with the in-process backends' ``value in field_value``
+            # (basic.py) instead of matching a substring of the serialised
+            # JSON array — which diverged across backends and produced false
+            # positives like ``contains("m4")`` hitting ``["m40"]``. Scalar
+            # string fields keep substring ``LIKE``. See #362, #378.
+            if field_path in self._list_fields:
+                return self._list_contains(field_path, value)
+            # Oracle scalar string substring: JSON_VALUE + LIKE.
             if self._get_dialect() == DialectType.oracle:
-                # Heuristic: if field name contains 'list', treat as array
-                if "list" in field_path.lower():
-                    path = self._json_path(field_path).replace("'", "''")
-                    # Remove the leading $. for array path
-                    array_path = path[2:] if path.startswith("$.") else path
-                    # Format value for JSON path expression
-                    if isinstance(value, str):
-                        # String values need to be quoted in the path expression
-                        json_value = f'"{value}"'
-                    elif isinstance(value, bool):
-                        json_value = "true" if value else "false"
-                    else:
-                        json_value = str(value)
-                    return literal_column(
-                        f"JSON_EXISTS(indexed_data, '$.{array_path}[*]?(@ == {json_value})')"
-                    )
-                else:
-                    # String contains: use LIKE with JSON_VALUE
-                    path = self._json_path(field_path).replace("'", "''")
-                    return literal_column(f"JSON_VALUE(indexed_data, '{path}')").like(
-                        f"%{value}%"
-                    )
+                path = self._json_path(field_path).replace("'", "''")
+                return literal_column(f"JSON_VALUE(indexed_data, '{path}')").like(
+                    f"%{value}%"
+                )
             return jsonb_text.contains(str(value))
         if operator == DataSearchOperator.starts_with:
             return jsonb_text.startswith(str(value))

--- a/tests/test_contains_list_pushdown_sqlalchemy.py
+++ b/tests/test_contains_list_pushdown_sqlalchemy.py
@@ -1,0 +1,212 @@
+"""``contains`` on list-typed indexed fields, via the SQLAlchemy meta store.
+
+Issue #378. The in-process backends (``basic.py``) define ``contains`` on a
+list field as element membership (``value in field_value``). The raw psycopg
+(``postgres.py``) and sqlite3 (``sqlite3.py``) stores were aligned to that in
+#367 / #374, but the SQLAlchemy store still emitted substring ``LIKE`` against
+the serialised JSON array — so the same query returned different rows on a
+SQLAlchemy-backed Postgres/MySQL/SQLite/Oracle deployment (e.g. ``contains("m4")``
+wrongly matched a row whose list was ``["m40"]``). It also gated Oracle's true
+member check on a ``"list" in field_path.lower()`` *field-name* heuristic, so a
+``norm_keys`` field silently fell back to substring matching.
+
+The fix mirrors the other backends: list-typed fields are declared via
+``register_list_field`` and ``contains`` lowers to true element membership per
+dialect (PG ``@>``; SQLite ``json_each``; MySQL ``JSON_CONTAINS``; Oracle
+``JSON_EXISTS`` — now gated on the registry, not the field name). Scalar string
+fields keep substring ``LIKE``.
+
+SQLite is in-process, so its tests exercise real ``iter_search``. The
+PG/MySQL/Oracle tests pin the emitted SQL by compiling the expression against
+the target dialect (no live server needed). All run in the fast (no-services)
+gate — only ``sqlalchemy`` is required.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import MetaData  # noqa: E402
+from sqlalchemy.dialects import mysql, oracle, postgresql  # noqa: E402
+
+from specstar.query_types import (  # noqa: E402
+    DataSearchCondition,
+    DataSearchOperator,
+    ResourceMetaSearchQuery,
+)
+from specstar.resource_manager.meta_store.sqlalchemy import (  # noqa: E402
+    DialectType,
+    SQLAlchemyMetaStore,
+    _build_resource_meta_table,
+)
+from specstar.types import ResourceMeta  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _meta(rid: str, norm_keys: list[str]) -> ResourceMeta:
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    return ResourceMeta(
+        current_revision_id=f"{rid}-r1",
+        resource_id=rid,
+        total_revision_count=1,
+        created_time=now,
+        updated_time=now,
+        created_by="t",
+        updated_by="t",
+        indexed_data={"norm_keys": norm_keys, "title": rid},
+    )
+
+
+def _contains_sql(dialect_type: DialectType, sa_dialect, field_path: str, value):
+    """Compile the ``contains`` predicate for *field_path* against a dialect.
+
+    Bypasses ``__init__`` (no DB connection) and exercises the pure builder so
+    the PG/MySQL/Oracle SQL can be pinned without a live server. ``norm_keys``
+    is pre-registered as list-typed; pass an unregistered ``field_path`` to
+    exercise the scalar fallback.
+    """
+    s = SQLAlchemyMetaStore.__new__(SQLAlchemyMetaStore)
+    s._list_fields = {"norm_keys"}
+    s._table = _build_resource_meta_table(
+        "resource_meta", MetaData(), dialect=dialect_type
+    )
+    s._get_dialect = lambda: dialect_type
+    cond = DataSearchCondition(
+        field_path=field_path,
+        operator=DataSearchOperator.contains,
+        value=value,
+    )
+    expr = s._build_data_condition(cond, field_path, cond.operator, cond.value)
+    compiled = expr.compile(dialect=sa_dialect)
+    return str(compiled), compiled.params
+
+
+# ---------------------------------------------------------------------------
+# SQLite — in-process, real iter_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_store(tmp_path):
+    db = tmp_path / "contains378.db"
+    store = SQLAlchemyMetaStore(url=f"sqlite:///{db}")
+    store.register_list_field("norm_keys")
+    store.save_many(
+        [
+            _meta("forty", ["m40"]),
+            _meta("four", ["capping", "m4"]),
+            _meta("under", ["a_b"]),
+        ]
+    )
+    return store
+
+
+def _search(store, field_path, value):
+    query = ResourceMetaSearchQuery(
+        data_conditions=[
+            DataSearchCondition(
+                field_path=field_path,
+                operator=DataSearchOperator.contains,
+                value=value,
+            ),
+        ],
+    )
+    return sorted(m.resource_id for m in store.iter_search(query))
+
+
+def test_sqlite_list_contains_is_element_membership(sqlite_store):
+    """``contains("m4")`` must not match a row whose list is ``["m40"]``.
+
+    The substring-LIKE bug returned both rows because ``"m4"`` is a substring
+    of the serialised ``["m40"]``. Element membership returns only ``four``.
+    """
+    assert _search(sqlite_store, "norm_keys", "m4") == ["four"]
+    assert _search(sqlite_store, "norm_keys", "m40") == ["forty"]
+    assert _search(sqlite_store, "norm_keys", "capping") == ["four"]
+    # Element not present anywhere.
+    assert _search(sqlite_store, "norm_keys", "m") == []
+
+
+def test_sqlite_list_contains_does_not_treat_value_as_like_wildcard(sqlite_store):
+    """An underscore in the value is a literal char, not a LIKE ``_`` wildcard.
+
+    Under substring LIKE, ``contains("axb")`` would match ``["a_b"]`` because
+    ``_`` matches any single char. Membership compares the element verbatim.
+    """
+    assert _search(sqlite_store, "norm_keys", "axb") == []
+    assert _search(sqlite_store, "norm_keys", "a_b") == ["under"]
+
+
+def test_sqlite_scalar_field_keeps_substring(sqlite_store):
+    """A non-list field keeps substring ``LIKE`` semantics (must not regress)."""
+    # "our" is a substring of the title "four".
+    assert _search(sqlite_store, "title", "our") == ["four"]
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL / MySQL / Oracle — compiled-SQL pinning
+# ---------------------------------------------------------------------------
+
+
+def test_postgresql_list_contains_uses_jsonb_containment():
+    sql, params = _contains_sql(
+        DialectType.postgresql, postgresql.dialect(), "norm_keys", "m4"
+    )
+    assert "@>" in sql, sql
+    assert "LIKE" not in sql.upper(), sql
+    # The value is JSON-encoded text cast to jsonb — exactly the param the raw
+    # psycopg store sends — not double-encoded by the JSONB bind processor.
+    assert json.dumps("m4") in params.values(), params
+    assert '"\\"m4\\""' not in params.values(), f"double-encoded: {params}"
+
+
+def test_postgresql_scalar_field_keeps_like():
+    sql, params = _contains_sql(
+        DialectType.postgresql, postgresql.dialect(), "description", "urgent"
+    )
+    assert "LIKE" in sql.upper(), sql
+    assert "@>" not in sql, sql
+    # SQLAlchemy's ``.contains`` wraps the wildcards in SQL, binding the raw value.
+    assert "urgent" in params.values(), params
+
+
+def test_mysql_list_contains_uses_json_contains():
+    sql, params = _contains_sql(DialectType.mysql, mysql.dialect(), "norm_keys", "m4")
+    assert "JSON_CONTAINS" in sql.upper(), sql
+    assert "LIKE" not in sql.upper(), sql
+    # Candidate is JSON-encoded so MySQL parses it as a JSON scalar string.
+    assert json.dumps("m4") in params.values(), params
+
+
+def test_oracle_list_contains_uses_json_exists():
+    sql, _ = _contains_sql(DialectType.oracle, oracle.dialect(), "norm_keys", "m4")
+    assert "JSON_EXISTS" in sql.upper(), sql
+    assert "LIKE" not in sql.upper(), sql
+
+
+def test_oracle_no_longer_keys_on_field_name_heuristic():
+    """The removed ``"list" in field_path`` heuristic must not drive dispatch.
+
+    Before #378, Oracle treated any field whose *name* contained "list" as an
+    array and everything else as a string. Now dispatch is purely the
+    registry: a registered ``norm_keys`` (no "list" in the name) gets the
+    member check, and an unregistered ``mylist`` (has "list") gets substring.
+    """
+    # Registered but name has no "list" -> member check.
+    sql_member, _ = _contains_sql(
+        DialectType.oracle, oracle.dialect(), "norm_keys", "m4"
+    )
+    assert "JSON_EXISTS" in sql_member.upper(), sql_member
+
+    # Unregistered but name has "list" -> substring LIKE (no false array path).
+    sql_scalar, _ = _contains_sql(DialectType.oracle, oracle.dialect(), "mylist", "m4")
+    assert "JSON_EXISTS" not in sql_scalar.upper(), sql_scalar
+    assert "LIKE" in sql_scalar.upper(), sql_scalar


### PR DESCRIPTION
## Problem (#378)

`QB[field].contains(v)` on an indexed **list** field is element membership in the in-process backends (`basic.py`: `value in field_value`). The raw psycopg (`postgres.py`) and sqlite3 (`sqlite3.py`) stores were aligned to that in #367 / #374, and #379 fixed the `crud/core.py` registration so the membership path actually engages for bare-string / `Optional[list]` declarations.

The **SQLAlchemy meta store** was the last SQL backend still lowering `contains` on a list field to substring `LIKE` against the serialised JSON array — so the same query returned different rows on a SQLAlchemy-backed Postgres/MySQL/SQLite/Oracle deployment, e.g. `contains("m4")` wrongly matched a row whose list was `["m40"]` (a privacy/correctness hazard, invisible to memory-backed unit tests). It also gated Oracle's true member check on a `"list" in field_path.lower()` **field-name** heuristic, so a `norm_keys` field silently fell back to substring matching.

## Fix (SQLAlchemy only)

- Add `SQLAlchemyMetaStore.register_list_field` + `_list_fields` (mirrors postgres/sqlite). The `add_model` auto-wiring landed in #379 already calls `register_list_field` via `hasattr`, so SQLAlchemy backends are wired automatically — **no crud change here**.
- `_build_condition`: a list-typed `contains` dispatches to `_list_contains`, which emits true element membership per dialect:
  - PostgreSQL — `indexed_data->'f' @> '"v"'::jsonb`
  - SQLite — `EXISTS (SELECT 1 FROM json_each(indexed_data,'$.f') WHERE value = ?)`
  - MySQL — `JSON_CONTAINS(indexed_data, '"v"', '$.f') = 1`
  - Oracle — `JSON_EXISTS(indexed_data, '$.f[*]?(@ == "v"))')` (now gated on the registry, not the field name)
- Scalar string fields keep substring `LIKE` (unchanged).
- The Postgres path binds the JSON-encoded scalar as *String* before the `::jsonb` cast, avoiding the JSONB bind processor double-encoding the value.

## Relationship to #379

#378 had two independent root causes. #379 (merged) fixed **registration** in `crud/core.py` — flipping the membership switch ON for backends that already had the code (postgres/sqlite). This PR adds the **membership code to the SQLAlchemy backend** so the switch has something to turn on there. With both, all three SQL backends agree with the in-process `value in list` semantics and #378 is closed across the matrix.

## Tests

`tests/test_contains_list_pushdown_sqlalchemy.py` (8 tests):
- SQLite is in-process → real `iter_search` (membership; no LIKE-wildcard leakage from `_`; scalar substring preserved).
- PG / MySQL / Oracle pinned by compiling the predicate against each dialect (no live server needed).
- Regression: `norm_keys` gets membership and `mylist` (scalar) does **not** — the field-name heuristic is gone.

All 19 contains-related tests pass (8 sqlalchemy + 7 raw pushdown + 4 autoregister); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
