### PR TITLE
fix(mq): honor partition_key/idempotency_key on all queue backends (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `partition_key` / `idempotency_key` are now honored by **every** message
+  queue backend, not just `SimpleMessageQueue` (#384). RabbitMQ and Celery
+  previously accepted the tags on `Job` but silently ignored them, so
+  same-partition jobs ran concurrently and idempotent enqueue could
+  duplicate. Both backends now check for a PROCESSING peer before claiming a
+  job and defer it through a short delay (configurable via
+  `partition_retry_delay_seconds`) if the partition is busy; a deferred job
+  is not counted as a retry. Enforcement is **best-effort** on multi-worker
+  backends (the check-then-claim is not atomic across workers) and strict
+  only on the single-consumer `SimpleMessageQueue` — see `Job.partition_key`.
+  `enqueue()` is now part of the `IMessageQueue` contract, and the queue
+  auto-registers `partition_key` / `idempotency_key` as indexed fields so
+  the lookups don't silently degrade on SQL backends (cf. #378).
 - Postgres stores sharing a DSN now share one process-global connection
   pool, so connection count scales with the number of distinct DSNs instead
   of `models × 2 × replicas` — no more boot-time `too many clients` storms

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -1471,6 +1471,19 @@ class SpecStar:
                         IndexableField(field_path="retries", field_type=int)
                     )
 
+                # partition_key / idempotency_key are queried by equality at
+                # claim/dedup time (#384). Register them as indexed fields so
+                # the search hits an index instead of silently degrading on
+                # SQL backends (cf. #378), which would make idempotent enqueue
+                # dedup unreliable.
+                for _job_field in ("partition_key", "idempotency_key"):
+                    if not any(
+                        field.field_path == _job_field for field in _indexed_fields
+                    ):
+                        _indexed_fields.append(
+                            IndexableField(field_path=_job_field, field_type=str)
+                        )
+
         # Auto-mount dim validator for any Vector / Embedding fields
         from specstar.resource_manager.vector_validator import (
             CompositeValidator,

--- a/specstar/message_queue/basic.py
+++ b/specstar/message_queue/basic.py
@@ -70,6 +70,12 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
         self._recovery_interval: float = 60.0
         self._recovery_stop_event: threading.Event = threading.Event()
         self._recovery_thread: threading.Thread | None = None
+        # When a job is held back because a same-``partition_key`` peer is
+        # already PROCESSING (#384), it is re-scheduled after this many
+        # seconds rather than run concurrently. A blocked job is *not*
+        # counted as a retry. Public attribute — set it after construction
+        # to tune defer cadence.
+        self.partition_retry_delay_seconds: float = 1.0
 
     # ------------------------------------------------------------------
     # Handler introspection
@@ -150,6 +156,136 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
     def _rm_meta_provide(self, user: str):
         """Deprecated: use ``_rm_using`` instead."""
         return self._rm_using(user)
+
+    # ------------------------------------------------------------------
+    # Enqueue + partition serialization (#384)
+    # ------------------------------------------------------------------
+
+    def enqueue(
+        self,
+        payload: T,
+        *,
+        partition_key: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Resource[Job[T]]:
+        """Create-and-enqueue in one step, honoring optional dedup +
+        per-key serialization tags.
+
+        Why this exists alongside ``put()``:
+            ``put(resource_id)`` is the low-level "already-created" entry
+            point. ``enqueue()`` is the user-facing path that knows about
+            the dedup/serialization semantics — it owns the "is this a
+            retry of an enqueue I already processed?" check because that
+            check must happen *before* the new resource is created
+            (otherwise dedup is a race).
+
+        Defined here on :class:`BasicMessageQueue` so every backend
+        (Simple, RabbitMQ, Celery) exposes the same contract — see #384.
+        The ``partition_key`` *enforcement* is per-backend (it happens at
+        claim time); this method only records the tags on the job.
+
+        Args:
+            payload: The job payload.
+            partition_key: When set, no two jobs with this same key run
+                concurrently. ``None`` = no serialization. Enforcement is
+                strict on :class:`SimpleMessageQueue` (single consumer) and
+                best-effort on multi-worker backends.
+            idempotency_key: When set, a prior enqueue with this key
+                returns the *original* job — including after completion —
+                so caller retries are exactly-once. Re-using a key with a
+                different payload raises :class:`ValueError` (programming
+                error, not a benign retry).
+
+        Returns:
+            The job resource (existing one on dedup, fresh one otherwise).
+        """
+        if idempotency_key is not None:
+            existing = self._find_by_idempotency_key(idempotency_key)
+            if existing is not None:
+                if existing.data.payload != payload:
+                    raise ValueError(
+                        f"idempotency_key {idempotency_key!r} was previously "
+                        "used with a different payload — refusing to dedup "
+                        "across mismatched requests. Use a fresh key or "
+                        "send the original payload."
+                    )
+                return existing
+
+        job: Job[T] = Job(
+            payload=payload,
+            partition_key=partition_key,
+            idempotency_key=idempotency_key,
+        )
+        info = self.rm.create(job)  # ty:ignore[invalid-argument-type]
+        return self.put(info.resource_id)
+
+    def _find_by_idempotency_key(self, idempotency_key: str) -> Resource[Job[T]] | None:
+        """Look up an existing job by ``idempotency_key``.
+
+        Returns ``None`` if no prior enqueue used this key. Returns the
+        resource regardless of its current status — the contract is "same
+        key → same job, forever", including after completion (otherwise a
+        late retry would re-do the work).
+
+        Relies on ``idempotency_key`` being a registered indexed field so
+        the equality search hits an index rather than degrading on SQL
+        backends; ``crud`` auto-registers it for the job model (#384).
+        """
+        query = ResourceMetaSearchQuery(
+            conditions=[
+                DataSearchCondition(
+                    field_path="idempotency_key",
+                    operator=DataSearchOperator.equals,
+                    value=idempotency_key,
+                )
+            ],
+            limit=1,
+        )
+        metas = self.rm.search_resources(query)
+        for meta in metas:
+            try:
+                return self.rm.get(meta.resource_id)
+            except Exception:
+                return None
+        return None
+
+    def _busy_partition_keys(self) -> set[str]:
+        """Return the set of ``partition_key`` values currently in flight
+        (any job with status PROCESSING).
+
+        Walks the PROCESSING set rather than maintaining a separate index
+        so the source of truth stays the job records themselves — there's
+        no second structure to keep consistent across crashes / recovery.
+        """
+        query = ResourceMetaSearchQuery(
+            conditions=[
+                DataSearchCondition(
+                    field_path="status",
+                    operator=DataSearchOperator.equals,
+                    value=TaskStatus.PROCESSING,
+                )
+            ],
+        )
+        busy: set[str] = set()
+        for meta in self.rm.search_resources(query):
+            try:
+                pk = self.rm.get(meta.resource_id).data.partition_key
+            except Exception:
+                continue
+            if pk is not None:
+                busy.add(pk)
+        return busy
+
+    def _is_partition_busy(self, partition_key: str) -> bool:
+        """Best-effort check: is a peer in ``partition_key`` already PROCESSING?
+
+        Used by the multi-worker backends (RabbitMQ, Celery) at claim time
+        to decide whether to defer a job (#384). This is *not* atomic — two
+        workers receiving same-partition jobs simultaneously can both see
+        ``False`` and proceed, leaving a brief overlap window. For strict
+        serialization use a single consumer (:class:`SimpleMessageQueue`).
+        """
+        return partition_key in self._busy_partition_keys()
 
     # ------------------------------------------------------------------
     # Log helpers

--- a/specstar/message_queue/celery_queue.py
+++ b/specstar/message_queue/celery_queue.py
@@ -145,6 +145,25 @@ class CeleryMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 # Worker received stop signal, terminate gracefully
                 raise Ignore()  # Stop processing without retry
 
+            # Partition serialization (best-effort, #384): if a same-partition
+            # peer is already PROCESSING, re-schedule this job after a short
+            # delay instead of running it concurrently. Done *before* the main
+            # try/except so the Ignore() isn't swallowed by the failure
+            # handler, and via a fresh apply_async (NOT task_self.retry) so the
+            # deferral does not consume the job's retry budget — being blocked
+            # is not a failure.
+            try:
+                _pk = queue.rm.get(resource_id).data.partition_key
+            except Exception:
+                _pk = None
+            if _pk is not None and queue._is_partition_busy(_pk):
+                queue._celery_task.apply_async(
+                    args=(resource_id, retry_count),
+                    countdown=queue.partition_retry_delay_seconds,
+                    queue=queue.queue_name,
+                )
+                raise Ignore()
+
             blob_store = queue._blob_store
             log_key = queue._log_key(resource_id)
             lf: LogFlushThread | None = None

--- a/specstar/message_queue/rabbitmq.py
+++ b/specstar/message_queue/rabbitmq.py
@@ -176,6 +176,19 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
                     # 1. Fetch resource
                     resource = self.rm.get(resource_id)
 
+                    # Partition serialization (best-effort, #384): if a
+                    # same-partition peer is already PROCESSING, defer this
+                    # job to a short delay queue instead of running it
+                    # concurrently, and report "nothing claimable" for now.
+                    pk = resource.data.partition_key
+                    if pk is not None and self._is_partition_busy(pk):
+                        retry_count = 0
+                        if header_frame and header_frame.headers:
+                            retry_count = header_frame.headers.get("x-retry-count", 0)
+                        self._defer_partition_job(channel, resource_id, retry_count)
+                        channel.basic_ack(method_frame.delivery_tag)
+                        return None
+
                     # 2. Update status to PROCESSING
                     # Note: We update RM first. If update fails, we don't Ack.
                     # Use draft status so HeartbeatThread can use modify()
@@ -297,6 +310,44 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
         """
         with self._get_connection() as (_, channel):
             self._enqueue_periodic_job(channel, resource_id, delay_seconds)
+
+    def _defer_partition_job(
+        self, ch: BlockingChannel, resource_id: str, retry_count: int
+    ) -> None:
+        """Re-route a job held back by ``partition_key`` through a short
+        delay queue (#384, best-effort serialization).
+
+        A partition-blocked job is **not** a failure: ``x-retry-count`` is
+        carried through the round-trip (dead-lettering preserves message
+        headers) so the retry budget is unchanged when the job re-enters
+        the main queue. Delay granularity is whole seconds (broker TTL),
+        so :attr:`partition_retry_delay_seconds` is rounded up to ``>= 1``.
+
+        Args:
+            ch: An open RabbitMQ channel to publish on.
+            resource_id: The blocked job's resource ID.
+            retry_count: The job's current retry count, preserved verbatim.
+        """
+        delay_seconds = max(1, int(round(self.partition_retry_delay_seconds)))
+        delay_queue_name = f"{self.queue_name}:partition-wait:{delay_seconds}s"
+        ch.queue_declare(
+            queue=delay_queue_name,
+            durable=True,
+            arguments={
+                "x-message-ttl": delay_seconds * 1000,
+                "x-dead-letter-exchange": "",  # Default exchange
+                "x-dead-letter-routing-key": self.queue_name,  # Back to main
+            },  # ty:ignore[invalid-argument-type]
+        )
+        ch.basic_publish(
+            exchange="",
+            routing_key=delay_queue_name,
+            body=resource_id.encode("utf-8"),
+            properties=pika.BasicProperties(
+                delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE,
+                headers={"x-retry-count": retry_count} if retry_count else None,
+            ),
+        )
 
     def _execute_job(
         self,
@@ -496,6 +547,18 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
                     # Use draft status so HeartbeatThread can use modify()
                     resource = self.rm.get(resource_id)
                     job = resource.data
+
+                    # Partition serialization (best-effort, #384): if a
+                    # same-partition peer is already PROCESSING, defer this
+                    # job to a short delay queue rather than run it
+                    # concurrently. A deferred job is NOT a retry — it
+                    # re-enters the main queue with its retry budget intact.
+                    pk = job.partition_key
+                    if pk is not None and self._is_partition_busy(pk):
+                        self._defer_partition_job(ch, resource_id, retry_count)
+                        ch.basic_ack(delivery_tag=method.delivery_tag)  # ty:ignore[invalid-argument-type]
+                        return
+
                     job.status = TaskStatus.PROCESSING
                     with self._rm_using(resource.info.created_by):
                         self.rm.create_or_update(

--- a/specstar/message_queue/simple.py
+++ b/specstar/message_queue/simple.py
@@ -85,85 +85,6 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
 
         return resource
 
-    def enqueue(
-        self,
-        payload: T,
-        *,
-        partition_key: str | None = None,
-        idempotency_key: str | None = None,
-    ) -> Resource[Job[T]]:
-        """Create-and-enqueue in one step, honoring optional dedup +
-        per-key serialization tags.
-
-        Why this exists alongside ``put()``:
-            ``put(resource_id)`` is the low-level "already-created" entry
-            point. ``enqueue()`` is the user-facing path that knows about
-            the new dedup/serialization semantics — it owns the
-            "is this a retry of an enqueue I already processed?" check
-            because that check must happen *before* the new resource is
-            created (otherwise dedup is a race).
-
-        Args:
-            payload: The job payload.
-            partition_key: When set, no two jobs with this same key will
-                be PROCESSING simultaneously. ``None`` = no serialization.
-            idempotency_key: When set, a prior enqueue with this key
-                returns the *original* job — including after completion —
-                so caller retries are exactly-once. Re-using a key with a
-                different payload raises :class:`ValueError` (programming
-                error, not a benign retry).
-
-        Returns:
-            The job resource (existing one on dedup, fresh one otherwise).
-        """
-        if idempotency_key is not None:
-            existing = self._find_by_idempotency_key(idempotency_key)
-            if existing is not None:
-                if existing.data.payload != payload:
-                    raise ValueError(
-                        f"idempotency_key {idempotency_key!r} was previously "
-                        "used with a different payload — refusing to dedup "
-                        "across mismatched requests. Use a fresh key or "
-                        "send the original payload."
-                    )
-                return existing
-
-        job: Job[T] = Job(
-            payload=payload,
-            partition_key=partition_key,
-            idempotency_key=idempotency_key,
-        )
-        info = self.rm.create(job)  # ty:ignore[invalid-argument-type]
-        return self.put(info.resource_id)
-
-    def _find_by_idempotency_key(
-        self, idempotency_key: str
-    ) -> Resource[Job[T]] | None:
-        """Look up an existing job by ``idempotency_key``.
-
-        Returns ``None`` if no prior enqueue used this key. Returns the
-        resource regardless of its current status — the contract is "same
-        key → same job, forever", including after completion (otherwise a
-        late retry would re-do the work).
-        """
-        query = ResourceMetaSearchQuery(
-            conditions=[
-                DataSearchCondition(
-                    field_path="idempotency_key",
-                    operator=DataSearchOperator.equals,
-                    value=idempotency_key,
-                )
-            ],
-            limit=1,
-        )
-        metas = self.rm.search_resources(query)
-        for meta in metas:
-            try:
-                return self.rm.get(meta.resource_id)
-            except Exception:
-                return None
-        return None
-
     def pop(self) -> Resource[Job[T]] | None:
         """
         Dequeue the next pending job and mark it as processing.
@@ -248,33 +169,6 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 continue
 
         return None
-
-    def _busy_partition_keys(self) -> set[str]:
-        """Return the set of ``partition_key`` values currently in flight
-        (any job with status PROCESSING).
-
-        Walks the PROCESSING set rather than maintaining a separate index
-        so the source of truth stays the job records themselves — there's
-        no second structure to keep consistent across crashes / recovery.
-        """
-        query = ResourceMetaSearchQuery(
-            conditions=[
-                DataSearchCondition(
-                    field_path="status",
-                    operator=DataSearchOperator.equals,
-                    value=TaskStatus.PROCESSING,
-                )
-            ],
-        )
-        busy: set[str] = set()
-        for meta in self.rm.search_resources(query):
-            try:
-                pk = self.rm.get(meta.resource_id).data.partition_key
-            except Exception:
-                continue
-            if pk is not None:
-                busy.add(pk)
-        return busy
 
     def _schedule_periodic_job(self, resource_id: str, interval_seconds: int) -> None:
         """

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -1023,7 +1023,7 @@ class MergePatch(dict):
     ``jsonpatch.JsonPatch`` marks an RFC 6902 operation list. Construct it
     around the changed fields::
 
-        mgr.patch(rid, MergePatch({"qty": 50}))   # merge, keep other fields
+        mgr.patch(rid, MergePatch({"qty": 50}))  # merge, keep other fields
     """
 
     @property
@@ -2417,24 +2417,48 @@ class Job(Struct, Generic[T, D]):
     partition_key: str | None = None
     """Per-key serialization tag (``#342 #3``).
 
-    Two jobs sharing the same ``partition_key`` never run concurrently —
+    Two jobs sharing the same ``partition_key`` are not run concurrently:
     the consumer holds back a pending job whose partition already has a
-    PROCESSING peer. ``None`` (default) means no serialization (every
-    pending job is independently eligible, matching legacy behavior).
-    Typical use: a per-tenant or per-aggregate write workflow where
-    inflight reruns would trample each other.
+    PROCESSING peer and re-schedules it after a short delay. ``None``
+    (default) means no serialization (every pending job is independently
+    eligible, matching legacy behavior). Typical use: a per-tenant or
+    per-aggregate write workflow where inflight reruns would trample each
+    other.
+
+    Enforcement strength depends on the backend (#384):
+
+    * :class:`~specstar.message_queue.simple.SimpleMessageQueue` — **strict**.
+      Its single consumer checks and claims in one thread, so two
+      same-partition jobs never overlap.
+    * :class:`~specstar.message_queue.rabbitmq.RabbitMQMessageQueue` and
+      :class:`~specstar.message_queue.celery_queue.CeleryMessageQueue` —
+      **best-effort**. Each worker checks for a PROCESSING peer before
+      claiming and defers if it finds one, but the check-then-claim is not
+      atomic across workers: two same-partition jobs that arrive at
+      different workers simultaneously can briefly overlap. Order within a
+      partition is **not** guaranteed.
+
+    For strictly-serialized partitions on a multi-worker deployment, run a
+    single consumer (``SimpleMessageQueue``); a future release may add an
+    atomic cross-worker lock backend for strict guarantees.
     """
 
     idempotency_key: str | None = None
     """Exactly-once enqueue tag (``#342 #4``).
 
-    When supplied to ``enqueue()``, a second call with the same
-    ``idempotency_key`` returns the *original* job instead of creating
-    a new one — including after the original ran to completion. This is
-    the standard contract for retry-prone client paths (mobile, webhook
-    receivers, public APIs). Re-using a key with a *different* payload
-    is rejected as a programming error. ``None`` (default) disables
+    When supplied to :meth:`~specstar.types.IMessageQueue.enqueue`, a second
+    call with the same ``idempotency_key`` returns the *original* job instead
+    of creating a new one — including after the original ran to completion.
+    This is the standard contract for retry-prone client paths (mobile,
+    webhook receivers, public APIs). Re-using a key with a *different*
+    payload is rejected as a programming error. ``None`` (default) disables
     dedup.
+
+    ``enqueue`` (and therefore this dedup) is available on every backend
+    (#384). The lookup is best-effort across workers: two enqueues racing
+    on the same key from different processes can briefly both miss and
+    create two jobs, since the find-then-create is not atomic. For a single
+    enqueue producer the dedup is exact.
     """
 
 
@@ -2456,6 +2480,37 @@ class IMessageQueue(ABC, Generic[T]):
     @abstractmethod
     def pop(self) -> Resource[Job[T]] | None:
         """Dequeue the next pending job."""
+        ...
+
+    @abstractmethod
+    def enqueue(
+        self,
+        payload: T,
+        *,
+        partition_key: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> Resource[Job[T]]:
+        """Create-and-enqueue a job in one step, honoring optional dedup and
+        per-key serialization tags.
+
+        This is the user-facing companion to :meth:`put` (which enqueues an
+        already-created resource). It is implemented uniformly by every
+        backend (#384); see :attr:`Job.partition_key` and
+        :attr:`Job.idempotency_key` for the per-backend enforcement strength.
+
+        Args:
+            payload: The job payload.
+            partition_key: When set, jobs sharing this key are not run
+                concurrently (strict on a single consumer, best-effort on
+                multi-worker backends). ``None`` = no serialization.
+            idempotency_key: When set, a prior enqueue with the same key
+                returns the *original* job. Re-using a key with a different
+                payload raises :class:`ValueError`. ``None`` = no dedup.
+
+        Returns:
+            The job resource (the existing one on dedup, a fresh one
+            otherwise).
+        """
         ...
 
     @abstractmethod

--- a/tests/test_job_indexed_fields.py
+++ b/tests/test_job_indexed_fields.py
@@ -1,0 +1,59 @@
+"""#384 — auto-register ``partition_key`` / ``idempotency_key`` as indexed fields.
+
+The queue queries these two ``Job`` fields by equality at claim time
+(``partition_key``) and dedup time (``idempotency_key``). If they are not
+registered as indexed fields, the equality search degrades on SQL backends
+(cf. #378), which would make idempotent-enqueue dedup unreliable. ``crud``
+must auto-register them on the generated Job model — alongside the existing
+``status`` / ``retries`` auto-registration.
+"""
+
+import datetime as dt
+import warnings
+
+from fastapi import Body, FastAPI
+from msgspec import Struct
+
+from specstar.crud.core import SpecStar
+from specstar.message_queue.simple import SimpleMessageQueueFactory
+
+
+class Article(Struct):
+    content: str
+    title: str
+
+
+class ArticleRequest(Struct):
+    prompt: str
+    title: str
+
+
+def _build_job_rm():
+    """Build a SpecStar with one async-job create_action and return its
+    auto-generated Job resource manager."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        spec = SpecStar(
+            default_user="t",
+            default_now=dt.datetime.now,
+            message_queue_factory=SimpleMessageQueueFactory(max_retries=1),
+        )
+        spec.add_model(Article, name="article")
+
+        @spec.create_action("article", async_mode="job", label="Generate")
+        def generate_article(payload: ArticleRequest = Body(...)) -> Article:
+            return Article(title=payload.title, content="ok")
+
+        app = FastAPI()
+        spec.apply(app)
+    return spec.resource_managers["generate-article-job"]
+
+
+def test_partition_and_idempotency_keys_are_auto_indexed():
+    job_rm = _build_job_rm()
+    indexed = {getattr(f, "field_path", f) for f in job_rm._indexed_fields}
+    # The pre-existing auto-registrations stay...
+    assert {"status", "retries"} <= indexed
+    # ...and the two #384 keys are now registered too.
+    assert "partition_key" in indexed
+    assert "idempotency_key" in indexed

--- a/tests/test_message_queue/test_partition_defer.py
+++ b/tests/test_message_queue/test_partition_defer.py
@@ -1,0 +1,199 @@
+"""#384 — partition_key serialization is honored by RabbitMQ and Celery.
+
+These backends previously *silently ignored* ``partition_key``: the contract
+was implemented only in ``SimpleMessageQueue``. Now each multi-worker backend
+checks for a PROCESSING peer in the same partition before claiming a job and,
+if it finds one, defers the job (re-routing it through a short delay) instead
+of running it concurrently. A deferred job is **not** a retry — its retry
+budget is untouched.
+
+The checks here are unit-level (mocked broker / mocked ``apply_async``) so
+they run in fast CI without a live RabbitMQ or Celery worker; they assert the
+*decision* (defer vs. claim), which is the behavior #384 is about.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import msgspec
+import pytest
+
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField, Job, TaskStatus
+
+
+class Payload(msgspec.Struct):
+    task_name: str
+
+
+def _rm():
+    """A ResourceManager *not* wired to a message queue, so create() does not
+    auto-enqueue. partition_key/status are indexed so the busy-peer search works.
+    """
+    storage = SimpleStorage(MemoryMetaStore(), MemoryResourceStore())
+    return ResourceManager(
+        Job[Payload],
+        storage=storage,
+        indexed_fields=[
+            IndexableField(field_path="status", field_type=str),
+            IndexableField(field_path="partition_key", field_type=str),
+            IndexableField(field_path="idempotency_key", field_type=str),
+        ],
+        default_user="t",
+    )
+
+
+def _seed_busy_and_candidate(rm):
+    """Create a PROCESSING peer and a PENDING candidate, both in partition 'P'.
+
+    Returns the candidate's resource_id.
+    """
+    rm.create(
+        Job(payload=Payload("busy"), partition_key="P", status=TaskStatus.PROCESSING)
+    )
+    cand = rm.create(
+        Job(payload=Payload("cand"), partition_key="P", status=TaskStatus.PENDING)
+    )
+    return cand.resource_id
+
+
+# ---------------------------------------------------------------------------
+# RabbitMQ
+# ---------------------------------------------------------------------------
+
+
+def test_rabbitmq_pop_defers_when_partition_busy(monkeypatch):
+    pytest.importorskip("pika")
+    from specstar.message_queue.rabbitmq import RabbitMQMessageQueue
+
+    rm = _rm()
+    candidate_id = _seed_busy_and_candidate(rm)
+
+    channel = MagicMock()
+
+    @contextmanager
+    def fake_conn(self):
+        yield (MagicMock(), channel)
+
+    # Avoid touching a real broker during __init__ and pop().
+    monkeypatch.setattr(RabbitMQMessageQueue, "_declare_queues", lambda self: None)
+    monkeypatch.setattr(RabbitMQMessageQueue, "_get_connection", fake_conn)
+
+    q = RabbitMQMessageQueue(do=lambda r: None, resource_manager=rm)
+
+    # basic_get hands the consumer the candidate (partition 'P', PENDING).
+    method_frame = MagicMock()
+    method_frame.delivery_tag = 7
+    channel.basic_get.return_value = (method_frame, None, candidate_id.encode("utf-8"))
+
+    result = q.pop()
+
+    # Deferred: nothing claimable right now.
+    assert result is None
+    # Re-routed through a delay queue (defer) and acked off the main queue.
+    channel.basic_publish.assert_called_once()
+    channel.basic_ack.assert_called_once_with(7)
+    # The candidate was NOT marked PROCESSING (it goes back to wait its turn).
+    assert rm.get(candidate_id).data.status == TaskStatus.PENDING
+
+
+def test_rabbitmq_pop_claims_when_partition_free(monkeypatch):
+    pytest.importorskip("pika")
+    from specstar.message_queue.rabbitmq import RabbitMQMessageQueue
+
+    rm = _rm()
+    # No busy peer this time — a lone PENDING job in partition 'Q'.
+    cand = rm.create(
+        Job(payload=Payload("solo"), partition_key="Q", status=TaskStatus.PENDING)
+    )
+
+    channel = MagicMock()
+
+    @contextmanager
+    def fake_conn(self):
+        yield (MagicMock(), channel)
+
+    monkeypatch.setattr(RabbitMQMessageQueue, "_declare_queues", lambda self: None)
+    monkeypatch.setattr(RabbitMQMessageQueue, "_get_connection", fake_conn)
+
+    q = RabbitMQMessageQueue(do=lambda r: None, resource_manager=rm)
+
+    method_frame = MagicMock()
+    method_frame.delivery_tag = 3
+    channel.basic_get.return_value = (
+        method_frame,
+        None,
+        cand.resource_id.encode("utf-8"),
+    )
+
+    result = q.pop()
+
+    # Claimed normally: returned and marked PROCESSING; no defer publish.
+    assert result is not None
+    assert result.data.status == TaskStatus.PROCESSING
+    channel.basic_publish.assert_not_called()
+    channel.basic_ack.assert_called_once_with(3)
+
+
+# ---------------------------------------------------------------------------
+# Celery
+# ---------------------------------------------------------------------------
+
+
+def test_celery_task_defers_when_partition_busy():
+    pytest.importorskip("celery")
+    from celery import Celery
+
+    from specstar.message_queue.celery_queue import CeleryMessageQueue
+
+    app = Celery("test_partition", broker="memory://", backend="cache+memory://")
+    app.conf.update(task_always_eager=True, task_eager_propagates=False)
+
+    rm = _rm()
+    candidate_id = _seed_busy_and_candidate(rm)
+
+    q = CeleryMessageQueue(do=lambda r: None, resource_manager=rm, celery_app=app)
+    # Record the deferral instead of letting eager mode recurse into it.
+    q._celery_task.apply_async = MagicMock()
+
+    # Run the task body eagerly; the deferral raises Ignore which eager mode
+    # captures (task_eager_propagates=False).
+    q._celery_task.apply(args=(candidate_id, 0))
+
+    q._celery_task.apply_async.assert_called_once()
+    _, kwargs = q._celery_task.apply_async.call_args
+    assert kwargs["args"] == (candidate_id, 0)  # retry budget preserved
+    assert kwargs["countdown"] == q.partition_retry_delay_seconds
+    # Candidate never marked PROCESSING.
+    assert rm.get(candidate_id).data.status == TaskStatus.PENDING
+
+
+def test_celery_task_runs_when_partition_free():
+    pytest.importorskip("celery")
+    from celery import Celery
+
+    from specstar.message_queue.celery_queue import CeleryMessageQueue
+
+    app = Celery("test_partition2", broker="memory://", backend="cache+memory://")
+    app.conf.update(task_always_eager=True, task_eager_propagates=False)
+
+    rm = _rm()
+    cand = rm.create(
+        Job(payload=Payload("solo"), partition_key="Q", status=TaskStatus.PENDING)
+    )
+
+    ran = []
+    q = CeleryMessageQueue(
+        do=lambda r: ran.append(r.info.resource_id),
+        resource_manager=rm,
+        celery_app=app,
+    )
+    q._celery_task.apply_async = MagicMock()
+
+    q._celery_task.apply(args=(cand.resource_id, 0))
+
+    # No defer; the handler ran.
+    q._celery_task.apply_async.assert_not_called()
+    assert ran == [cand.resource_id]


### PR DESCRIPTION
## Problem

`partition_key` and `idempotency_key` are documented on `Job` as cross-backend contracts, but only `SimpleMessageQueue` enforced them. RabbitMQ and Celery accepted the tags and **silently ignored** them — so on those backends two jobs sharing a `partition_key` ran concurrently, and idempotent enqueue could create duplicates. Closes #384.

## Approach (best-effort serialization)

Keep the wake-up/consume model: a worker checks for a PROCESSING peer in the same partition before claiming a job, and if the partition is busy it defers the job through a short delay instead of running it concurrently.

- **`BasicMessageQueue`** — `enqueue` / `_find_by_idempotency_key` / `_busy_partition_keys` lifted here so every backend shares them; adds `_is_partition_busy` and a configurable `partition_retry_delay_seconds` (default `1.0`).
- **RabbitMQ** — `pop()` and the consume callback defer via `_defer_partition_job`, which re-routes through a short TTL delay queue and **preserves `x-retry-count`** (a partition-blocked job is not a failed/retried job).
- **Celery** — the task checks before marking PROCESSING and re-schedules via `apply_async(countdown=)` (not `task.retry`), so the retry budget is untouched; the `Ignore()` is raised outside the main try/except so it isn't swallowed.
- **`enqueue()`** is now part of the `IMessageQueue` contract.
- **crud** auto-registers `partition_key` / `idempotency_key` as indexed fields so the equality lookups don't silently degrade on SQL backends (cf. #378) — this also fixes latent unreliability of idempotent-enqueue dedup.
- **Docs** — `Job.partition_key` / `idempotency_key` now state enforcement strength per backend: **strict** on `SimpleMessageQueue` (single consumer), **best-effort** on multi-worker backends (check-then-claim is not atomic across workers; order within a partition is not guaranteed).

## Tests

- `tests/test_job_indexed_fields.py` — asserts `partition_key`/`idempotency_key` are auto-registered as indexed fields.
- `tests/test_message_queue/test_partition_defer.py` — RabbitMQ `pop()` defers when the partition is busy and claims when free (mocked channel); Celery task defers (preserving `args=(id, retry_count)`) when busy and runs when free.
- Existing Simple partition/idempotency (12), Celery eager (7), async-create-action (62), docs-contract (8) all still pass; ruff clean.

## Deliberately out of scope (follow-ups)

- Strict cross-worker serialization via an atomic lock backend (PG advisory lock / `RedisLockBackend`) — the existing `if_not_exists` / `expected_revision_id` CAS is app-level read-then-write and **not** atomic across workers, so it can't back a strict guarantee today.
- Correcting the `if_not_exists` / `expected_revision_id` docstrings that claim an "atomic cross-worker mutex" (surfaced while investigating; same family as this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)