### PR TITLE
fix(storage): shard disk stores into fanout subdirs to avoid NAS inode limits (#387)

### DIFF
--- a/specstar/resource_manager/blob_store/simple.py
+++ b/specstar/resource_manager/blob_store/simple.py
@@ -17,6 +17,11 @@ from specstar.types import (
     BlobStreamInfo,
     BlobUploadSession,
 )
+from specstar.util.fanout import (
+    iter_legacy_children,
+    sharded_dir,
+    sharded_path,
+)
 from specstar.util.fs_retry import retry_on_estale
 
 
@@ -384,9 +389,18 @@ class _DiskBlobMeta(Struct, kw_only=True):
 class DiskBlobStore(BasicBlobStore):
     """Disk-based blob store — data persisted to local filesystem.
 
-    Upload sessions are persisted to disk under ``root_path/_sessions/``
-    so that multiple processes (or Kubernetes pods sharing a PVC) can
-    cooperate on the same upload lifecycle.
+    Blobs are spread across a sharded subdirectory tree
+    (``root_path/_sh/<ab>/<cd>/<file_id>`` plus a ``.blobmeta`` sidecar in
+    the same directory) so that no single directory accumulates an unbounded
+    number of entries — which on NAS / networked filesystems hits
+    per-directory inode/dirent limits. Blobs written before this layout
+    (flat at ``root_path/<file_id>``) are still read transparently; call
+    :meth:`migrate_layout` to relocate them. See #387.
+
+    Upload sessions are persisted under ``root_path/_sessions/`` (each
+    session in its own sharded ``_sh/<ab>/<cd>/<upload_id>/`` directory) so
+    that multiple processes (or Kubernetes pods sharing a PVC) can cooperate
+    on the same upload lifecycle.
     """
 
     def __init__(self, root_path: str | Path):
@@ -402,21 +416,32 @@ class DiskBlobStore(BasicBlobStore):
 
     # -- Internal helpers for disk-persisted sessions ---------------------
 
+    def _session_dir(self, upload_id: str) -> Path:
+        """Per-session directory ``_sessions/_sh/<ab>/<cd>/<upload_id>/``.
+
+        Each upload owns one directory holding all of its files (``meta``,
+        ``data``, ``part.N``, ``lock``). Sharding the session directory keeps
+        ``_sessions/`` from accumulating an unbounded number of entries, and a
+        per-session directory makes transient cleanup (``data``/``part.*``) a
+        single bounded operation. See #387.
+        """
+        return sharded_dir(self._sessions_dir, upload_id) / upload_id
+
     def _session_meta_path(self, upload_id: str) -> Path:
         """Path for the msgpack-encoded session metadata file."""
-        return self._sessions_dir / f"{upload_id}.meta"
+        return self._session_dir(upload_id) / "meta"
 
     def _session_data_path(self, upload_id: str) -> Path:
         """Path for the raw uploaded bytes (merged/final data)."""
-        return self._sessions_dir / f"{upload_id}.data"
+        return self._session_dir(upload_id) / "data"
 
     def _session_part_path(self, upload_id: str, part_number: int) -> Path:
         """Path for an out-of-order part file."""
-        return self._sessions_dir / f"{upload_id}.part.{part_number}"
+        return self._session_dir(upload_id) / f"part.{part_number}"
 
     def _session_lock_path(self, upload_id: str) -> Path:
         """Path for the per-session POSIX lock file."""
-        return self._sessions_dir / f"{upload_id}.lock"
+        return self._session_dir(upload_id) / "lock"
 
     @contextmanager
     def _lock_session(self, upload_id: str):
@@ -428,6 +453,7 @@ class DiskBlobStore(BasicBlobStore):
         (including on exceptions or process crashes).
         """
         lock_path = self._session_lock_path(upload_id)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = lock_path.open("w")
         try:
             fcntl.flock(fd, fcntl.LOCK_EX)
@@ -440,7 +466,8 @@ class DiskBlobStore(BasicBlobStore):
         """Persist session metadata atomically (write-to-tmp + rename)."""
         encoded = self._session_meta_encoder.encode(meta)
         path = self._session_meta_path(meta.upload_id)
-        tmp = path.with_suffix(".meta.tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name("meta.tmp")
         tmp.write_bytes(encoded)
         tmp.rename(path)
 
@@ -459,9 +486,23 @@ class DiskBlobStore(BasicBlobStore):
 
     # -- Blob put / get / exists ------------------------------------------
 
-    def _blob_meta_path(self, safe_name: str) -> Path:
-        """Path for the ``.blobmeta`` sidecar of a stored blob."""
-        return self.root_path / f"{safe_name}.blobmeta"
+    @staticmethod
+    def _safe_name(file_id: str) -> str:
+        """Filesystem-safe leaf name for *file_id*."""
+        return file_id.replace("/", "_").replace("..", "_")
+
+    def _candidate_data_paths(self, safe_name: str):
+        """Yield data-file paths to try on read: sharded first, legacy flat last.
+
+        New writes land in the sharded tree (``_sh/<ab>/<cd>/<name>``); blobs
+        written before #387 are still flat at the root. The ``.blobmeta``
+        sidecar always lives next to whichever data file is found. See #387.
+        """
+        yield sharded_path(self.root_path, safe_name)
+        yield self.root_path / safe_name
+
+    def _blob_exists(self, safe_name: str) -> bool:
+        return any(p.exists() for p in self._candidate_data_paths(safe_name))
 
     def put(
         self,
@@ -471,24 +512,30 @@ class DiskBlobStore(BasicBlobStore):
         content_type: str | UnsetType = UNSET,
     ) -> Binary:
         file_id = key if key is not None else xxh3_128_hexdigest(data)
-        # Make filename safe for filesystem
-        safe_name = file_id.replace("/", "_").replace("..", "_")
+        safe_name = self._safe_name(file_id)
 
-        file_path = self.root_path / safe_name
+        # New blobs are written into the sharded tree to keep any single
+        # directory from accumulating an unbounded number of entries (NAS
+        # per-directory inode/dirent limits). See #387.
+        blob_dir = sharded_dir(self.root_path, safe_name)
+        file_path = blob_dir / safe_name
         final_content_type = self.guess_content_type(data, content_type)
-        # When key is caller-specified, always overwrite; for hash keys skip if exists
-        if key is not None or not file_path.exists():
+        # Caller-specified key always overwrites; content-addressed (hash) keys
+        # are immutable, so skip the write when the blob already exists in
+        # *either* layout (sharded or legacy flat). See #387, #352.
+        if key is not None or not self._blob_exists(safe_name):
             # Atomic write: dump bytes into a uniquely-named tmp file in the
-            # same directory, then ``os.replace`` it onto the final path. A
-            # concurrent reader either sees the previous complete file or the
-            # new complete file — never a truncated mid-write prefix.
+            # same (shard) directory, then ``os.replace`` it onto the final
+            # path. A concurrent reader either sees the previous complete file
+            # or the new complete file — never a truncated mid-write prefix.
             # See #352 (local-FS half).
+            blob_dir.mkdir(parents=True, exist_ok=True)
             blob_meta = _DiskBlobMeta(
                 file_id=file_id,
                 size=len(data),
                 content_type=final_content_type,
             )
-            meta_path = self._blob_meta_path(safe_name)
+            meta_path = blob_dir / f"{safe_name}.blobmeta"
             _atomic_write_bytes(file_path, data)
             _atomic_write_bytes(meta_path, self.encoder.encode(blob_meta))
         return Binary(
@@ -499,17 +546,23 @@ class DiskBlobStore(BasicBlobStore):
         )
 
     def get(self, file_id: str) -> Binary:
-        safe_name = file_id.replace("/", "_").replace("..", "_")
-        file_path = self.root_path / safe_name
-        # Skip the exists() guard: it would race against a concurrent purge
-        # and leak the raw "[Errno 2] No such file or directory: '/abs/path'"
-        # message to the caller. Read straight and translate ENOENT into the
-        # same controlled "Blob {file_id} not found" surface. See #352.
-        try:
-            data = retry_on_estale(file_path.read_bytes)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"Blob {file_id} not found") from None
-        meta_path = self._blob_meta_path(safe_name)
+        safe_name = self._safe_name(file_id)
+        # Try sharded path first, then legacy flat. Read straight and catch
+        # ENOENT rather than guarding with exists(): the guard would TOCTOU
+        # against a concurrent purge/migration and leak a raw "[Errno 2] ..."
+        # path. See #352, #387.
+        data = None
+        found_path: Path | None = None
+        for candidate in self._candidate_data_paths(safe_name):
+            try:
+                data = retry_on_estale(candidate.read_bytes)
+                found_path = candidate
+                break
+            except FileNotFoundError:
+                continue
+        if found_path is None:
+            raise FileNotFoundError(f"Blob {file_id} not found")
+        meta_path = found_path.parent / f"{safe_name}.blobmeta"
         try:
             meta_bytes = retry_on_estale(meta_path.read_bytes)
         except FileNotFoundError:
@@ -525,25 +578,29 @@ class DiskBlobStore(BasicBlobStore):
         )
 
     def exists(self, file_id: str) -> bool:
-        safe_name = file_id.replace("/", "_").replace("..", "_")
-        return (self.root_path / safe_name).exists()
+        return self._blob_exists(self._safe_name(file_id))
 
     def get_stream(self, file_id: str):
         """Stream blob content in 8 MB chunks without loading into memory."""
         from specstar.types import BlobStreamInfo
 
-        safe_name = file_id.replace("/", "_").replace("..", "_")
-        file_path = self.root_path / safe_name
-        # Race-tolerant stat: an ``exists()`` guard here would TOCTOU against
-        # a concurrent purge and leak a raw "[Errno 2] ..." path to the
-        # caller. Catch ENOENT from stat() and translate to the controlled
-        # surface. See #352.
-        try:
-            size = retry_on_estale(file_path.stat).st_size
-        except FileNotFoundError:
-            raise FileNotFoundError(f"Blob {file_id} not found") from None
+        safe_name = self._safe_name(file_id)
+        # Race-tolerant stat across both layouts (sharded first, legacy flat).
+        # An exists() guard would TOCTOU against a concurrent purge/migration
+        # and leak a raw "[Errno 2] ..." path. See #352, #387.
+        size = None
+        found_path: Path | None = None
+        for candidate in self._candidate_data_paths(safe_name):
+            try:
+                size = retry_on_estale(candidate.stat).st_size
+                found_path = candidate
+                break
+            except FileNotFoundError:
+                continue
+        if found_path is None:
+            raise FileNotFoundError(f"Blob {file_id} not found")
         content_type = UNSET
-        meta_path = self._blob_meta_path(safe_name)
+        meta_path = found_path.parent / f"{safe_name}.blobmeta"
         try:
             meta_bytes = retry_on_estale(meta_path.read_bytes)
         except FileNotFoundError:
@@ -552,10 +609,10 @@ class DiskBlobStore(BasicBlobStore):
             blob_meta = self._blob_meta_decoder.decode(meta_bytes)
             content_type = blob_meta.content_type
 
-        def _iterate():
+        def _iterate(path: Path = found_path):
             # The open itself can ESTALE on NFS even when the parent dir
             # listing said the file is present. See #352.
-            f = retry_on_estale(open, file_path, "rb")
+            f = retry_on_estale(open, path, "rb")
             try:
                 while True:
                     chunk = f.read(8 * 1024 * 1024)  # 8 MB
@@ -568,6 +625,83 @@ class DiskBlobStore(BasicBlobStore):
         return BlobStreamInfo(
             _iterate(), size=size, content_type=content_type, file_id=file_id
         )
+
+    def migrate_layout(self, *, dry_run: bool = False) -> int:
+        """Relocate pre-#387 flat blobs into the sharded tree.
+
+        Walks the legacy flat layout (blob files written directly under
+        ``root_path``) and moves each blob — together with its ``.blobmeta``
+        sidecar — into ``_sh/<ab>/<cd>/``. Safe to run on a live store:
+        each move is an atomic ``os.replace`` on the same filesystem and
+        reads fall back to the flat layout until the move lands. Idempotent
+        (a blob already present in the sharded tree is skipped) and
+        re-runnable after an interruption.
+
+        Returns the number of legacy entries relocated (or, when *dry_run*,
+        that would be relocated): flat blobs plus any leftover flat session
+        files. A blob's ``.blobmeta`` sidecar is moved with its blob and not
+        counted separately.
+        """
+        moved = 0
+        for child in iter_legacy_children(self.root_path):
+            # Sharded data (``_sh/``) is already excluded by iter_legacy_children;
+            # ``_sessions/`` and any other directory is not a flat blob.
+            if child.is_dir():
+                continue
+            name = child.name
+            if name.endswith(".blobmeta"):
+                continue  # moved alongside its blob
+            if name.endswith(".tmp") or ".tmp." in name:
+                continue  # in-flight atomic write
+            target_dir = sharded_dir(self.root_path, name)
+            target = target_dir / name
+            if target.exists():
+                continue  # already migrated
+            moved += 1
+            if dry_run:
+                continue
+            target_dir.mkdir(parents=True, exist_ok=True)
+            os.replace(child, target)
+            legacy_meta = self.root_path / f"{name}.blobmeta"
+            if legacy_meta.exists():
+                os.replace(legacy_meta, target_dir / f"{name}.blobmeta")
+        return moved + self._migrate_sessions(dry_run=dry_run)
+
+    def _migrate_sessions(self, *, dry_run: bool = False) -> int:
+        """Relocate pre-#387 flat session files into per-session sharded dirs.
+
+        Legacy sessions stored each file flat under ``_sessions/`` as
+        ``<upload_id>.<kind>`` (``.meta`` / ``.data`` / ``.lock`` /
+        ``.part.N``). They are regrouped into ``_sessions/_sh/<ab>/<cd>/
+        <upload_id>/<kind>`` so ``_sessions/`` stops accumulating entries.
+        Returns the number of session files moved.
+        """
+        moved = 0
+        for child in iter_legacy_children(self._sessions_dir):
+            if child.is_dir():
+                continue
+            name = child.name
+            if name.endswith(".tmp"):
+                continue
+            upload_id, _, kind = name.partition(".")
+            if not kind:
+                continue
+            if kind in ("meta", "data", "lock"):
+                leaf = kind
+            elif kind.startswith("part."):
+                leaf = kind  # "part.N"
+            else:
+                continue
+            target_dir = self._session_dir(upload_id)
+            target = target_dir / leaf
+            if target.exists():
+                continue
+            moved += 1
+            if dry_run:
+                continue
+            target_dir.mkdir(parents=True, exist_ok=True)
+            os.replace(child, target)
+        return moved
 
     # -- Upload session methods (disk-persisted) --------------------------
 
@@ -651,7 +785,7 @@ class DiskBlobStore(BasicBlobStore):
         """
         data_path = self._session_data_path(upload_id)
         size = data_path.stat().st_size if data_path.exists() else 0
-        for part_file in self._sessions_dir.glob(f"{upload_id}.part.*"):
+        for part_file in self._session_dir(upload_id).glob("part.*"):
             size += part_file.stat().st_size
         return size
 
@@ -668,6 +802,7 @@ class DiskBlobStore(BasicBlobStore):
         # uploads of *different* parts never interfere.  A retry of the
         # *same* part_number simply overwrites the file (idempotent).
         part_path = self._session_part_path(upload_id, part_number)
+        part_path.parent.mkdir(parents=True, exist_ok=True)
         part_path.write_bytes(data)
 
         # ---- Phase 2 (SHORT LOCK): update meta + eager-merge --------
@@ -717,7 +852,7 @@ class DiskBlobStore(BasicBlobStore):
             # Check for remaining buffered part files (gaps)
             remaining_parts = sorted(
                 int(p.name.split(".")[-1])
-                for p in self._sessions_dir.glob(f"{upload_id}.part.*")
+                for p in self._session_dir(upload_id).glob("part.*")
             )
             if remaining_parts:
                 raise ValueError(
@@ -754,23 +889,28 @@ class DiskBlobStore(BasicBlobStore):
                         hasher.update(chunk)
                 file_id = hasher.hexdigest()
 
-            safe_name = file_id.replace("/", "_").replace("..", "_")
-            final_path = self.root_path / safe_name
+            safe_name = self._safe_name(file_id)
+            blob_dir = sharded_dir(self.root_path, safe_name)
+            final_path = blob_dir / safe_name
 
-            # Move data to final blob location (zero-copy on same filesystem)
-            if meta.key is not None or not final_path.exists():
+            # Move data to its final (sharded) blob location — zero-copy on the
+            # same filesystem. See #387.
+            if meta.key is not None or not self._blob_exists(safe_name):
+                blob_dir.mkdir(parents=True, exist_ok=True)
                 data_path.rename(final_path)
+                # Write metadata sidecar alongside the blob.
+                blob_meta = _DiskBlobMeta(
+                    file_id=file_id,
+                    size=size,
+                    content_type=final_content_type,
+                )
+                (blob_dir / f"{safe_name}.blobmeta").write_bytes(
+                    self.encoder.encode(blob_meta)
+                )
             else:
-                # Content-addressed blob already exists — discard duplicate
+                # Content-addressed blob already exists (either layout) — discard
+                # the duplicate; the existing blob + sidecar remain authoritative.
                 data_path.unlink()
-
-            # Write metadata sidecar
-            blob_meta = _DiskBlobMeta(
-                file_id=file_id,
-                size=size,
-                content_type=final_content_type,
-            )
-            self._blob_meta_path(safe_name).write_bytes(self.encoder.encode(blob_meta))
 
             meta.status = "finalized"
             self._save_session_meta(meta)
@@ -787,7 +927,11 @@ class DiskBlobStore(BasicBlobStore):
                 raise ValueError("Cannot abort a finalized session")
             meta.status = "aborted"
             self._save_session_meta(meta)
-            # Clean up data file and all part files
+            # Clean up the transient bulk (data + part files). The tiny ``meta``
+            # (now ``aborted``) and ``lock`` are retained: ``meta`` is the
+            # cross-instance status SSOT and unlinking a live ``flock`` anchor
+            # races concurrent lockers. They live in the per-session sharded
+            # directory, so no single directory bombs. See #387.
             self._session_data_path(upload_id).unlink(missing_ok=True)
-            for part_file in self._sessions_dir.glob(f"{upload_id}.part.*"):
+            for part_file in self._session_dir(upload_id).glob("part.*"):
                 part_file.unlink(missing_ok=True)

--- a/specstar/resource_manager/meta_store/simple.py
+++ b/specstar/resource_manager/meta_store/simple.py
@@ -16,6 +16,11 @@ from specstar.resource_manager.basic import (
     is_match_query,
 )
 from specstar.types import ResourceMeta
+from specstar.util.fanout import (
+    SHARD_ROOT,
+    iter_legacy_children,
+    sharded_dir,
+)
 from specstar.util.fs_retry import is_transient_fs_error, retry_on_estale
 
 T = TypeVar("T")
@@ -88,39 +93,67 @@ class DiskMetaStore(IFastMetaStore):
         # high-volume batch ingest (the workload most likely to be interrupted).
         self._fsync = fsync
 
-    def _get_path(self, pk: str) -> Path:
-        return self._rootdir / f"{pk}{self._suffix}"
+    def _leaf(self, pk: str) -> str:
+        return f"{pk}{self._suffix}"
+
+    def _write_path(self, pk: str) -> Path:
+        """Sharded path new records for *pk* are written to (#387)."""
+        return sharded_dir(self._rootdir, pk) / self._leaf(pk)
+
+    def _candidate_paths(self, pk: str):
+        """Yield paths to try on read: sharded first, then legacy flat (#387)."""
+        leaf = self._leaf(pk)
+        yield sharded_dir(self._rootdir, pk) / leaf
+        yield self._rootdir / leaf
+
+    def _iter_data_files(self) -> Generator[Path]:
+        """Yield every record file across both layouts, deduped by stem.
+
+        Sharded entries (``_sh/<ab>/<cd>/<pk>.data``) take precedence over a
+        stale legacy twin (``<pk>.data``) should both momentarily exist. The
+        top-level glob matches only legacy files — the ``_sh`` container has no
+        ``.data`` suffix and is not recursed into. See #387.
+        """
+        seen: set[str] = set()
+        for file in self._rootdir.glob(f"{SHARD_ROOT}/*/*/*{self._suffix}"):
+            seen.add(file.stem)
+            yield file
+        for file in self._rootdir.glob(f"*{self._suffix}"):
+            if file.stem not in seen:
+                yield file
 
     def __contains__(self, pk: str):  # ty:ignore[invalid-method-override]
-        path = self._get_path(pk)
-        return path.exists()
+        return any(p.exists() for p in self._candidate_paths(pk))
 
     def __getitem__(self, pk: str) -> ResourceMeta:
-        path = self._get_path(pk)
+        for path in self._candidate_paths(pk):
 
-        def _read() -> bytes:
-            with path.open("rb") as f:
-                return f.read()
+            def _read(p: Path = path) -> bytes:
+                with p.open("rb") as f:
+                    return f.read()
 
-        try:
-            # ESTALE retried inside; ENOENT still maps to KeyError so the
-            # "resource does not exist" contract matches every other meta
-            # store. See #352.
-            raw = retry_on_estale(_read)
-        except FileNotFoundError:
-            raise KeyError(pk) from None
-        return self._serializer.decode(raw)
+            try:
+                # ESTALE retried inside; ENOENT falls through to the next
+                # candidate (sharded -> legacy), and KeyError only if neither
+                # layout has it — matching every other meta store. See #352, #387.
+                raw = retry_on_estale(_read)
+            except FileNotFoundError:
+                continue
+            return self._serializer.decode(raw)
+        raise KeyError(pk)
 
     def __setitem__(self, pk: str, b: ResourceMeta) -> None:
-        path = self._get_path(pk)
+        path = self._write_path(pk)
+        path.parent.mkdir(parents=True, exist_ok=True)
         data = self._serializer.encode(b)
-        # Write to a temp file in the same directory, then atomically rename it
-        # into place. A finalised ``<pk>.data`` therefore always holds a
-        # complete record and acts as the "commit marker": an interrupted write
-        # leaves only the temp file (excluded by the ``*.data`` glob and never
-        # decoded), so it is invisible to the loader instead of crashing boot.
+        # Write to a temp file in the same (shard) directory, then atomically
+        # rename it into place. A finalised ``<pk>.data`` therefore always holds
+        # a complete record and acts as the "commit marker": an interrupted
+        # write leaves only the temp file (excluded by the ``*.data`` glob and
+        # never decoded), so it is invisible to the loader instead of crashing
+        # boot.
         fd, tmp = tempfile.mkstemp(
-            dir=self._rootdir, prefix=f"{pk}.", suffix=".data.tmp"
+            dir=path.parent, prefix=f"{pk}.", suffix=".data.tmp"
         )
         try:
             with os.fdopen(fd, "wb") as f:
@@ -135,24 +168,32 @@ class DiskMetaStore(IFastMetaStore):
             with suppress(FileNotFoundError):
                 os.unlink(tmp)
             raise
+        # Drop any legacy flat twin so the record exists in exactly one place
+        # (write-through migration). See #387.
+        with suppress(FileNotFoundError):
+            (self._rootdir / self._leaf(pk)).unlink()
 
     def __delitem__(self, pk: str) -> None:
-        path = self._get_path(pk)
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            raise KeyError(pk) from None
+        removed = False
+        for path in self._candidate_paths(pk):
+            try:
+                path.unlink()
+                removed = True
+            except FileNotFoundError:
+                continue
+        if not removed:
+            raise KeyError(pk)
 
     def __iter__(self) -> Generator[str]:
-        for file in self._rootdir.glob(f"*{self._suffix}"):
+        for file in self._iter_data_files():
             yield file.stem
 
     def __len__(self) -> int:
-        return len(list(self._rootdir.glob(f"*{self._suffix}")))
+        return sum(1 for _ in self._iter_data_files())
 
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
         results: list[ResourceMeta] = []
-        for file in self._rootdir.glob(f"*{self._suffix}"):
+        for file in self._iter_data_files():
 
             def _read(p: Path = file) -> bytes:
                 with p.open("rb") as f:
@@ -185,3 +226,29 @@ class DiskMetaStore(IFastMetaStore):
         for pk in pks:
             with suppress(FileNotFoundError):
                 del self[pk]
+
+    def migrate_layout(self, *, dry_run: bool = False) -> int:
+        """Relocate pre-#387 flat ``<pk>.data`` records into the sharded tree.
+
+        Walks the legacy flat layout and moves each record into
+        ``_sh/<ab>/<cd>/``. Safe to run on a live store: each move is an
+        atomic ``os.replace`` on the same filesystem and reads fall back to
+        the flat layout until the move lands. Idempotent and re-runnable.
+        Returns the number of records moved (or, when *dry_run*, that would
+        be moved).
+        """
+        moved = 0
+        for child in iter_legacy_children(self._rootdir):
+            if child.is_dir():
+                continue
+            if not child.name.endswith(self._suffix):
+                continue  # skip in-flight ``*.data.tmp`` temp files
+            target = sharded_dir(self._rootdir, child.stem) / child.name
+            if target.exists():
+                continue
+            moved += 1
+            if dry_run:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(child, target)
+        return moved

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -13,6 +13,11 @@ from specstar.resource_manager.basic import (
     MsgspecSerializer,
 )
 from specstar.types import RevisionInfo
+from specstar.util.fanout import (
+    SHARD_ROOT,
+    iter_legacy_children,
+    sharded_dir,
+)
 from specstar.util.fs_retry import retry_on_estale
 
 UID = UUID
@@ -146,8 +151,34 @@ class DiskResourceStore(IResourceStore):
         self._rootdir = Path(rootdir)
         self._rootdir.mkdir(parents=True, exist_ok=True)
 
+    # -- Path helpers -----------------------------------------------------
+    #
+    # Real data lives under ``store/`` keyed by uid; the revision->uid symlink
+    # tree lives under ``resource/`` keyed by resource_id. Both top levels are
+    # sharded (``_sh/<ab>/<cd>/``) so neither accumulates an unbounded number
+    # of entries — NAS per-directory inode/dirent limits. Reads fall back to
+    # the pre-#387 flat layout so existing data keeps working. See #387.
+
+    def _store_root(self) -> Path:
+        return self._rootdir / "store"
+
+    def _resource_root(self) -> Path:
+        return self._rootdir / "resource"
+
     def _get_uid_store_realdir(self, uid: UIDStr) -> Path:
-        return self._rootdir / "store" / uid
+        """Sharded directory new real data for *uid* is written to (#387)."""
+        return sharded_dir(self._store_root(), uid) / uid
+
+    def _realdir_candidates(self, uid: UIDStr) -> Generator[Path]:
+        """Yield real dirs to try: sharded first, then legacy flat (#387)."""
+        yield sharded_dir(self._store_root(), uid) / uid
+        yield self._store_root() / uid
+
+    def _resolve_realdir(self, uid: UIDStr) -> Path:
+        for candidate in self._realdir_candidates(uid):
+            if candidate.exists():
+                return candidate
+        return self._get_uid_store_realdir(uid)
 
     def _get_raw_data_path(self, uid: UIDStr) -> Path:
         return self._get_uid_store_realdir(uid) / "data"
@@ -155,46 +186,85 @@ class DiskResourceStore(IResourceStore):
     def _get_raw_info_path(self, uid: UIDStr) -> Path:
         return self._get_uid_store_realdir(uid) / "info"
 
+    @staticmethod
+    def _p_schema(schema_version: SchemaVersion | None) -> str:
+        return "no_ver" if schema_version is None else f"v_{schema_version}"
+
     def _get_uid_store_symdir(
         self,
         resource_id: ResourceID,
         revision_id: RevisionID,
         schema_version: SchemaVersion | None,
     ) -> Path:
-        if schema_version is None:
-            p_schema_version = "no_ver"
-        else:
-            p_schema_version = f"v_{schema_version}"
-        return self._rootdir / "resource" / resource_id / revision_id / p_schema_version
+        """Sharded symlink path new revisions are written to (#387)."""
+        return (
+            sharded_dir(self._resource_root(), resource_id)
+            / resource_id
+            / revision_id
+            / self._p_schema(schema_version)
+        )
+
+    def _symdir_candidates(
+        self,
+        resource_id: ResourceID,
+        revision_id: RevisionID,
+        schema_version: SchemaVersion | None,
+    ) -> Generator[Path]:
+        """Yield symlink dirs to try: sharded first, then legacy flat (#387)."""
+        p = self._p_schema(schema_version)
+        yield (
+            sharded_dir(self._resource_root(), resource_id)
+            / resource_id
+            / revision_id
+            / p
+        )
+        yield self._resource_root() / resource_id / revision_id / p
+
+    def _rid_dir_candidates(self, resource_id: ResourceID) -> Generator[Path]:
+        """Yield a resource_id's revision-tree dirs across both layouts (#387)."""
+        yield sharded_dir(self._resource_root(), resource_id) / resource_id
+        yield self._resource_root() / resource_id
 
     def list_resources(self) -> Generator[ResourceID]:
-        resource_dir = self._rootdir / "resource"
-        if not resource_dir.exists():
-            return
-        for d in resource_dir.iterdir():
-            if d.is_dir():
+        resource_root = self._resource_root()
+        seen: set[str] = set()
+        # Sharded entries first, then legacy flat children (excluding ``_sh``).
+        for d in resource_root.glob(f"{SHARD_ROOT}/*/*/*"):
+            if d.is_dir() and d.name not in seen:
+                seen.add(d.name)
+                yield d.name
+        for d in iter_legacy_children(resource_root):
+            if d.is_dir() and d.name not in seen:
+                seen.add(d.name)
                 yield d.name
 
     def list_revisions(self, resource_id: ResourceID) -> Generator[RevisionID]:
-        revision_dir = self._rootdir / "resource" / resource_id
-        if not revision_dir.exists():
-            return
-        for d in revision_dir.iterdir():
-            if d.is_dir():
-                yield d.name
+        # A resource_id's revisions may be split across layouts after a partial
+        # migration, so union both candidate trees. See #387.
+        seen: set[str] = set()
+        for rid_dir in self._rid_dir_candidates(resource_id):
+            if not rid_dir.exists():
+                continue
+            for d in rid_dir.iterdir():
+                if d.is_dir() and d.name not in seen:
+                    seen.add(d.name)
+                    yield d.name
 
     def list_schema_versions(
         self, resource_id: ResourceID, revision_id: RevisionID
     ) -> Generator[SchemaVersion | None]:
-        schema_dir = self._rootdir / "resource" / resource_id / revision_id
-        if not schema_dir.exists():
-            return
-        for d in schema_dir.iterdir():
-            if d.is_dir():
-                if d.name == "no_ver":
-                    yield None
-                elif d.name.startswith("v_"):
-                    yield d.name[2:]
+        seen: set[str] = set()
+        for rid_dir in self._rid_dir_candidates(resource_id):
+            schema_dir = rid_dir / revision_id
+            if not schema_dir.exists():
+                continue
+            for d in schema_dir.iterdir():
+                if d.is_dir() and d.name not in seen:
+                    seen.add(d.name)
+                    if d.name == "no_ver":
+                        yield None
+                    elif d.name.startswith("v_"):
+                        yield d.name[2:]
 
     def exists(
         self,
@@ -202,8 +272,27 @@ class DiskResourceStore(IResourceStore):
         revision_id: RevisionID,
         schema_version: SchemaVersion | None,
     ) -> bool:
-        path = self._get_uid_store_symdir(resource_id, revision_id, schema_version)
-        return path.exists()
+        return any(
+            c.exists()
+            for c in self._symdir_candidates(
+                resource_id, revision_id, schema_version
+            )
+        )
+
+    def _resolve_symdir(
+        self,
+        resource_id: ResourceID,
+        revision_id: RevisionID,
+        schema_version: SchemaVersion | None,
+    ) -> Path:
+        for candidate in self._symdir_candidates(
+            resource_id, revision_id, schema_version
+        ):
+            if candidate.exists():
+                return candidate
+        # Default to the sharded path; a subsequent open() raises the same
+        # FileNotFoundError the flat layout would have. See #352, #387.
+        return self._get_uid_store_symdir(resource_id, revision_id, schema_version)
 
     @contextmanager
     def get_data_bytes(
@@ -213,8 +302,7 @@ class DiskResourceStore(IResourceStore):
         schema_version: SchemaVersion | None,
     ) -> Generator[DataIO]:
         data_path = (
-            self._get_uid_store_symdir(resource_id, revision_id, schema_version)
-            / "data"
+            self._resolve_symdir(resource_id, revision_id, schema_version) / "data"
         )
         # ESTALE on NFS — a concurrent rename invalidated our inode cache.
         # Bounded retry resolves it without surfacing OSError to the caller.
@@ -232,8 +320,7 @@ class DiskResourceStore(IResourceStore):
         schema_version: SchemaVersion | None,
     ) -> RevisionInfo:
         info_path = (
-            self._get_uid_store_symdir(resource_id, revision_id, schema_version)
-            / "info"
+            self._resolve_symdir(resource_id, revision_id, schema_version) / "info"
         )
 
         def _read() -> bytes:
@@ -257,6 +344,8 @@ class DiskResourceStore(IResourceStore):
         # FileExistsError or FileNotFoundError on local FS (see #352). Create a
         # uniquely-named tmp symlink, then ``os.replace`` it onto ``symd`` —
         # POSIX guarantees rename of a symlink onto an existing symlink is atomic.
+        # ``relative_walk_up`` recomputes the relative target for the deeper
+        # sharded nesting, keeping the symlink portable across PVC remounts.
         target = relative_walk_up(reald, symd.parent)
         tmp_link = symd.with_name(f"{symd.name}.tmp.{uuid_module.uuid4().hex}")
         try:
@@ -273,6 +362,26 @@ class DiskResourceStore(IResourceStore):
         with self._get_raw_info_path(str(info.uid)).open("wb") as f:
             f.write(self._info_serializer.encode(info))
 
+    def _iter_rid_dirs(self) -> Generator[Path]:
+        """Yield every resource-id revision-tree dir across both layouts."""
+        resource_root = self._resource_root()
+        for d in resource_root.glob(f"{SHARD_ROOT}/*/*/*"):
+            if d.is_dir():
+                yield d
+        for d in iter_legacy_children(resource_root):
+            if d.is_dir():
+                yield d
+
+    def _iter_uid_dirs(self) -> Generator[Path]:
+        """Yield every store uid dir across both layouts."""
+        store_root = self._store_root()
+        for d in store_root.glob(f"{SHARD_ROOT}/*/*/*"):
+            if d.is_dir():
+                yield d
+        for d in iter_legacy_children(store_root):
+            if d.is_dir():
+                yield d
+
     def collect_orphans(self, live_resource_ids: "set[str]") -> int:
         """Remove resource/store dirs not referenced by a finalised meta.
 
@@ -284,62 +393,138 @@ class DiskResourceStore(IResourceStore):
         * ``resource/<id>/`` trees whose id is not in *live_resource_ids*, and
         * ``store/<uid>/`` blobs no longer referenced by any live resource.
 
-        Returns the number of directories removed (resource trees + blobs).
+        Walks both the sharded (#387) and legacy flat layouts. Returns the
+        number of directories removed (resource trees + blobs).
         """
         import shutil
 
         removed = 0
-        resource_root = self._rootdir / "resource"
-        store_root = self._rootdir / "store"
-
         live_uids: set[str] = set()
-        if resource_root.exists():
-            for rid_dir in resource_root.iterdir():
-                if not rid_dir.is_dir():
-                    continue
-                if rid_dir.name in live_resource_ids:
-                    # Record the store blobs this live resource points at so we
-                    # don't reclaim them in the store sweep below.
-                    for rev_dir in rid_dir.iterdir():
-                        if not rev_dir.is_dir():
-                            continue
-                        for ver_link in rev_dir.iterdir():
-                            with suppress(OSError):
-                                live_uids.add(ver_link.resolve().name)
-                else:
-                    shutil.rmtree(rid_dir)
-                    removed += 1
+        for rid_dir in self._iter_rid_dirs():
+            if rid_dir.name in live_resource_ids:
+                # Record the store blobs this live resource points at so we
+                # don't reclaim them in the store sweep below.
+                for rev_dir in rid_dir.iterdir():
+                    if not rev_dir.is_dir():
+                        continue
+                    for ver_link in rev_dir.iterdir():
+                        with suppress(OSError):
+                            live_uids.add(ver_link.resolve().name)
+            else:
+                shutil.rmtree(rid_dir)
+                removed += 1
 
-        if store_root.exists():
-            for uid_dir in store_root.iterdir():
-                if uid_dir.is_dir() and uid_dir.name not in live_uids:
-                    shutil.rmtree(uid_dir)
-                    removed += 1
+        for uid_dir in self._iter_uid_dirs():
+            if uid_dir.name not in live_uids:
+                shutil.rmtree(uid_dir)
+                removed += 1
 
         return removed
 
     def purge_resource(self, resource_id: str) -> None:
-        """Hard-delete all revision data for a resource from disk."""
+        """Hard-delete all revision data for a resource from disk.
+
+        Handles both the sharded (#387) and legacy flat layouts. (The previous
+        implementation looked under ``rootdir/<id>`` instead of
+        ``rootdir/resource/<id>`` and silently purged nothing.)
+        """
         import shutil
 
-        resource_dir = self._rootdir / resource_id
-        if resource_dir.exists():
-            # Collect UIDs to remove from store/ as well
-            uids_to_remove: list[str] = []
+        rid_dirs = [d for d in self._rid_dir_candidates(resource_id) if d.exists()]
+        if not rid_dirs:
+            return
+        # Collect the uids the symlink tree points at before removing it.
+        uids_to_remove: list[str] = []
+        for resource_dir in rid_dirs:
             for revision_dir in resource_dir.iterdir():
                 if not revision_dir.is_dir():
                     continue
                 for schema_dir in revision_dir.iterdir():
                     if not schema_dir.is_dir():
                         continue
-                    # Resolve symlink to get the real directory
-                    real = schema_dir.resolve()
-                    uid = real.name
-                    uids_to_remove.append(uid)
-            # Remove resource symlink tree
+                    with suppress(OSError):
+                        uids_to_remove.append(schema_dir.resolve().name)
+        for resource_dir in rid_dirs:
             shutil.rmtree(resource_dir)
-            # Remove real store data
-            for uid in uids_to_remove:
-                real_dir = self._get_uid_store_realdir(uid)
+        for uid in uids_to_remove:
+            for real_dir in self._realdir_candidates(uid):
                 if real_dir.exists():
                     shutil.rmtree(real_dir)
+
+    def migrate_layout(self, *, dry_run: bool = False) -> int:
+        """Relocate pre-#387 flat resource/store data into the sharded trees.
+
+        Moves ``store/<uid>/`` directories into ``store/_sh/<ab>/<cd>/`` and
+        recreates each ``resource/<rid>/<rev>/<ver>`` symlink under
+        ``resource/_sh/<ab>/<cd>/`` with its relative target recomputed for the
+        new depth. Store dirs are moved first so the recomputed symlink targets
+        point at the already-relocated real data. Idempotent and re-runnable;
+        reads fall back to the flat layout until each move lands.
+
+        Returns the number of entries relocated (store dirs + symlinks), or —
+        when *dry_run* — that would be relocated.
+        """
+        moved = 0
+        store_root = self._store_root()
+        resource_root = self._resource_root()
+
+        # 1. store/<uid> -> store/_sh/<ab>/<cd>/<uid>
+        for child in iter_legacy_children(store_root):
+            if not child.is_dir():
+                continue
+            target = sharded_dir(store_root, child.name) / child.name
+            if target.exists():
+                continue
+            moved += 1
+            if dry_run:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(child, target)
+
+        # 2. resource/<rid>/<rev>/<ver> symlink -> sharded, target recomputed.
+        for rid_dir in list(iter_legacy_children(resource_root)):
+            if not rid_dir.is_dir():
+                continue
+            rid = rid_dir.name
+            for rev_dir in list(rid_dir.iterdir()):
+                if not rev_dir.is_dir():
+                    continue
+                rev = rev_dir.name
+                for ver_link in list(rev_dir.iterdir()):
+                    ver = ver_link.name
+                    new_symdir = (
+                        sharded_dir(resource_root, rid) / rid / rev / ver
+                    )
+                    if new_symdir.exists():
+                        continue
+                    # ``resolve().name`` yields the uid even if the legacy
+                    # relative target is now dangling (store dir already moved).
+                    try:
+                        uid = ver_link.resolve().name
+                    except OSError:
+                        continue
+                    moved += 1
+                    if dry_run:
+                        continue
+                    realdir = self._resolve_realdir(uid)
+                    new_symdir.parent.mkdir(parents=True, exist_ok=True)
+                    target = relative_walk_up(realdir, new_symdir.parent)
+                    tmp_link = new_symdir.with_name(
+                        f"{ver}.tmp.{uuid_module.uuid4().hex}"
+                    )
+                    try:
+                        tmp_link.symlink_to(target, target_is_directory=True)
+                        os.replace(tmp_link, new_symdir)
+                    except BaseException:
+                        with suppress(FileNotFoundError):
+                            tmp_link.unlink()
+                        raise
+                    ver_link.unlink()
+            if not dry_run:
+                # Prune the now-empty legacy revision dirs and rid dir.
+                for rev_dir in list(rid_dir.iterdir()):
+                    with suppress(OSError):
+                        rev_dir.rmdir()
+                with suppress(OSError):
+                    rid_dir.rmdir()
+        return moved

--- a/specstar/util/fanout.py
+++ b/specstar/util/fanout.py
@@ -1,0 +1,89 @@
+"""Filesystem fanout (sharding) helpers — see #387.
+
+Disk-backed stores historically wrote every object as a sibling directly
+under one root directory (``root/<name>``). At scale this puts millions of
+entries in a single directory, which on NAS / networked filesystems hits
+per-directory inode / dirent limits and degrades lookups.
+
+The fix spreads objects across a fixed two-level subdirectory tree rooted at
+a reserved container segment::
+
+    <root>/_sh/<ab>/<cd>/<name>
+
+The ``<ab>``/``<cd>`` prefix comes from a fresh ``xxh3`` hash of the *leaf
+name*, so the distribution is uniform whether the name is itself a content
+hash (already uniform) or a caller-supplied key / slug (arbitrary, possibly
+clustered). Both the writer and any later reader hold the leaf name, so the
+prefix is fully recomputable and deterministic — no marker file needed.
+
+Two-level × 2 hex = 65,536 leaf directories: every level (including the
+intermediates) stays ``<= 256`` children, and even at 100M objects a leaf
+holds only ~1.5k entries. The geometry is a fixed module constant on
+purpose — making it a per-store parameter would let an operator change the
+scheme after data exists, at which point old objects become unreachable
+because their shard path no longer computes.
+
+The reserved container segment :data:`SHARD_ROOT` ("_sh") gives every store a
+single, unambiguous rule for telling sharded data apart from pre-fanout
+("legacy") data during enumeration and migration: anything under ``_sh/`` is
+sharded; every other top-level entry is legacy. ``_sh`` is therefore a
+reserved name — a resource_id / blob key / pk equal to ``"_sh"`` is not
+supported (the default ``resource_id`` carries a ``:`` and never collides).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from xxhash import xxh3_128_hexdigest
+
+#: Reserved directory name under each store root that contains the sharded tree.
+SHARD_ROOT = "_sh"
+
+#: Number of nested prefix directories (``_sh/<ab>/<cd>`` -> 2).
+SHARD_LEVELS = 2
+
+#: Hex characters consumed per prefix level (2 -> 256 buckets/level).
+SHARD_HEX_PER_LEVEL = 2
+
+
+def shard_segments(name: str) -> tuple[str, ...]:
+    """Return the prefix segments for *name*, e.g. ``("ab", "cd")``.
+
+    Derived from a fresh ``xxh3`` hash of *name* so the spread is uniform
+    regardless of the name's own shape.
+    """
+    digest = xxh3_128_hexdigest(name.encode("utf-8"))
+    width = SHARD_HEX_PER_LEVEL
+    return tuple(digest[i * width : (i + 1) * width] for i in range(SHARD_LEVELS))
+
+
+def sharded_dir(root: Path, name: str) -> Path:
+    """Return the sharded directory under *root* that holds *name*.
+
+    ``<root>/_sh/<ab>/<cd>``.
+    """
+    directory = root / SHARD_ROOT
+    for segment in shard_segments(name):
+        directory = directory / segment
+    return directory
+
+
+def sharded_path(root: Path, name: str) -> Path:
+    """Return the full sharded leaf path ``<root>/_sh/<ab>/<cd>/<name>``."""
+    return sharded_dir(root, name) / name
+
+
+def iter_legacy_children(root: Path):
+    """Yield top-level entries under *root* that are not the shard container.
+
+    Used by migration and by enumeration fallbacks to walk pre-fanout data
+    without descending into the sharded tree. Yields nothing if *root* does
+    not exist.
+    """
+    if not root.exists():
+        return
+    for child in root.iterdir():
+        if child.name == SHARD_ROOT:
+            continue
+        yield child

--- a/tests/meta_store/test_disk_crash_safety.py
+++ b/tests/meta_store/test_disk_crash_safety.py
@@ -23,6 +23,7 @@ from specstar.resource_manager.core import (
 from specstar.resource_manager.meta_store.simple import DiskMetaStore
 from specstar.resource_manager.resource_store.simple import DiskResourceStore
 from specstar.types import ResourceIDNotFoundError, ResourceMeta
+from specstar.util.fanout import sharded_dir
 
 faker = Faker()
 
@@ -125,7 +126,7 @@ def test_interrupted_create_meta_missing_is_invisible(my_tmpdir: Path):
 
         # Drop only the finalised meta marker, leaving the resource dir behind
         # — exactly the on-disk shape of an aborted create().
-        (meta_dir / f"{rid}.data").unlink()
+        (sharded_dir(meta_dir, rid) / f"{rid}.data").unlink()
 
         with pytest.raises(ResourceIDNotFoundError):
             mgr.get_meta(rid)
@@ -147,7 +148,7 @@ def test_toctou_meta_vanishes_after_exists_check(my_tmpdir: Path, monkeypatch):
 
         # Force the stale "it exists" answer, then make the file truly absent.
         monkeypatch.setattr(mgr.storage, "exists", lambda _rid: True)
-        (meta_dir / f"{rid}.data").unlink()
+        (sharded_dir(meta_dir, rid) / f"{rid}.data").unlink()
 
         with pytest.raises(ResourceIDNotFoundError):
             mgr.get_meta(rid)
@@ -249,10 +250,11 @@ def test_collect_orphans_removes_unreferenced_data(my_tmpdir: Path):
         orphan = _create(mgr, Data(name="drop", age=2))
 
         # Make `orphan` an aborted create: drop its meta, keep data/resource.
-        (meta_dir / f"{orphan.resource_id}.data").unlink()
+        rid = orphan.resource_id
+        (sharded_dir(meta_dir, rid) / f"{rid}.data").unlink()
 
-        orphan_res = res_dir / "resource" / orphan.resource_id
-        orphan_blob = res_dir / "store" / str(orphan.uid)
+        orphan_res = sharded_dir(res_dir / "resource", rid) / rid
+        orphan_blob = sharded_dir(res_dir / "store", str(orphan.uid)) / str(orphan.uid)
         assert orphan_res.exists() and orphan_blob.exists()
 
         removed = mgr.collect_orphans()
@@ -262,7 +264,9 @@ def test_collect_orphans_removes_unreferenced_data(my_tmpdir: Path):
         assert not orphan_blob.exists()
         # The live resource is untouched and still readable.
         assert mgr.get(live.resource_id).data.name == "keep"
-        assert (res_dir / "store" / str(live.uid)).exists()
+        assert (
+            sharded_dir(res_dir / "store", str(live.uid)) / str(live.uid)
+        ).exists()
 
 
 def test_collect_orphans_noop_when_clean(my_tmpdir: Path):

--- a/tests/test_disk_blob_store_raw_storage.py
+++ b/tests/test_disk_blob_store_raw_storage.py
@@ -6,6 +6,7 @@ zero-copy finalization via file rename.
 """
 
 from specstar.resource_manager.blob_store.simple import DiskBlobStore
+from specstar.util.fanout import sharded_dir, sharded_path
 
 
 class TestDiskBlobStoreRawStorage:
@@ -18,7 +19,7 @@ class TestDiskBlobStoreRawStorage:
         result = store.put(data)
 
         safe_name = result.file_id.replace("/", "_").replace("..", "_")  # ty:ignore[unresolved-attribute]
-        blob_path = tmp_path / safe_name
+        blob_path = sharded_path(tmp_path, safe_name)
         assert blob_path.read_bytes() == data
 
     def test_put_writes_metadata_sidecar(self, tmp_path):
@@ -28,7 +29,7 @@ class TestDiskBlobStoreRawStorage:
         result = store.put(data, content_type="text/plain")
 
         safe_name = result.file_id.replace("/", "_").replace("..", "_")  # ty:ignore[unresolved-attribute]
-        meta_path = tmp_path / f"{safe_name}.blobmeta"
+        meta_path = sharded_dir(tmp_path, safe_name) / f"{safe_name}.blobmeta"
         assert meta_path.exists()
 
     def test_put_get_roundtrip(self, tmp_path):
@@ -79,7 +80,7 @@ class TestDiskBlobStoreRawStorage:
         result = store.finalize_upload_session(session.upload_id)
 
         safe_name = result.file_id.replace("/", "_").replace("..", "_")  # ty:ignore[unresolved-attribute]
-        blob_path = tmp_path / safe_name
+        blob_path = sharded_path(tmp_path, safe_name)
         # The blob file should contain raw bytes, NOT msgpack-encoded Binary
         assert blob_path.read_bytes() == data
 
@@ -99,7 +100,7 @@ class TestDiskBlobStoreRawStorage:
         result = store.finalize_upload_session(session.upload_id)
         assert result.file_id == "blob-key"
 
-        blob_path = tmp_path / "blob-key"
+        blob_path = sharded_path(tmp_path, "blob-key")
         # Same inode = renamed, not copied via read+write
         assert blob_path.stat().st_ino == data_inode
 

--- a/tests/test_disk_fanout_layout.py
+++ b/tests/test_disk_fanout_layout.py
@@ -1,0 +1,387 @@
+"""Fanout (sharding) layout for disk-backed stores — see #387.
+
+These are pure local-filesystem unit tests (``tmp_path``) and must stay in
+the fast CI lane, so the filename deliberately avoids the integration globs
+in ``tests/conftest.py`` (``test_postgres_*`` etc.).
+"""
+
+from pathlib import Path
+
+from specstar.resource_manager.blob_store.simple import (
+    DiskBlobStore,
+    _DiskBlobMeta,
+)
+from specstar.util.fanout import (
+    SHARD_HEX_PER_LEVEL,
+    SHARD_LEVELS,
+    SHARD_ROOT,
+    shard_segments,
+    sharded_dir,
+    sharded_path,
+)
+
+
+def _seed_legacy_blob(store, root, name, data, content_type="text/plain"):
+    """Write a blob in the pre-#387 flat layout: raw file + sidecar at root."""
+    (root / name).write_bytes(data)
+    meta = _DiskBlobMeta(file_id=name, size=len(data), content_type=content_type)
+    (root / f"{name}.blobmeta").write_bytes(store.encoder.encode(meta))
+
+
+# ---------------------------------------------------------------------------
+# helper
+# ---------------------------------------------------------------------------
+
+
+def test_shard_segments_shape_and_determinism():
+    segs = shard_segments("hello-world")
+    assert len(segs) == SHARD_LEVELS
+    assert all(len(s) == SHARD_HEX_PER_LEVEL for s in segs)
+    assert all(c in "0123456789abcdef" for s in segs for c in s)
+    # deterministic
+    assert shard_segments("hello-world") == segs
+
+
+def test_shard_segments_spread():
+    # Distinct names should not all collapse to one bucket.
+    buckets = {shard_segments(f"name-{i}") for i in range(500)}
+    assert len(buckets) > 100
+
+
+def test_sharded_path_under_reserved_container(tmp_path: Path):
+    p = sharded_path(tmp_path, "abc")
+    assert p.parent.parent.parent.name == SHARD_ROOT
+    assert p.name == "abc"
+    assert p.relative_to(tmp_path).parts[0] == SHARD_ROOT
+
+
+# ---------------------------------------------------------------------------
+# blob store: write lands sharded, round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_blob_put_lands_under_shard(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    b = store.put(b"payload", key="my-key")
+    leaf = sharded_path(tmp_path, "my-key")
+    assert leaf.exists(), "blob should be written into the sharded tree"
+    # sidecar lives in the SAME shard directory
+    assert (leaf.parent / "my-key.blobmeta").exists()
+    # nothing left flat at the root (besides the _sh container / _sessions)
+    flat = [
+        c.name
+        for c in tmp_path.iterdir()
+        if c.is_file() and not c.name.endswith(".tmp")
+    ]
+    assert flat == []
+    # round-trips
+    assert store.get(b.file_id).data == b"payload"
+    assert store.exists("my-key")
+
+
+def test_blob_put_spreads_across_buckets(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    for i in range(300):
+        store.put(f"data-{i}".encode(), key=f"key-{i}")
+    shard_root = tmp_path / SHARD_ROOT
+    level1 = [d for d in shard_root.iterdir() if d.is_dir()]
+    assert len(level1) > 20, "objects should spread across many buckets"
+
+
+def test_blob_get_stream_sharded(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    store.put(b"streamed-bytes", key="sk")
+    info = store.get_stream("sk")
+    assert b"".join(info.iterator) == b"streamed-bytes"
+
+
+# ---------------------------------------------------------------------------
+# blob store: legacy (pre-fanout, flat) read fallback
+# ---------------------------------------------------------------------------
+
+
+def test_blob_reads_legacy_flat_layout(tmp_path: Path):
+    # Simulate a pre-#387 store: blob written flat at the root (+ sidecar).
+    store = DiskBlobStore(tmp_path)
+    _seed_legacy_blob(store, tmp_path, "legacy", b"old-data", "application/x-test")
+    assert store.exists("legacy")
+    got = store.get("legacy")
+    assert got.data == b"old-data"
+    assert got.content_type == "application/x-test"
+    info = store.get_stream("legacy")
+    assert b"".join(info.iterator) == b"old-data"
+    assert info.content_type == "application/x-test"
+
+
+# ---------------------------------------------------------------------------
+# blob store: migration
+# ---------------------------------------------------------------------------
+
+
+def test_blob_migrate_layout_moves_legacy(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    # Seed legacy flat blobs (raw file + sidecar each).
+    _seed_legacy_blob(store, tmp_path, "a", b"AAA")
+    _seed_legacy_blob(store, tmp_path, "b", b"BBB")
+
+    moved = store.migrate_layout()
+    assert moved == 2  # sidecars move with their blob, not counted separately
+
+    # Data + sidecars now live under the shard tree and still read back.
+    assert sharded_path(tmp_path, "a").exists()
+    assert sharded_path(tmp_path, "b").exists()
+    assert (sharded_path(tmp_path, "a").parent / "a.blobmeta").exists()
+    assert not (tmp_path / "a").exists()
+    assert not (tmp_path / "a.blobmeta").exists()
+    assert store.get("a").data == b"AAA"
+    assert store.get("b").data == b"BBB"
+
+    # Idempotent: a second run moves nothing.
+    assert store.migrate_layout() == 0
+
+
+def test_blob_migrate_layout_dry_run(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    (tmp_path / "x").write_bytes(b"XXX")
+    would = store.migrate_layout(dry_run=True)
+    assert would == 1
+    # nothing actually moved
+    assert (tmp_path / "x").exists()
+    assert not sharded_path(tmp_path, "x").exists()
+
+
+def test_blob_half_migrated_store_still_reads(tmp_path: Path):
+    store = DiskBlobStore(tmp_path)
+    # one sharded, one legacy
+    store.put(b"new", key="fresh")
+    _seed_legacy_blob(store, tmp_path, "stale", b"old")
+    assert store.get("fresh").data == b"new"
+    assert store.get("stale").data == b"old"
+
+
+# ---------------------------------------------------------------------------
+# meta store
+# ---------------------------------------------------------------------------
+
+from datetime import datetime  # noqa: E402
+
+from specstar.query_types import ResourceMetaSearchQuery  # noqa: E402
+from specstar.resource_manager.meta_store.simple import DiskMetaStore  # noqa: E402
+from specstar.types import ResourceMeta  # noqa: E402
+
+_T = datetime(2026, 1, 1)
+
+
+def _meta(resource_id: str) -> ResourceMeta:
+    return ResourceMeta(
+        current_revision_id=f"{resource_id}:1",
+        resource_id=resource_id,
+        total_revision_count=1,
+        created_time=_T,
+        updated_time=_T,
+        created_by="u",
+        updated_by="u",
+    )
+
+
+def _disk_meta(tmp_path: Path) -> DiskMetaStore:
+    return DiskMetaStore(encoding="msgpack", rootdir=tmp_path)  # ty:ignore[invalid-argument-type]
+
+
+def test_meta_setitem_lands_under_shard(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    store["user:1"] = _meta("user:1")
+    leaf = sharded_path(tmp_path, "user:1").with_name("user:1.data")
+    assert leaf.exists()
+    # nothing flat at the root
+    assert [c.name for c in tmp_path.iterdir() if c.is_file()] == []
+    # round-trips
+    assert "user:1" in store
+    assert store["user:1"].resource_id == "user:1"
+
+
+def test_meta_iter_and_len_spread(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    for i in range(200):
+        store[f"r:{i}"] = _meta(f"r:{i}")
+    assert len(store) == 200
+    assert set(store) == {f"r:{i}" for i in range(200)}
+    shard_root = tmp_path / SHARD_ROOT
+    assert len([d for d in shard_root.iterdir() if d.is_dir()]) > 15
+
+
+def test_meta_reads_legacy_flat_layout(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    # Seed a pre-#387 flat record directly.
+    legacy = tmp_path / "old:1.data"
+    legacy.write_bytes(store._serializer.encode(_meta("old:1")))
+    assert "old:1" in store
+    assert store["old:1"].resource_id == "old:1"
+    assert "old:1" in set(store)
+    assert len(store) == 1
+
+
+def test_meta_iter_search_across_layouts(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    (tmp_path / "leg:1.data").write_bytes(store._serializer.encode(_meta("leg:1")))
+    store["new:1"] = _meta("new:1")
+    found = {m.resource_id for m in store.iter_search(ResourceMetaSearchQuery())}
+    assert found == {"leg:1", "new:1"}
+
+
+def test_meta_migrate_layout(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    (tmp_path / "a:1.data").write_bytes(store._serializer.encode(_meta("a:1")))
+    (tmp_path / "b:1.data").write_bytes(store._serializer.encode(_meta("b:1")))
+    assert store.migrate_layout(dry_run=True) == 2
+    assert (tmp_path / "a:1.data").exists()  # dry-run moved nothing
+
+    assert store.migrate_layout() == 2
+    assert sharded_path(tmp_path, "a:1").with_name("a:1.data").exists()
+    assert not (tmp_path / "a:1.data").exists()
+    assert store["a:1"].resource_id == "a:1"
+    assert store.migrate_layout() == 0  # idempotent
+
+
+def test_meta_setitem_clears_legacy_twin(tmp_path: Path):
+    store = _disk_meta(tmp_path)
+    (tmp_path / "k:1.data").write_bytes(store._serializer.encode(_meta("k:1")))
+    store["k:1"] = _meta("k:1")  # write-through should drop the flat twin
+    assert not (tmp_path / "k:1.data").exists()
+    assert len(store) == 1
+    del store["k:1"]
+    assert "k:1" not in store
+
+
+# ---------------------------------------------------------------------------
+# resource store
+# ---------------------------------------------------------------------------
+
+import io  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+from specstar.resource_manager.resource_store.simple import (  # noqa: E402
+    DiskResourceStore,
+    relative_walk_up,
+)
+from specstar.types import RevisionInfo, RevisionStatus  # noqa: E402
+
+
+def _rev_info(rid: str, rev: str, uid, sv="1.0") -> RevisionInfo:
+    return RevisionInfo(
+        uid=uid,
+        resource_id=rid,
+        revision_id=rev,
+        schema_version=sv,
+        status=RevisionStatus.stable,
+        created_time=_T,
+        updated_time=_T,
+        created_by="u",
+        updated_by="u",
+        parent_revision_id=None,
+        data_hash="h",
+    )
+
+
+def _disk_resource(tmp_path: Path) -> DiskResourceStore:
+    return DiskResourceStore(encoding="msgpack", rootdir=tmp_path)  # ty:ignore[invalid-argument-type]
+
+
+def _seed_legacy_revision(store, root, rid, rev, uid, data, sv="1.0"):
+    """Recreate the pre-#387 flat resource layout by hand."""
+    p_sv = "no_ver" if sv is None else f"v_{sv}"
+    reald = root / "store" / str(uid)
+    reald.mkdir(parents=True, exist_ok=True)
+    (reald / "data").write_bytes(data)
+    (reald / "info").write_bytes(
+        store._info_serializer.encode(_rev_info(rid, rev, uid, sv))
+    )
+    symd = root / "resource" / rid / rev / p_sv
+    symd.parent.mkdir(parents=True, exist_ok=True)
+    symd.symlink_to(
+        relative_walk_up(reald, symd.parent), target_is_directory=True
+    )
+
+
+def test_resource_save_lands_sharded_and_roundtrips(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    uid = uuid4()
+    info = _rev_info("res:1", "res:1:1", uid)
+    store.save(info, io.BytesIO(b'{"v":1}'))
+
+    # symlink under sharded resource/, real data under sharded store/
+    symd = sharded_dir(tmp_path / "resource", "res:1") / "res:1" / "res:1:1" / "v_1.0"
+    assert symd.is_symlink()
+    reald = sharded_dir(tmp_path / "store", str(uid)) / str(uid)
+    assert (reald / "data").exists()
+    # nothing flat
+    assert [c.name for c in (tmp_path / "store").iterdir()] == [SHARD_ROOT]
+
+    assert store.exists("res:1", "res:1:1", "1.0")
+    with store.get_data_bytes("res:1", "res:1:1", "1.0") as f:
+        assert f.read() == b'{"v":1}'
+    assert store.get_revision_info("res:1", "res:1:1", "1.0").uid == uid
+
+
+def test_resource_listings_sharded(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    for i in range(60):
+        store.save(_rev_info(f"r:{i}", f"r:{i}:1", uuid4()), io.BytesIO(b"x"))
+    assert set(store.list_resources()) == {f"r:{i}" for i in range(60)}
+    assert list(store.list_revisions("r:3")) == ["r:3:1"]
+    assert list(store.list_schema_versions("r:3", "r:3:1")) == ["1.0"]
+
+
+def test_resource_reads_legacy_flat_layout(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    _seed_legacy_revision(store, tmp_path, "old:1", "old:1:1", uuid4(), b"LEGACY")
+    assert store.exists("old:1", "old:1:1", "1.0")
+    assert list(store.list_resources()) == ["old:1"]
+    assert list(store.list_revisions("old:1")) == ["old:1:1"]
+    with store.get_data_bytes("old:1", "old:1:1", "1.0") as f:
+        assert f.read() == b"LEGACY"
+
+
+def test_resource_migrate_layout(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    uid = uuid4()
+    _seed_legacy_revision(store, tmp_path, "m:1", "m:1:1", uid, b"DATA")
+
+    assert store.migrate_layout(dry_run=True) == 2  # 1 store dir + 1 symlink
+    assert (tmp_path / "store" / str(uid)).exists()  # dry-run moved nothing
+
+    assert store.migrate_layout() == 2
+    # legacy trees drained
+    assert not (tmp_path / "store" / str(uid)).exists()
+    assert not (tmp_path / "resource" / "m:1").exists()
+    # sharded data present and symlink resolves through to it
+    reald = sharded_dir(tmp_path / "store", str(uid)) / str(uid)
+    assert (reald / "data").read_bytes() == b"DATA"
+    with store.get_data_bytes("m:1", "m:1:1", "1.0") as f:
+        assert f.read() == b"DATA"
+    assert store.migrate_layout() == 0  # idempotent
+
+
+def test_resource_collect_orphans_across_layouts(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    live_uid = uuid4()
+    store.save(_rev_info("live:1", "live:1:1", live_uid), io.BytesIO(b"L"))
+    orphan_uid = uuid4()
+    store.save(_rev_info("dead:1", "dead:1:1", orphan_uid), io.BytesIO(b"D"))
+
+    removed = store.collect_orphans({"live:1"})
+    assert removed >= 1
+    assert store.exists("live:1", "live:1:1", "1.0")
+    assert not store.exists("dead:1", "dead:1:1", "1.0")
+    # the orphan's real data is reclaimed too
+    assert not (sharded_dir(tmp_path / "store", str(orphan_uid)) / str(orphan_uid)).exists()
+
+
+def test_resource_purge_resource(tmp_path: Path):
+    store = _disk_resource(tmp_path)
+    uid = uuid4()
+    store.save(_rev_info("p:1", "p:1:1", uid), io.BytesIO(b"P"))
+    assert store.exists("p:1", "p:1:1", "1.0")
+    store.purge_resource("p:1")
+    assert not store.exists("p:1", "p:1:1", "1.0")
+    assert not (sharded_dir(tmp_path / "store", str(uid)) / str(uid)).exists()

--- a/tests/test_fs_retry.py
+++ b/tests/test_fs_retry.py
@@ -32,6 +32,7 @@ from specstar.resource_manager.blob_store.simple import DiskBlobStore
 from specstar.resource_manager.meta_store.simple import DiskMetaStore
 from specstar.resource_manager.resource_store.simple import DiskResourceStore
 from specstar.types import ResourceMeta, RevisionInfo, RevisionStatus
+from specstar.util.fanout import sharded_path
 
 faker = Faker()
 
@@ -437,7 +438,7 @@ def test_blob_get_translates_toctou_race_to_controlled_error(
 
     # Force the exists() check to lie, then make the file truly absent.
     monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
-    (tmpdir_path / "race-key").unlink()
+    sharded_path(tmpdir_path, "race-key").unlink()
 
     with pytest.raises(FileNotFoundError) as exc_info:
         store.get(stored.file_id)
@@ -458,7 +459,7 @@ def test_blob_get_stream_translates_toctou_race_to_controlled_error(
     stored = store.put(b"payload", key="race-stream-key")
 
     monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
-    (tmpdir_path / "race-stream-key").unlink()
+    sharded_path(tmpdir_path, "race-stream-key").unlink()
 
     with pytest.raises(FileNotFoundError) as exc_info:
         store.get_stream(stored.file_id)
@@ -482,7 +483,7 @@ def test_load_session_meta_translates_toctou_race_to_controlled_error(
     upload_id = session.upload_id
 
     monkeypatch.setattr(pathlib.Path, "exists", lambda self: True)
-    (tmpdir_path / "_sessions" / f"{upload_id}.meta").unlink()
+    store._session_meta_path(upload_id).unlink()
 
     with pytest.raises(FileNotFoundError) as exc_info:
         store._load_session_meta(upload_id)


### PR DESCRIPTION
Fixes #387.

## Problem
The three disk-backed stores (`DiskBlobStore`, `DiskMetaStore`, `DiskResourceStore`) wrote every object **flat** under one root directory. At scale this puts millions of entries in a single directory, hitting NAS / networked-filesystem **per-directory inode/dirent limits**.

## Fix
Spread objects across a fixed **2-level × 256** subdirectory tree under a reserved container segment:

```
<root>/_sh/<ab>/<cd>/<name>
```

- Prefix = `xxh3(leaf_name)` first 4 hex → uniform whether the name is a content hash or a caller-supplied key/slug.
- Geometry is a fixed module constant (`specstar/util/fanout.py`) — the scheme can never drift after data exists.
- The reserved `_sh/` container gives one unambiguous rule for telling sharded data from pre-fanout ("legacy") data during enumeration/migration, even when a custom `id_generator` emits a 2-hex `resource_id`.

## Backward compatibility
- **Reads fall back** sharded → legacy flat, so existing deployments keep working with **no migration step required**.
- Each store gains `migrate_layout(dry_run=False)` to relocate legacy data: idempotent, crash-safe (atomic `os.replace`), re-runnable. **No** auto-migrate on boot (that would re-introduce the very inode scan this fixes).

## Per-store notes
- **Resource store**: both `store/` (uid) and `resource/` (rid) trees are sharded; symlink targets recomputed for the deeper nesting via `relative_walk_up`. Also fixes a latent bug where `purge_resource` looked under `rootdir/<id>` (missing the `resource/` segment) and silently purged nothing.
- **Upload sessions**: each upload owns a sharded per-session directory (`_sessions/_sh/<ab>/<cd>/<upload_id>/`). finalize/abort delete the bulk (`data`/`part.*`); `meta`/`lock` are **retained on purpose** — `meta` is the cross-instance finalized/aborted status SSOT (covered by `test_finalized_status_visible_cross_instance`) and a live `flock` anchor cannot be safely unlinked. Sharding bounds the per-directory count instead.

## Tests
- New `tests/test_disk_fanout_layout.py` (22 cases across blob/meta/resource): round-trip, distribution, legacy fallback, migration idempotency + dry-run + half-migrated reads, symlink resolution, `collect_orphans`, `purge`. Named to stay in the fast CI lane.
- Existing layout-coupled tests updated to the sharded paths (raw_storage, 3× fs_retry TOCTOU, crash_safety).
- Full fast (non-integration) suite: **3094 passed / 0 failed** locally.

## Out of scope / follow-up
`resource_store/cache.py` `DiskCache` (an evictable S3 cache) is still flat-keyed `cache_dir/<resource_id>/` — same latent pattern, lower urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)