### PR TITLE
feat(blob): ref-count GC to reclaim unreferenced blobs (#370)

### DIFF
--- a/docs/design/blob-refcount-gc.md
+++ b/docs/design/blob-refcount-gc.md
@@ -1,0 +1,200 @@
+# Blob Ref-Count 與歸零回收設計
+
+> **狀態**:Phase 1(reconcile 核心)+ Phase 2(incremental 優化)均已實作並測試
+> **日期**:2026-06-26
+> **Issue**:[#370](https://github.com/HYChou0515/autocrud/issues/370) — 「binary 需要紀錄 ref count 並在歸零時 remove」
+> **背景**:blob 內容定址去重、跨 model 共用、且目前**永不刪除**。`permanently_delete` 清掉 revision 後,只被該 resource 引用的 blob 變成 orphan 卻仍留在 store,儲存空間無限膨脹。本文件是這個回收機制的設計決議,供實作參考。
+
+## 實作進度
+
+**Phase 1 — reconcile 核心(已完成):**
+
+- `IBlobStore` 新增原語:`delete`、`quarantine`、`restore_from_quarantine`、
+  `iter_quarantined`、`iter_active`、`get_mtime`,以及 `get`/`exists` 在活躍區 miss 時
+  fall-through 隔離區。三個 backend(Memory/Disk/S3)全數實作。
+- `ResourceManager.collect_all_referenced_file_ids()`:權威重掃,回傳 `(file_ids, complete)`。
+- `SpecStar.gc(mode="reconcile", t1, t2, now)`:跨 model live 聯集 → T1 freshness gate →
+  可逆隔離 → restore 被引用者 → 隔離待過 T2 且 scan 完整才 unlink。回傳 `GcStats`。
+
+**Phase 2 — incremental 優化(已完成):**
+
+- `IBlobStore` 再加 `incref`、`decref`、`touch`、`iter_orphan_candidates`(後者由
+  `BasicBlobStore` 提供共用實作)。candidate 集合為**行程內、盡力、非持久**,由
+  `decref` 歸零時填入、`incref`/`quarantine`/`delete` 清除。
+- 接線:`permanently_delete` 先對自己 resource 的每個 (revision, file_id) `decref`;
+  寫入路徑 `_process_binary_fields` 對每個 (revision, file_id) 做
+  resurrection + `incref` + `touch`(全 best-effort try/except,絕不讓記帳搞垮寫入)。
+- `SpecStar.gc(mode="incremental", t1, now)`:只掃 candidate 集合(不掃 revision),
+  對 age>T1 者 `quarantine`,**從不 unlink**。
+- 測試:blob store 契約(touch/candidate)+ crud 端到端(incremental 隔離→reconcile 刪除、
+  count 驅動跳過仍被引用者、寫入路徑即時 resurrection)。
+
+> **與 #387 的潛在衝突**:#387 將 disk store 改為 `_sh/<ab>/<cd>/` sharding。本實作的
+> Disk `iter_active`/隔離區/`.refcount`/`.blobmeta` 假設 flat layout;合併時需讓
+> `iter_active` 掃進 sharded 子目錄、並把 `_quarantine/`/`_refcount/` 與 `_sh/` 的
+> reserved 前綴對齊。
+
+---
+
+## 1. 問題與約束
+
+現況(已從程式碼確認):
+
+- **內容定址 + 去重**:`put(data)` 用 `xxh3_128` hash 當 `file_id`(`blob_store/simple.py`、`s3.py`)。相同內容在不同 resource / revision / model 都對映到**同一個 blob**。
+- **`IBlobStore` 沒有 delete**:blob 至今永不刪除(`resource_manager/basic.py`)。
+- **revision 不可變、從不單獨刪除或 pruning**:唯一會丟掉 blob 引用的操作是 `permanently_delete(resource_id)` → `purge_resource`(清掉該 resource 的所有 revision)。soft delete 不動 revision,因此不產生 orphan。
+- **`BinaryProcessor.collect_file_ids()` 已存在**:目前只用在 `dump()` 匯出。可直接複用來推導引用集合。
+- **blob store 跨所有 model 共用**:`crud/core.py` 把**同一個 `self.blob_store`** 傳給每一個 model 的 `ResourceManager`。
+
+三個關鍵約束塑造了整個設計:
+
+1. **去重**:同一份 bytes 處處同一個 `file_id`,所以即使 `put` 因去重變成 no-op,也得記一次引用。
+2. **唯一減少引用的事件**:`permanently_delete`。
+3. **沒有原子計數器原語**(尤其純 S3 無法原子自增)。
+
+---
+
+## 2. 核心取捨:近似計數 + 權威推導
+
+**不做精確的原子計數。** 改採 hybrid:
+
+- **近似 count**(盡力、非原子)當**便宜的預篩**——只負責快速篩出「orphan 嫌疑犯」。
+- **權威真相一律靠重掃 revision 資料**(複用 `collect_file_ids`)當場推導——這是去重後唯一可信的 ground truth。
+
+決定性的不對稱性:
+
+> **洩漏(blob 該刪沒刪)可被下次掃描回收;誤刪(blob 還被引用卻刪了)是不可復原的資料遺失。**
+
+因此硬約束:**近似 count 永遠不能單獨授權「真正的 unlink」。** count 只是嫌疑犯名單,任何不可逆的刪除前都必須通過權威推導。
+
+> 為什麼不維護反向索引(`file_id → 引用它的 revisions`)?因為精確索引的基數本身就是精確 count,等於把我們想避開的原子化負擔搬回來。權威真相一律當場重掃,索引免維護。
+
+---
+
+## 3. 生命週期
+
+```
+[活躍區]  put / 引用時 touch 刷新 mtime;引用時 incref(盡力、非原子)
+   │  permanently_delete(rid):
+   │     對「自己這個 resource 的 revisions」collect_file_ids → 逐個 decref(盡力)
+   │     降到 <=0 者丟進 pending-candidates 集合      ← 熱路徑到此為止,極快
+   │
+   │  ===== gc(incremental):便宜、不掃 revision =====
+   │     只看 pending 集合,age > T1 者 ── 搬移(可逆)──▶
+   ▼
+[隔離區資料夾]  記錄進入時間
+   │  reference 事件碰到它 → resurrection:搬回活躍 + incref + touch
+   │
+   │  ===== gc(reconcile):唯一權威全掃,唯一會 unlink =====
+   │     掃所有 model 的所有 revision → 全域 live 聯集 + 精確 count
+   │       ① 回填 / 修正所有 count(含既有 blob,免遷移腳本)
+   │       ② 仍在 live 聯集卻被隔離的 → restore
+   │       ③ 新發現的 orphan → 搬進隔離(起算 T2)
+   │       ④ 隔離區待過 T2 且確認不在 live 聯集 → unlink
+   ▼
+真正 unlink(不可逆,只在這裡)
+```
+
+### 防禦層(為什麼不會誤刪)
+
+1. 近似 count 只是預篩,永不單獨授權刪除。
+2. `age`(T1)擋住「上傳→引用」「假歸零」的暫時窗口。
+3. 隔離是**可逆搬移**,不是硬刪。
+4. resurrection:任何再引用當場把 blob 拉回活躍。
+5. unlink 前必過 reconcile 的**權威全掃**確認。
+6. 洩漏可被下次 reconcile 回收;誤刪零容忍。
+
+---
+
+## 4. `age` 定義(定義 A:量「新不新」)
+
+`age = now − blob 的最後寫入時間(原生 mtime / LastModified)`。
+
+`age` 的職責是補上「**有人引用了這個 blob**」與「**count 追上來反映這個引用**」之間的非原子落差。一個 `count <= 0` 的 blob 正常情況下沒人 touch、mtime 自然停滯、於是老化被掃;唯一會 touch 一個 `count <= 0` blob 的事件,就是「新引用正在進來」(同時也是一次 incref)。
+
+逐 backend 落地(幾乎免費,因為各 backend 原生就有最後修改時間):
+
+| backend | mtime 來源 | touch 方式 |
+| --- | --- | --- |
+| Disk | 檔案 `stat().st_mtime` | `os.utime`(去重命中 skip 寫檔時補一次) |
+| S3 | 物件 `LastModified` | 帶資料 put 自然刷新;純 file_id 引用付一次 self `copy_object` 硬刷 |
+| Memory | dict entry 時戳 | 覆寫時戳 |
+
+**每次引用都 touch**,所有 backend、所有情況(含 S3 的 self-copy),換取 `age` 閘在任何情況都成立,不依賴下游 resurrection 去補。
+
+> 否決的「定義 B」:`age = now − 上次變 orphan 的時間`。它想擋的 dereference→recreate race 已被「隔離可逆 + resurrection + reconcile 權威全掃」三道閘接住,不值得為它付「歸零時寫戳記 + 維護模糊狀態」的代價。
+
+---
+
+## 5. 兩段門檻
+
+| 門檻 | 階段 | 預設 |
+| --- | --- | --- |
+| **T1** | 活躍 → 隔離(進隔離的 age 下限) | 1h |
+| **T2** | 隔離 → unlink(在隔離區待的時間下限) | 24h |
+
+門檻當 `gc()` 參數傳、給合理預設,不存成全域狀態,讓不同排程能用不同 policy。
+
+---
+
+## 6. 架構(X):blob store 持有原語,crud 編排
+
+權威推導要掃的是 revision,而 revision 只有 `ResourceManager` / `storage` 看得到、blob store 看不到。所以**編排在 crud 層級**,但 count / mtime / 隔離區 / 搬移 / unlink 這些**原語在 blob store**。
+
+### 6.1 `IBlobStore` 新增面
+
+| 方法 | 階段 | 各 backend 落地 |
+| --- | --- | --- |
+| `incref(file_id) / decref(file_id)` | 記帳(盡力、非原子) | Memory: dict;Disk: 寫進 `.blobmeta` sidecar;S3: object metadata / tag |
+| `touch(file_id)` | 引用時刷新 age | Disk `utime` / S3 self-copy / Memory 時戳 |
+| `quarantine(file_id)` | gc 階段1 動作 | Disk: 搬到 `_quarantine/`;S3: 搬到 `{prefix}_quarantine/`;記隔離時間 |
+| `iter_quarantined(older_than)` | gc 階段2 輸入 | 隔離區待過 `older_than` 者 |
+| `restore_from_quarantine(file_id)` | resurrection | 搬回活躍區 |
+| `delete(file_id)` | gc 階段2 動作(不可逆) | 真正 unlink |
+
+`get` / `exists` 在**活躍區 miss 時** fall through 隔離區(miss 本來就是罕見/錯誤路徑,這層只是保險,命中活躍區零開銷)。
+
+**count 單位 = per-revision 出現次數**(`collect_file_ids` 回傳 set,故同一 revision 內多欄位算一次):
+
+- `incref`:每存一個引用它的 revision +1。
+- `decref`:`permanently_delete` 時按「該 resource 內引用它的 revision 數」遞減。
+- reconcile 的精確 count = 所有 model 中引用該 file_id 的 revision 數,與 incref/decref 單位一致。
+
+### 6.2 熱路徑:resurrection
+
+reference 事件(帶資料的 put、`process` 裡的 file_id 純引用驗證)一旦在隔離區找到該內容,當場 **resurrection:搬回活躍區 + incref + touch**。任何真正的再引用都會立刻把 blob 拉出隔離,無鎖地關掉「gc 掃描 vs 並行 create」的 race。`reconcile` 階段2 也會把「掃出來其實仍在 live 聯集」的隔離 blob `restore` 回去,當雙保險。
+
+---
+
+## 7. 編排:`crud.gc(mode, t1, t2) -> stats`
+
+掛 **crud 物件**(它才同時握有 `self.blob_store` 與全部 `resource_managers`)。
+
+- `permanently_delete` 只做最便宜的 best-effort `decref` + 把降到 <=0 的 file_id 丟進 pending-candidates 集合,立刻返回 — 熱路徑永不碰搬移與掃描。
+- **`gc(mode="incremental")`**:只看 pending 集合,對 `age > T1` 者 `quarantine`。**不掃 revision、不 unlink。** 純記帳驅動。
+- **`gc(mode="reconcile")`**:唯一的權威全掃,也是**唯一會 unlink** 的地方。掃**所有 model** 的所有 revision → 全域 live 聯集 + 精確 count,一趟做完:回填/修正 count、restore 錯置隔離、quarantine 新 orphan、unlink「隔離待過 T2 且不在 live 聯集」者。
+
+> live 聯集 = **所有 model 的聯集**,缺一不可。否則某 model 的 gc 會把「其實被別的 model 引用」的共用 blob 誤判 orphan。
+
+使用者自行排程(incremental 常跑、reconcile 偶爾跑);**library 不自己開背景執行緒**。
+
+---
+
+## 8. 已決定但記錄為約束 / 預設
+
+1. **顯式 key 的 blob**(非內容定址、可能被 out-of-band 引用):reconcile 的 live 聯集只看得到「透過 resource `Binary` 欄位」的引用。若有人手動 `put(key=...)` 並在模型外引用,會被誤判 orphan。**文件化「GC 只管透過 resource 模型引用的內容定址 blob」**。
+2. **blob store 不可被多個獨立 crud app 共用**:否則 live 聯集不完整、會誤刪跨 app 的引用。**文件化帶過**,不在 gc 內強制偵測。
+3. **並行兩個 reconcile**:靠 best-effort advisory lock(Disk `flock` / Memory lock)避免;S3 不強制。撞上也只是重工,idempotent,不丟資料。
+4. **pending-candidates 集合**:盡力、非持久亦可 — 重啟掉了沒關係,reconcile 全掃會補回。
+5. **崩潰中斷的搬移**(半搬狀態):由 reconcile 的全掃自我修復。
+6. **soft delete 不釋放 blob**:soft-deleted resource 的 revision 仍存在 → 其 blob 仍在 live 聯集 → 保持存活(與「soft delete 可復原」一致)。只有 `permanently_delete` 才會讓 blob 走向回收。
+
+---
+
+## 9. 設計不變式(實作與測試的驗收基準)
+
+1. **絕不誤刪**:被任一存活 revision(任一 model、含 soft-deleted)引用的 blob,在任何 gc 之後仍可讀。
+2. **最終回收**:一個 blob 在「最後一個引用它的 revision 被 `permanently_delete`」之後,經過足夠時間 + 至少一次 reconcile,必被 unlink。
+3. **可逆性**:unlink 之前的每一步(quarantine)都可由 resurrection / restore 還原。
+4. **冪等 / 可重入**:gc(任一模式)中斷後重跑,結果與未中斷一致;重複跑不造成額外效果。
+5. **熱路徑零回歸**:活躍區命中的 `get` / `exists` / `put` 不因本功能增加 I/O。

--- a/docs/en/howto/binary-data.md
+++ b/docs/en/howto/binary-data.md
@@ -106,6 +106,62 @@ Depending on the backend, SpecStar may:
 
 ---
 
+## 6. Blob lifecycle and garbage collection
+
+Blobs are **content-addressed and deduplicated**: identical bytes always map to the
+same `file_id`, so a single blob can be shared by many revisions, many resources, and
+even many models that share the same blob store.
+
+Because of that sharing, SpecStar never deletes a blob the moment a resource goes away.
+Even `permanently_delete` only removes the resource's metadata and revisions — the blob
+itself may still be referenced elsewhere. Reclaiming truly-unreferenced blobs is done by
+explicit garbage-collection passes that you run (or schedule) yourself:
+
+```python
+# Cheap, scan-free pass: quarantine blobs that just lost their last reference.
+spec.gc(mode="incremental")
+
+# Authoritative pass: rescans every model's revisions, then permanently removes
+# blobs that no live revision references. This is the only pass that deletes.
+spec.gc(mode="reconcile")
+
+# Tune the two grace periods (defaults shown).
+spec.gc(mode="reconcile", t1="1h", t2="24h")
+```
+
+The two passes work together:
+
+- **`incremental`** is cheap and never rescans revision data. When `permanently_delete`
+  drops a blob's last reference, that blob becomes a candidate; after the `t1` grace the
+  incremental pass *moves it to a quarantine area* — a reversible step, not a delete. It
+  never deletes.
+- **`reconcile`** is authoritative. It rescans the revisions of **all** models, computes
+  the exact set of still-referenced blobs, **restores** any blob that is still referenced
+  (self-healing), **quarantines** any newly orphaned blob older than `t1`, and
+  **permanently deletes** quarantined blobs that no revision references and that have sat in
+  quarantine past `t2`. It also brings pre-existing blobs under management on its first run,
+  so **no migration is needed**.
+
+A typical schedule runs `incremental` often (e.g. hourly) and `reconcile` occasionally
+(e.g. nightly). SpecStar does **not** spawn a background thread for you — wire `gc()` into
+your own scheduler/cron.
+
+Safety: a blob is never deleted while any revision still references it (including
+soft-deleted resources, whose revisions are retained). A blob is only removed after it has
+sat unreferenced in quarantine past `t2`, confirmed by a scan that is authoritative across
+every model that shares the blob store. While a blob sits in quarantine it remains fully
+readable, and if it is referenced again it is restored out of quarantine immediately.
+
+> **Caveats**
+>
+> - GC only manages content-addressed blobs that are referenced through a resource's
+>   `Binary` fields. Blobs you `put` with an explicit `key` and reference out-of-band are
+>   not tracked and may be collected.
+> - A blob store must be owned by a single SpecStar app. Sharing one bucket/prefix across
+>   independent apps breaks GC's view of what is referenced.
+
+---
+
 ## What the Binary type stores
 
 A `Binary` value typically contains:
@@ -126,6 +182,7 @@ In most stored resources, the raw byte content is not kept inline.
 - store only the metadata you need in the resource itself
 - use content types when available so downloads are served correctly
 - combine blob support with S3-compatible storage for multi-node deployments
+- schedule `gc()` (incremental often, reconcile occasionally) so unreferenced blobs are reclaimed
 
 ---
 

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -163,6 +163,47 @@ class LoadStats:
         )
 
 
+class GcStats:
+    """Statistics returned by :meth:`SpecStar.gc` (issue #370)."""
+
+    __slots__ = ("mode", "quarantined", "restored", "deleted", "live", "scan_complete")
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.quarantined = 0
+        self.restored = 0
+        self.deleted = 0
+        self.live = 0
+        self.scan_complete = True
+
+    def __repr__(self) -> str:
+        return (
+            f"GcStats(mode={self.mode!r}, quarantined={self.quarantined}, "
+            f"restored={self.restored}, deleted={self.deleted}, "
+            f"live={self.live}, scan_complete={self.scan_complete})"
+        )
+
+
+_DURATION_UNITS = {
+    "s": "seconds",
+    "m": "minutes",
+    "h": "hours",
+    "d": "days",
+    "w": "weeks",
+}
+
+
+def _coerce_duration(value: "str | dt.timedelta") -> dt.timedelta:
+    """Coerce ``"1h"`` / ``"30m"`` / ``"7d"`` / ``"10s"`` (or a bare-number
+    seconds string) or a ``timedelta`` into a ``timedelta``."""
+    if isinstance(value, dt.timedelta):
+        return value
+    s = value.strip().lower()
+    if s and s[-1] in _DURATION_UNITS:
+        return dt.timedelta(**{_DURATION_UNITS[s[-1]]: float(s[:-1])})
+    return dt.timedelta(seconds=float(s))
+
+
 class SpecStar:
     """High-level entry point for registering resource models and generating CRUD routes.
 
@@ -3261,6 +3302,129 @@ class SpecStar:
         encoded = _json.format(_json.encode(descriptor), indent=2)
         Path(path).write_bytes(encoded)
         return None
+
+    def gc(
+        self,
+        *,
+        mode: str = "reconcile",
+        t1: "str | dt.timedelta" = "1h",
+        t2: "str | dt.timedelta" = "24h",
+        now: "dt.datetime | None" = None,
+    ) -> GcStats:
+        """Reclaim blobs no longer referenced by any resource revision (issue #370).
+
+        Blobs are content-addressed and shared across resources, revisions, and
+        models, so a blob is only safe to remove once **no** live revision in
+        **any** registered model references it.  This method is the explicit,
+        user-scheduled garbage collector — the library never runs it on a
+        background thread.
+
+        Args:
+            mode: ``"reconcile"`` (default) rescans every model's revisions to
+                compute the authoritative live set, then quarantines newly
+                orphaned blobs and permanently deletes quarantined blobs that
+                no revision references and that have dwelt past ``t2``.  This is
+                the only mode that deletes, and it also self-heals (restores
+                blobs quarantined by mistake) and backfills bookkeeping for
+                pre-existing blobs — so no migration is needed.
+            t1: Grace period protecting freshly-written blobs from being
+                quarantined (covers the upload-then-reference window).
+            t2: Grace period a blob must dwell in quarantine before it can be
+                permanently deleted.
+            now: Reference time (defaults to the current UTC time); injectable
+                for testing and deterministic scheduling.
+
+        Returns:
+            A :class:`GcStats` with counts of quarantined / restored / deleted
+            blobs.
+
+        Note:
+            A blob store must be owned by a single SpecStar app.  Sharing one
+            bucket/prefix across independent apps breaks the live-set view and
+            can orphan cross-app references.  GC also only manages blobs
+            referenced through resource ``Binary`` fields; blobs ``put`` with an
+            explicit ``key`` and referenced out-of-band are not tracked.
+        """
+        stats = GcStats(mode)
+        if self.blob_store is None:
+            return stats
+        if now is None:
+            now = dt.datetime.now(dt.timezone.utc)
+        t1_delta = _coerce_duration(t1)
+        t2_delta = _coerce_duration(t2)
+        if mode == "reconcile":
+            return self._gc_reconcile(stats, now=now, t1=t1_delta, t2=t2_delta)
+        if mode == "incremental":
+            return self._gc_incremental(stats, now=now, t1=t1_delta)
+        raise ValueError(
+            f"Unknown gc mode {mode!r}; expected 'reconcile' or 'incremental'."
+        )
+
+    def _gc_incremental(
+        self,
+        stats: GcStats,
+        *,
+        now: dt.datetime,
+        t1: dt.timedelta,
+    ) -> GcStats:
+        """Cheap, scan-free pass: quarantine orphan candidates (blobs whose
+        approximate count hit zero via ``permanently_delete``) older than
+        ``t1``.  Never scans revisions and never deletes — only ``reconcile``
+        deletes."""
+        store = self.blob_store
+        assert store is not None
+        t1_cutoff = now - t1
+        for file_id in list(store.iter_orphan_candidates(modified_before=t1_cutoff)):
+            store.quarantine(file_id, now=now)
+            stats.quarantined += 1
+        return stats
+
+    def _gc_reconcile(
+        self,
+        stats: GcStats,
+        *,
+        now: dt.datetime,
+        t1: dt.timedelta,
+        t2: dt.timedelta,
+    ) -> GcStats:
+        store = self.blob_store
+        assert store is not None
+
+        # 1. Authoritative live set = union across ALL models sharing this store.
+        live: set[str] = set()
+        complete = True
+        for mgr in self.resource_managers.values():
+            ids, ok = mgr.collect_all_referenced_file_ids()
+            live |= ids
+            complete = complete and ok
+        stats.live = len(live)
+        stats.scan_complete = complete
+
+        # 2. Active orphans older than T1 -> quarantine (reversible).
+        t1_cutoff = now - t1
+        for file_id in list(store.iter_active()):
+            if file_id in live:
+                continue
+            mtime = store.get_mtime(file_id)
+            if mtime is not None and mtime > t1_cutoff:
+                continue  # too fresh — protect the upload->reference window
+            store.quarantine(file_id, now=now)
+            stats.quarantined += 1
+
+        # 3. Quarantined blobs: restore the referenced, delete the long-orphaned.
+        far_future = now + dt.timedelta(days=36500)
+        all_quarantined = set(store.iter_quarantined(entered_before=far_future))
+        old_enough = set(store.iter_quarantined(entered_before=now - t2))
+        for file_id in all_quarantined:
+            if file_id in live:
+                store.restore_from_quarantine(file_id)
+                stats.restored += 1
+            elif complete and file_id in old_enough:
+                # Only delete when the scan was complete: an un-decodable
+                # revision might reference this blob unseen.
+                store.delete(file_id)
+                stats.deleted += 1
+        return stats
 
     def dump(
         self,

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -852,6 +852,115 @@ class IBlobStore(ABC):
         pass
 
     @abstractmethod
+    def delete(self, file_id: str) -> None:
+        """Permanently remove a blob by ``file_id``.
+
+        This is the **irreversible** primitive used by garbage collection
+        (issue #370) once a blob has been confirmed unreferenced.  It is
+        **idempotent**: deleting a ``file_id`` that does not exist is a
+        no-op, never an error, so a crashed/restarted GC can safely retry.
+
+        Removes the blob whether it lives in the active area or in
+        quarantine.
+        """
+        pass
+
+    @abstractmethod
+    def quarantine(self, file_id: str, *, now: dt.datetime) -> None:
+        """Move a blob from the active area into a reversible quarantine area.
+
+        ``now`` is recorded as the blob's quarantine **entry time** so that
+        :meth:`iter_quarantined` can later select blobs that have dwelt long
+        enough (the GC's ``T2`` grace period).  Quarantining is **reversible**
+        via :meth:`restore_from_quarantine`, and a quarantined blob remains
+        readable through :meth:`get` / :meth:`exists` (active-miss
+        fall-through).  No-op if ``file_id`` is not currently active.
+        """
+        pass
+
+    @abstractmethod
+    def restore_from_quarantine(self, file_id: str) -> None:
+        """Move a blob back from quarantine to the active area (resurrection).
+
+        No-op if ``file_id`` is not currently quarantined.
+        """
+        pass
+
+    @abstractmethod
+    def iter_quarantined(self, *, entered_before: dt.datetime) -> Generator[str]:
+        """Yield ``file_id``s quarantined strictly before ``entered_before``.
+
+        Used by the reconcile pass to find quarantined blobs old enough to be
+        considered for the irreversible :meth:`delete`.
+        """
+        pass
+
+    @abstractmethod
+    def incref(self, file_id: str) -> int:
+        """Increment the blob's approximate reference count, returning the new
+        value.
+
+        The count is a **best-effort, non-atomic** hint (issue #370): it is
+        only used to cheaply nominate orphan candidates, never as the sole
+        authority for deletion.  The reconcile pass recomputes exact counts.
+        """
+        pass
+
+    @abstractmethod
+    def decref(self, file_id: str) -> int:
+        """Decrement the blob's approximate reference count, returning the new
+        value.  Clamps at zero (never negative).  Best-effort / non-atomic."""
+        pass
+
+    @abstractmethod
+    def iter_active(self) -> Generator[str]:
+        """Yield the ``file_id`` of every blob in the **active** area
+        (excluding quarantined blobs).
+
+        Used by the reconcile pass to discover orphans (active blobs that no
+        live revision references).
+        """
+        pass
+
+    @abstractmethod
+    def get_mtime(self, file_id: str) -> "dt.datetime | None":
+        """Return the active blob's last-write time, or ``None`` if absent.
+
+        This is the blob's *age* source (issue #370): the GC protects blobs
+        younger than the ``T1`` grace period from being quarantined, covering
+        the "uploaded-but-not-yet-referenced" window.  Implementations use the
+        backend's native modification time (filesystem ``mtime`` / S3
+        ``LastModified`` / in-memory put timestamp).  Returns a timezone-aware
+        UTC datetime.
+        """
+        pass
+
+    @abstractmethod
+    def touch(self, file_id: str, *, now: "dt.datetime | None" = None) -> None:
+        """Refresh an active blob's last-write time to ``now`` (default: the
+        current UTC time).
+
+        Called on the reference hot path (issue #370): re-referencing a blob
+        keeps its *age* fresh so the ``T1`` grace covers the gap between
+        "someone referenced it" and "the count caught up".  No-op if the blob
+        is not active.  (S3 stamps the server's current time regardless of
+        ``now``, since object ``LastModified`` is server-controlled.)
+        """
+        pass
+
+    @abstractmethod
+    def iter_orphan_candidates(self, *, modified_before: dt.datetime) -> Generator[str]:
+        """Yield active ``file_id``s whose approximate count has dropped to
+        ``<= 0`` (orphan suspects) and whose last-write time precedes
+        ``modified_before`` (the ``T1`` grace cutoff).
+
+        This is the cheap, scan-free candidate feed for the incremental GC
+        pass — populated as a side effect of :meth:`decref`.  Best-effort:
+        the authoritative truth is always the reconcile scan.
+        """
+        pass
+
+    @abstractmethod
     def get_url(self, file_id: str) -> str | None:
         """
         Get a direct download URL for the blob if supported.

--- a/specstar/resource_manager/blob_store/s3.py
+++ b/specstar/resource_manager/blob_store/s3.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import uuid
 from typing import Any, Literal
 
@@ -158,10 +159,26 @@ class S3BlobStore(BasicBlobStore):
             content_type=content_type_ if content_type_ else UNSET,
         )
 
+    def _active_key(self, file_id: str) -> str:
+        return f"{self.prefix}{file_id}"
+
+    def _quarantine_key(self, file_id: str) -> str:
+        return f"{self.prefix}_quarantine/{file_id}"
+
+    def _refcount_key(self, file_id: str) -> str:
+        return f"{self.prefix}_refcount/{file_id}"
+
     def get(self, file_id: str) -> Binary:
-        key = f"{self.prefix}{file_id}"
-        try:
-            response = self.client.get_object(Bucket=self.bucket, Key=key)
+        # Active first (zero overhead on hit); on miss fall through to the
+        # quarantine area so a transiently-quarantined blob is never lost (#370).
+        for key in (self._active_key(file_id), self._quarantine_key(file_id)):
+            try:
+                response = self.client.get_object(Bucket=self.bucket, Key=key)
+            except _ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code")
+                if error_code in ("NoSuchKey", "404"):
+                    continue
+                raise
             content = response["Body"].read()
             content_type = response.get("ContentType")
             if content_type is None:
@@ -172,22 +189,177 @@ class S3BlobStore(BasicBlobStore):
                 data=content,
                 content_type=content_type,
             )
-        except _ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code")
-            if error_code == "NoSuchKey":
-                raise FileNotFoundError(f"Blob {file_id} not found")
-            raise
+        raise FileNotFoundError(f"Blob {file_id} not found")
 
     def exists(self, file_id: str) -> bool:
-        key = f"{self.prefix}{file_id}"
+        for key in (self._active_key(file_id), self._quarantine_key(file_id)):
+            try:
+                self.client.head_object(Bucket=self.bucket, Key=key)
+                return True
+            except _ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code")
+                if error_code in ("404", "NoSuchKey"):
+                    continue
+                raise
+        return False
+
+    def delete(self, file_id: str) -> None:
+        """Idempotently remove a blob (active or quarantined) and its refcount.
+        S3 delete is already a no-op for a missing key."""
+        for key in (
+            self._active_key(file_id),
+            self._quarantine_key(file_id),
+            self._refcount_key(file_id),
+        ):
+            try:
+                self.client.delete_object(Bucket=self.bucket, Key=key)
+            except _ClientError:
+                pass
+        self._clear_candidate(file_id)
+
+    def _read_refcount(self, file_id: str) -> int:
         try:
-            self.client.head_object(Bucket=self.bucket, Key=key)
-            return True
+            resp = self.client.get_object(
+                Bucket=self.bucket, Key=self._refcount_key(file_id)
+            )
+            return int(resp["Body"].read().decode())
+        except _ClientError:
+            return 0
+        except ValueError:
+            return 0
+
+    def incref(self, file_id: str) -> int:
+        n = self._read_refcount(file_id) + 1
+        self.client.put_object(
+            Bucket=self.bucket, Key=self._refcount_key(file_id), Body=str(n).encode()
+        )
+        self._note_count(file_id, n)
+        return n
+
+    def decref(self, file_id: str) -> int:
+        n = max(0, self._read_refcount(file_id) - 1)
+        self.client.put_object(
+            Bucket=self.bucket, Key=self._refcount_key(file_id), Body=str(n).encode()
+        )
+        self._note_count(file_id, n)
+        return n
+
+    def get_mtime(self, file_id: str) -> dt.datetime | None:
+        try:
+            head = self.client.head_object(
+                Bucket=self.bucket, Key=self._active_key(file_id)
+            )
+        except _ClientError:
+            return None
+        last_modified = head.get("LastModified")
+        if last_modified is None:
+            return None
+        # boto returns an aware datetime; normalise to UTC.
+        return last_modified.astimezone(dt.timezone.utc)
+
+    def touch(self, file_id: str, *, now: dt.datetime | None = None) -> None:
+        """Refresh ``LastModified`` via an in-place server-side self-copy.
+
+        S3 sets ``LastModified`` to the server's current time on copy, so the
+        ``now`` argument is accepted for API uniformity but not used as the
+        stored stamp.  No-op if the blob is not active.
+        """
+        key = self._active_key(file_id)
+        try:
+            head = self.client.head_object(Bucket=self.bucket, Key=key)
+        except _ClientError:
+            return
+        copy_kwargs: dict[str, Any] = {
+            "Bucket": self.bucket,
+            "CopySource": {"Bucket": self.bucket, "Key": key},
+            "Key": key,
+            "Metadata": head.get("Metadata", {}),
+            "MetadataDirective": "REPLACE",
+        }
+        ct = head.get("ContentType")
+        if ct:
+            copy_kwargs["ContentType"] = ct
+        try:
+            self.client.copy_object(**copy_kwargs)
+        except _ClientError:
+            pass
+
+    def iter_active(self):
+        internal = ("_quarantine/", "_refcount/", "_sessions/", "_uploads/")
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):
+            for obj in page.get("Contents", []):
+                rest = obj["Key"][len(self.prefix) :]
+                if not rest or any(rest.startswith(p) for p in internal):
+                    continue
+                yield rest
+
+    def quarantine(self, file_id: str, *, now: dt.datetime) -> None:
+        """Move an active object into the quarantine prefix, recording ``now``
+        in object metadata as the entry time. No-op if not active."""
+        src = self._active_key(file_id)
+        dst = self._quarantine_key(file_id)
+        try:
+            head = self.client.head_object(Bucket=self.bucket, Key=src)
         except _ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code")
-            if error_code == "404" or error_code == "NoSuchKey":
-                return False
+            code = e.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404"):
+                return
             raise
+        copy_kwargs: dict[str, Any] = {
+            "Bucket": self.bucket,
+            "CopySource": {"Bucket": self.bucket, "Key": src},
+            "Key": dst,
+            "Metadata": {"quarantine-entered": now.isoformat()},
+            "MetadataDirective": "REPLACE",
+        }
+        ct = head.get("ContentType")
+        if ct:
+            copy_kwargs["ContentType"] = ct
+        self.client.copy_object(**copy_kwargs)
+        self.client.delete_object(Bucket=self.bucket, Key=src)
+        self._clear_candidate(file_id)
+
+    def restore_from_quarantine(self, file_id: str) -> None:
+        """Move an object back from the quarantine prefix to active. No-op if absent."""
+        src = self._quarantine_key(file_id)
+        dst = self._active_key(file_id)
+        try:
+            head = self.client.head_object(Bucket=self.bucket, Key=src)
+        except _ClientError as e:
+            code = e.response.get("Error", {}).get("Code")
+            if code in ("NoSuchKey", "404"):
+                return
+            raise
+        copy_kwargs: dict[str, Any] = {
+            "Bucket": self.bucket,
+            "CopySource": {"Bucket": self.bucket, "Key": src},
+            "Key": dst,
+            "Metadata": {},
+            "MetadataDirective": "REPLACE",
+        }
+        ct = head.get("ContentType")
+        if ct:
+            copy_kwargs["ContentType"] = ct
+        self.client.copy_object(**copy_kwargs)
+        self.client.delete_object(Bucket=self.bucket, Key=src)
+
+    def iter_quarantined(self, *, entered_before: dt.datetime):
+        """Yield file_ids quarantined strictly before ``entered_before``."""
+        qprefix = f"{self.prefix}_quarantine/"
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=qprefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                file_id = key[len(qprefix) :]
+                if not file_id:
+                    continue
+                head = self.client.head_object(Bucket=self.bucket, Key=key)
+                entered_str = head.get("Metadata", {}).get("quarantine-entered")
+                if entered_str is None:
+                    continue
+                if dt.datetime.fromisoformat(entered_str) < entered_before:
+                    yield file_id
 
     def get_url(self, file_id: str) -> str | None:
         key = f"{self.prefix}{file_id}"

--- a/specstar/resource_manager/blob_store/simple.py
+++ b/specstar/resource_manager/blob_store/simple.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import fcntl
 import os
 import threading
@@ -134,6 +135,40 @@ class BasicBlobStore(IBlobStore):
 
         raise FileNotFoundError(f"Blob {file_id} not found")
 
+    # ------------------------------------------------------------------
+    # Orphan-candidate tracking (issue #370, incremental GC)
+    #
+    # A best-effort, in-memory, process-local set of file_ids whose
+    # approximate count has dropped to <= 0.  Populated by ``decref`` and
+    # cleared by ``incref`` / ``quarantine`` / ``delete``.  Non-persistent on
+    # purpose: a restart loses it, and the reconcile pass recovers everything.
+    # ------------------------------------------------------------------
+
+    def _candidate_set(self) -> set[str]:
+        candidates = getattr(self, "_candidates", None)
+        if candidates is None:
+            candidates = set()
+            self._candidates = candidates
+        return candidates
+
+    def _note_count(self, file_id: str, count: int) -> None:
+        """Record/clear *file_id* as an orphan candidate from a count update."""
+        if count <= 0:
+            self._candidate_set().add(file_id)
+        else:
+            self._candidate_set().discard(file_id)
+
+    def _clear_candidate(self, file_id: str) -> None:
+        self._candidate_set().discard(file_id)
+
+    def iter_orphan_candidates(self, *, modified_before: dt.datetime):
+        for file_id in list(self._candidate_set()):
+            mtime = self.get_mtime(file_id)
+            # Skip non-active (already quarantined/deleted) and too-fresh blobs.
+            if mtime is None or mtime >= modified_before:
+                continue
+            yield file_id
+
 
 # ---------------------------------------------------------------------------
 # Shared session state dataclass (used by MemoryBlobStore and DiskBlobStore)
@@ -168,6 +203,12 @@ class MemoryBlobStore(BasicBlobStore):
 
     def __init__(self):
         self._store: dict[str, Binary] = {}
+        # Quarantined blobs (issue #370): file_id -> (Binary, entered_at).
+        self._quarantine: dict[str, tuple[Binary, dt.datetime]] = {}
+        # Approximate, non-atomic ref counts (issue #370).
+        self._refcount: dict[str, int] = {}
+        # Last-write time per active blob (the "age" source for the T1 gate).
+        self._mtime: dict[str, dt.datetime] = {}
         self._sessions: dict[str, _UploadSessionState] = {}
         self._session_locks: dict[str, threading.Lock] = {}
         self._global_lock = threading.Lock()
@@ -190,15 +231,76 @@ class MemoryBlobStore(BasicBlobStore):
         )
 
         self._store[file_id] = stored_binary
+        self._mtime[file_id] = dt.datetime.now(dt.timezone.utc)
         return stored_binary
 
     def get(self, file_id: str) -> Binary:
-        if file_id not in self._store:
-            raise FileNotFoundError(f"Blob {file_id} not found")
-        return self._store[file_id]
+        if file_id in self._store:
+            return self._store[file_id]
+        # Active miss: fall through to quarantine so a transiently-quarantined
+        # blob is never lost to readers (issue #370).
+        if file_id in self._quarantine:
+            return self._quarantine[file_id][0]
+        raise FileNotFoundError(f"Blob {file_id} not found")
 
     def exists(self, file_id: str) -> bool:
-        return file_id in self._store
+        return file_id in self._store or file_id in self._quarantine
+
+    def delete(self, file_id: str) -> None:
+        """Idempotently remove a blob from active or quarantine (no error if absent)."""
+        self._store.pop(file_id, None)
+        self._quarantine.pop(file_id, None)
+        self._mtime.pop(file_id, None)
+        self._refcount.pop(file_id, None)
+        self._clear_candidate(file_id)
+
+    def quarantine(self, file_id: str, *, now: dt.datetime) -> None:
+        """Move a blob from the active area into quarantine, stamping ``now``
+        as its entry time. No-op if the blob is not active."""
+        binary = self._store.pop(file_id, None)
+        if binary is None:
+            return
+        self._mtime.pop(file_id, None)
+        self._clear_candidate(file_id)
+        self._quarantine[file_id] = (binary, now)
+
+    def get_mtime(self, file_id: str) -> dt.datetime | None:
+        return self._mtime.get(file_id)
+
+    def touch(self, file_id: str, *, now: dt.datetime | None = None) -> None:
+        if file_id not in self._store:
+            return
+        self._mtime[file_id] = now or dt.datetime.now(dt.timezone.utc)
+
+    def restore_from_quarantine(self, file_id: str) -> None:
+        """Move a blob back from quarantine to the active area. No-op if absent."""
+        entry = self._quarantine.pop(file_id, None)
+        if entry is None:
+            return
+        binary, entered_at = entry
+        self._store[file_id] = binary
+        self._mtime[file_id] = entered_at
+
+    def incref(self, file_id: str) -> int:
+        n = self._refcount.get(file_id, 0) + 1
+        self._refcount[file_id] = n
+        self._note_count(file_id, n)
+        return n
+
+    def decref(self, file_id: str) -> int:
+        n = max(0, self._refcount.get(file_id, 0) - 1)
+        self._refcount[file_id] = n
+        self._note_count(file_id, n)
+        return n
+
+    def iter_active(self):
+        yield from list(self._store.keys())
+
+    def iter_quarantined(self, *, entered_before: dt.datetime):
+        """Yield file_ids quarantined strictly before ``entered_before``."""
+        for fid, (_binary, entered_at) in list(self._quarantine.items()):
+            if entered_at < entered_before:
+                yield fid
 
     # -- Session locking ------------------------------------------------
 
@@ -498,18 +600,22 @@ class DiskBlobStore(BasicBlobStore):
             content_type=final_content_type,
         )
 
-    def get(self, file_id: str) -> Binary:
-        safe_name = file_id.replace("/", "_").replace("..", "_")
-        file_path = self.root_path / safe_name
-        # Skip the exists() guard: it would race against a concurrent purge
-        # and leak the raw "[Errno 2] No such file or directory: '/abs/path'"
-        # message to the caller. Read straight and translate ENOENT into the
-        # same controlled "Blob {file_id} not found" surface. See #352.
+    @property
+    def _quarantine_dir(self) -> Path:
+        return self.root_path / "_quarantine"
+
+    def _read_binary_from(self, base: Path, safe_name: str) -> Binary | None:
+        """Read a blob (data + sidecar) from *base*, or ``None`` if absent.
+
+        Skips the ``exists()`` guard: it would race a concurrent purge and
+        leak a raw "[Errno 2] ..." path. Translate ENOENT to ``None``. See #352.
+        """
+        file_path = base / safe_name
         try:
             data = retry_on_estale(file_path.read_bytes)
         except FileNotFoundError:
-            raise FileNotFoundError(f"Blob {file_id} not found") from None
-        meta_path = self._blob_meta_path(safe_name)
+            return None
+        meta_path = base / f"{safe_name}.blobmeta"
         try:
             meta_bytes = retry_on_estale(meta_path.read_bytes)
         except FileNotFoundError:
@@ -524,9 +630,137 @@ class DiskBlobStore(BasicBlobStore):
             content_type=blob_meta.content_type,
         )
 
+    def get(self, file_id: str) -> Binary:
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        # Active first (zero overhead on hit); on miss fall through to the
+        # quarantine area so a transiently-quarantined blob is never lost (#370).
+        for base in (self.root_path, self._quarantine_dir):
+            result = self._read_binary_from(base, safe_name)
+            if result is not None:
+                return result
+        raise FileNotFoundError(f"Blob {file_id} not found")
+
     def exists(self, file_id: str) -> bool:
         safe_name = file_id.replace("/", "_").replace("..", "_")
-        return (self.root_path / safe_name).exists()
+        return (self.root_path / safe_name).exists() or (
+            self._quarantine_dir / safe_name
+        ).exists()
+
+    def delete(self, file_id: str) -> None:
+        """Idempotently remove a blob (active or quarantined) and its sidecars."""
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        for base in (self.root_path, self._quarantine_dir):
+            (base / safe_name).unlink(missing_ok=True)
+            (base / f"{safe_name}.blobmeta").unlink(missing_ok=True)
+        self._refcount_path(safe_name).unlink(missing_ok=True)
+        self._clear_candidate(file_id)
+
+    def quarantine(self, file_id: str, *, now: dt.datetime) -> None:
+        """Move an active blob into quarantine, stamping ``now`` as its entry
+        time (recorded as the quarantined file's mtime). No-op if not active."""
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        src = self.root_path / safe_name
+        if not src.exists():
+            return
+        self._quarantine_dir.mkdir(exist_ok=True)
+        dst = self._quarantine_dir / safe_name
+        os.replace(src, dst)
+        src_meta = self._blob_meta_path(safe_name)
+        if src_meta.exists():
+            os.replace(src_meta, self._quarantine_dir / f"{safe_name}.blobmeta")
+        ts = now.timestamp()
+        os.utime(dst, (ts, ts))
+        self._clear_candidate(file_id)
+
+    def restore_from_quarantine(self, file_id: str) -> None:
+        """Move a blob back from quarantine to the active area. No-op if absent."""
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        src = self._quarantine_dir / safe_name
+        if not src.exists():
+            return
+        os.replace(src, self.root_path / safe_name)
+        src_meta = self._quarantine_dir / f"{safe_name}.blobmeta"
+        if src_meta.exists():
+            os.replace(src_meta, self._blob_meta_path(safe_name))
+
+    def _refcount_path(self, safe_name: str) -> Path:
+        return self.root_path / f"{safe_name}.refcount"
+
+    def _read_refcount(self, safe_name: str) -> int:
+        try:
+            return int(self._refcount_path(safe_name).read_text())
+        except (FileNotFoundError, ValueError):
+            return 0
+
+    def incref(self, file_id: str) -> int:
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        n = self._read_refcount(safe_name) + 1
+        self._refcount_path(safe_name).write_text(str(n))
+        self._note_count(file_id, n)
+        return n
+
+    def decref(self, file_id: str) -> int:
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        n = max(0, self._read_refcount(safe_name) - 1)
+        self._refcount_path(safe_name).write_text(str(n))
+        self._note_count(file_id, n)
+        return n
+
+    def get_mtime(self, file_id: str) -> dt.datetime | None:
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        try:
+            ts = (self.root_path / safe_name).stat().st_mtime
+        except FileNotFoundError:
+            return None
+        return dt.datetime.fromtimestamp(ts, dt.timezone.utc)
+
+    def touch(self, file_id: str, *, now: dt.datetime | None = None) -> None:
+        safe_name = file_id.replace("/", "_").replace("..", "_")
+        path = self.root_path / safe_name
+        if not path.exists():
+            return
+        ts = (now or dt.datetime.now(dt.timezone.utc)).timestamp()
+        os.utime(path, (ts, ts))
+
+    def iter_active(self):
+        for entry in self.root_path.iterdir():
+            if not entry.is_file():
+                continue  # skips _sessions/ and _quarantine/ subdirs
+            name = entry.name
+            if (
+                name.endswith(".blobmeta")
+                or name.endswith(".refcount")
+                or ".tmp." in name
+            ):
+                continue
+            meta_file = self._blob_meta_path(name)
+            if meta_file.exists():
+                meta = self._blob_meta_decoder.decode(meta_file.read_bytes())
+                yield meta.file_id
+            else:
+                yield name
+
+    def iter_quarantined(self, *, entered_before: dt.datetime):
+        """Yield file_ids quarantined strictly before ``entered_before``."""
+        qdir = self._quarantine_dir
+        if not qdir.exists():
+            return
+        cutoff = entered_before.timestamp()
+        for data_file in qdir.iterdir():
+            if data_file.name.endswith(".blobmeta") or not data_file.is_file():
+                continue
+            try:
+                mtime = data_file.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            if mtime >= cutoff:
+                continue
+            meta_file = qdir / f"{data_file.name}.blobmeta"
+            if meta_file.exists():
+                meta = self._blob_meta_decoder.decode(meta_file.read_bytes())
+                yield meta.file_id
+            else:
+                yield data_file.name
 
     def get_stream(self, file_id: str):
         """Stream blob content in 8 MB chunks without loading into memory."""

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -188,7 +188,11 @@ def _validate_resource_id(resource_id: str) -> None:
     """
     if not isinstance(resource_id, str) or not resource_id.strip():
         raise ValidationError("resource_id must be a non-empty string.")
-    if "/" in resource_id or "\\" in resource_id or any(ord(c) < 32 for c in resource_id):
+    if (
+        "/" in resource_id
+        or "\\" in resource_id
+        or any(ord(c) < 32 for c in resource_id)
+    ):
         raise ValidationError(
             f"resource_id {resource_id!r} contains characters that are not "
             "allowed: path separators ('/', '\\') or control characters. A "
@@ -1589,7 +1593,20 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         return data_hash
 
     def _process_binary_fields(self, data: Any) -> Any:
-        return self._binary_processor.process(data, self.blob_store)
+        result = self._binary_processor.process(data, self.blob_store)
+        store = self.blob_store
+        if store is not None:
+            # Phase-2 ref accounting (issue #370): once per (revision, file_id).
+            # Best-effort — a hiccup here must never break the write; the
+            # reconcile pass is the authoritative source of truth.
+            for file_id in self._binary_processor.collect_file_ids(result):
+                try:
+                    store.restore_from_quarantine(file_id)  # resurrection
+                    store.incref(file_id)
+                    store.touch(file_id)
+                except Exception:
+                    pass
+        return result
 
     def restore_binary(self, data: T) -> T:
         """
@@ -2420,7 +2437,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         if not isinstance(by, _Field):
             raise TypeError(
                 "exp_aggregate_by: ``by`` must be a QB Field "
-                "(e.g. QB[\"source_doc_id\"] for indexed data or "
+                '(e.g. QB["source_doc_id"] for indexed data or '
                 "QB.resource_id() / QB.created_by() for ResourceMeta); "
                 f"got {type(by).__name__}."
             )
@@ -2446,9 +2463,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             a.field for a in self_aggs.values() if isinstance(a, (Sum, Min, Max, Avg))
         ]
         bad = [
-            f.name
-            for f in (by, *agg_field_specs)
-            if not self._is_field_queryable(f)
+            f.name for f in (by, *agg_field_specs) if not self._is_field_queryable(f)
         ]
         if bad:
             from specstar.types import OnUnindexedQuery, UnindexedQueryError
@@ -2598,7 +2613,9 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             row_kwargs = {n: _finalize(self_aggs[n], state[n]) for n in self_aggs}
             for n, fa in foreign_aggs.items():
                 row_kwargs[n] = foreign_results[n].get(key, _foreign_zero(fa))
-            out.append(GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs))
+            out.append(
+                GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs)
+            )
         return out
 
     def _read_field(self, meta: ResourceMeta, field: "object") -> object:
@@ -2841,10 +2858,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             resource_id, revision_id, schema_version
         ) as data_io:
             raw = data_io.read()
-        if (
-            self._migration is not None
-            and info.schema_version != self._schema_version
-        ):
+        if self._migration is not None and info.schema_version != self._schema_version:
             # Lazy read-time migration: the row is stored at an older version,
             # so apply the registered migration to present it as the current
             # model. Storage is NOT rewritten — ``info.schema_version`` keeps
@@ -3357,8 +3371,41 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             ResourceIDNotFoundError: If the resource ID does not exist.
         """
         meta = self._get_meta_no_check_is_deleted(resource_id)
+        # Phase-2 ref accounting (issue #370): decref this resource's blobs
+        # before purging its revisions, so blobs that hit zero feed the
+        # incremental GC's candidate set. Best-effort; reconcile is authoritative.
+        self._decref_resource_blobs(resource_id)
         self.storage.purge_resource(resource_id)
         return meta
+
+    def _decref_resource_blobs(self, resource_id: str) -> None:
+        """Best-effort ``decref`` of every blob referenced by *resource_id*'s
+        revisions, once per (revision, file_id).
+
+        ``dump_resource`` yields once per (revision, schema_version), so a
+        migrated revision appears multiple times; we dedupe by ``revision_id``
+        so the decref count matches ``incref`` (which fires once per logical
+        revision write)."""
+        store = self.blob_store
+        if store is None or self._binary_processor._collector is None:
+            return
+        decode = self._data_serializer.decode
+        collect = self._binary_processor.collect_file_ids
+        decremented: dict[str, set[str]] = {}
+        try:
+            for info, data_io in self.storage.dump_resource(resource_id):
+                try:
+                    file_ids = collect(decode(data_io.read()))
+                except Exception:
+                    continue
+                seen = decremented.setdefault(info.revision_id, set())
+                for file_id in file_ids:
+                    if file_id in seen:
+                        continue
+                    seen.add(file_id)
+                    store.decref(file_id)
+        except Exception:
+            pass
 
     @execute_with_events(
         (BeforeDump, AfterDump, OnSuccessDump, OnFailureDump),
@@ -3455,6 +3502,53 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                         )
                 except Exception:
                     pass
+
+    def collect_all_referenced_file_ids(self) -> tuple[set[str], bool]:
+        """Scan every revision of every resource for referenced blob file_ids.
+
+        Returns ``(referenced_file_ids, complete)`` (issue #370):
+
+        * ``referenced_file_ids`` — every blob ``file_id`` referenced by any
+          stored revision (any resource, including soft-deleted ones, any
+          schema version).  This is the authoritative "live" set used by the
+          garbage collector's reconcile pass.
+        * ``complete`` — ``False`` if any revision failed to decode.  When
+          incomplete the caller must **not** treat a missing file_id as proof
+          that a blob is unreferenced (it must skip irreversible deletion),
+          because an un-decodable revision may reference blobs we could not
+          see.
+
+        Returns ``(set(), True)`` when the model has no blob store or no
+        ``Binary`` fields.
+        """
+        if self.blob_store is None or self._binary_processor._collector is None:
+            return set(), True
+        collect = self._binary_processor.collect_file_ids
+        data_decode = self._data_serializer.decode
+        result: set[str] = set()
+        complete = True
+
+        metas_list = list(self.storage.dump_meta(None))
+        rid_set = frozenset(m.resource_id for m in metas_list)
+        bulk = self.storage.dump_resources_bulk(resource_ids=rid_set)
+
+        def _accumulate(raw_data: bytes) -> None:
+            nonlocal complete
+            try:
+                result.update(collect(data_decode(raw_data)))
+            except Exception:
+                complete = False
+
+        if bulk is not None:
+            for meta in metas_list:
+                for _info, raw_data in bulk.get(meta.resource_id, []):
+                    _accumulate(raw_data)
+        else:
+            for meta in metas_list:
+                for _info, data_io in self.storage.dump_resource(meta.resource_id):
+                    _accumulate(data_io.read())
+
+        return result, complete
 
     @execute_with_events(
         (BeforeLoad, AfterLoad, OnSuccessLoad, OnFailureLoad),

--- a/tests/test_blob_gc.py
+++ b/tests/test_blob_gc.py
@@ -1,0 +1,215 @@
+"""End-to-end garbage-collection tests for blob ref-counting (issue #370).
+
+Exercised at the ``SpecStar`` (crud) level with the default in-memory blob
+store, driving the resource managers directly.
+
+Timing note: a blob's *age* is its real wall-clock write time, while the GC's
+``now`` is injected.  Tests therefore capture a reference time **before**
+creating blobs and drive ``gc(now=...)`` relative to it — ``+2h`` clears the
+default ``T1`` (1h) grace so orphans become quarantine-eligible, and ``+27h``
+clears ``T1`` + ``T2`` (24h) so a quarantined orphan is deleted.
+"""
+
+import datetime as dt
+
+import msgspec
+from xxhash import xxh3_128_hexdigest
+
+from specstar.crud.core import SpecStar
+from specstar.types import Binary
+
+UTC = dt.timezone.utc
+T0 = dt.datetime(2026, 1, 1, tzinfo=UTC)  # revision timestamp (independent of blob age)
+
+
+class Doc(msgspec.Struct):
+    title: str
+    file: Binary | None = None
+
+
+class Note(msgspec.Struct):
+    body: str
+    attachment: Binary | None = None
+
+
+def _create(spec: SpecStar, model_name: str, struct) -> str:
+    rm = spec.resource_managers[model_name]
+    with rm.using("alice", T0) as ops:
+        info = ops.create(struct)
+    return info.resource_id
+
+
+def _perm_delete(spec: SpecStar, model_name: str, rid: str) -> None:
+    rm = spec.resource_managers[model_name]
+    with rm.using("alice", T0) as ops:
+        ops.permanently_delete(rid)
+
+
+def test_reconcile_collects_orphaned_blob():
+    """A blob referenced only by a permanently-deleted resource is removed —
+    but only after dwelling in quarantine past T2 (reversible until then)."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    fid = xxh3_128_hexdigest(b"orphan-payload")
+    rid = _create(spec, "doc", Doc(title="t", file=Binary(data=b"orphan-payload")))
+    assert spec.blob_store.exists(fid) is True
+
+    _perm_delete(spec, "doc", rid)
+
+    # First reconcile only quarantines (reversible) — blob still present.
+    s1 = spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=2))
+    assert s1.quarantined == 1
+    assert s1.deleted == 0
+    assert spec.blob_store.exists(fid) is True
+
+    # After T2 the quarantined orphan is permanently removed.
+    s2 = spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+    assert s2.deleted == 1
+    assert spec.blob_store.exists(fid) is False
+
+
+def test_reconcile_keeps_blob_referenced_by_another_model():
+    """The live set is the union across ALL models: a blob still referenced by
+    a different model must survive even when one referencing resource is purged."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    spec.add_model(Note)
+    ref = dt.datetime.now(UTC)
+    shared = b"shared-across-models"
+    fid = xxh3_128_hexdigest(shared)
+
+    doc_rid = _create(spec, "doc", Doc(title="d", file=Binary(data=shared)))
+    _create(spec, "note", Note(body="n", attachment=Binary(data=shared)))
+
+    _perm_delete(spec, "doc", doc_rid)
+
+    spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=2))
+    spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+
+    # Note still references the shared blob → never collected.
+    assert spec.blob_store.exists(fid) is True
+
+
+def test_reconcile_keeps_blob_of_soft_deleted_resource():
+    """Soft delete keeps the revision (and thus the blob) alive."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    fid = xxh3_128_hexdigest(b"soft-deleted-payload")
+    rid = _create(
+        spec, "doc", Doc(title="t", file=Binary(data=b"soft-deleted-payload"))
+    )
+
+    rm = spec.resource_managers["doc"]
+    with rm.using("alice", T0) as ops:
+        ops.delete(rid)  # soft delete — revision still stored
+
+    spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=2))
+    spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+
+    assert spec.blob_store.exists(fid) is True
+
+
+def test_reconcile_protects_fresh_unreferenced_blob_within_t1():
+    """A freshly-written orphan is NOT quarantined while within the T1 grace —
+    protecting the upload-then-reference window."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    fid = xxh3_128_hexdigest(b"fresh-orphan")
+    rid = _create(spec, "doc", Doc(title="t", file=Binary(data=b"fresh-orphan")))
+
+    _perm_delete(spec, "doc", rid)
+
+    # now is only 30 min after creation — within the 1h T1 grace.
+    stats = spec.gc(mode="reconcile", now=ref + dt.timedelta(minutes=30))
+    assert stats.quarantined == 0
+    assert spec.blob_store.exists(fid) is True
+
+
+def test_reconcile_keeps_blob_referenced_again_before_delete():
+    """A blob re-referenced while in quarantine is never deleted — the new
+    reference resurrects it, so a later reconcile leaves it live."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    payload = b"comes-back-from-the-dead"
+    fid = xxh3_128_hexdigest(payload)
+
+    rid = _create(spec, "doc", Doc(title="a", file=Binary(data=payload)))
+    _perm_delete(spec, "doc", rid)
+
+    # Quarantine the now-orphaned blob.
+    spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=2))
+
+    # Before T2 elapses, a brand-new resource references the same content
+    # (the write resurrects it out of quarantine immediately).
+    _create(spec, "doc", Doc(title="b", file=Binary(data=payload)))
+
+    # Even past T2, the blob is live again → never deleted.
+    stats = spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+    assert stats.deleted == 0
+    assert spec.blob_store.exists(fid) is True
+
+
+def test_incremental_quarantines_candidate_then_reconcile_deletes():
+    """The cheap incremental pass quarantines blobs whose count hit zero on
+    permanently_delete (no revision scan); reconcile later deletes them."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    fid = xxh3_128_hexdigest(b"incremental-orphan")
+    rid = _create(spec, "doc", Doc(title="t", file=Binary(data=b"incremental-orphan")))
+
+    _perm_delete(spec, "doc", rid)
+
+    s_inc = spec.gc(mode="incremental", now=ref + dt.timedelta(hours=2))
+    assert s_inc.quarantined == 1
+    assert s_inc.deleted == 0  # incremental never deletes
+    assert spec.blob_store.exists(fid) is True
+
+    s_rec = spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+    assert s_rec.deleted == 1
+    assert spec.blob_store.exists(fid) is False
+
+
+def test_incremental_skips_blob_still_referenced_by_count():
+    """incref/decref keep a still-shared blob's count > 0, so the incremental
+    pass does not quarantine it."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    shared = b"shared-incremental"
+    fid = xxh3_128_hexdigest(shared)
+
+    r1 = _create(spec, "doc", Doc(title="1", file=Binary(data=shared)))  # count 1
+    _create(spec, "doc", Doc(title="2", file=Binary(data=shared)))  # count 2
+    _perm_delete(spec, "doc", r1)  # decref → count 1 (> 0)
+
+    stats = spec.gc(mode="incremental", now=ref + dt.timedelta(hours=2))
+    assert stats.quarantined == 0
+    assert spec.blob_store.exists(fid) is True
+
+
+def test_new_reference_resurrects_quarantined_blob_on_write():
+    """Referencing a quarantined blob on a write resurrects it immediately
+    (hot-path restore), without waiting for the next reconcile."""
+    spec = SpecStar()
+    spec.add_model(Doc)
+    ref = dt.datetime.now(UTC)
+    payload = b"resurrect-on-write"
+    fid = xxh3_128_hexdigest(payload)
+
+    rid = _create(spec, "doc", Doc(title="a", file=Binary(data=payload)))
+    _perm_delete(spec, "doc", rid)
+    spec.gc(mode="incremental", now=ref + dt.timedelta(hours=2))  # quarantined
+
+    # A brand-new resource references the same content.
+    _create(spec, "doc", Doc(title="b", file=Binary(data=payload)))
+
+    quarantined = set(
+        spec.blob_store.iter_quarantined(entered_before=ref + dt.timedelta(days=999))
+    )
+    assert fid not in quarantined
+    assert fid in set(spec.blob_store.iter_active())

--- a/tests/test_blob_store.py
+++ b/tests/test_blob_store.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections.abc import Generator
 
 import pytest
@@ -212,3 +213,155 @@ class TestIBlobStoreBehavior:
 
         self.blob_store.put(b"exists_data", key=unique_key)
         assert self.blob_store.exists(unique_key) is True
+
+
+class TestIBlobStoreGarbageCollection:
+    """Contract tests for the blob garbage-collection primitives (issue #370).
+
+    Exercised against every ``IBlobStore`` implementation via the shared
+    ``blob_store`` fixture.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, blob_store: IBlobStore):
+        self.blob_store = blob_store
+
+    def test_delete_removes_blob(self):
+        """delete(file_id) makes the blob no longer retrievable."""
+        file_id = self.blob_store.put(b"to_be_deleted").file_id
+
+        self.blob_store.delete(file_id)
+
+        assert self.blob_store.exists(file_id) is False
+        with pytest.raises(FileNotFoundError):
+            self.blob_store.get(file_id)
+
+    def test_quarantine_lists_and_keeps_retrievable(self):
+        """A quarantined blob stays readable (fall-through) and is listed by
+        iter_quarantined, filtered by its recorded entry time."""
+        t = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        file_id = self.blob_store.put(b"quarantined_payload").file_id
+
+        self.blob_store.quarantine(file_id, now=t)
+
+        # Reversible: data is not lost — get/exists fall through to quarantine.
+        assert self.blob_store.get(file_id).data == b"quarantined_payload"
+        assert self.blob_store.exists(file_id) is True
+
+        # Listed when the cutoff is after its entry time, not before.
+        after = set(
+            self.blob_store.iter_quarantined(entered_before=t + dt.timedelta(seconds=1))
+        )
+        before = set(
+            self.blob_store.iter_quarantined(entered_before=t - dt.timedelta(seconds=1))
+        )
+        assert file_id in after
+        assert file_id not in before
+
+    def test_restore_from_quarantine_brings_back_to_active(self):
+        """restore_from_quarantine moves a blob back to active; it leaves the
+        quarantine listing and stays retrievable."""
+        t = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        file_id = self.blob_store.put(b"resurrect_me").file_id
+        self.blob_store.quarantine(file_id, now=t)
+
+        self.blob_store.restore_from_quarantine(file_id)
+
+        assert self.blob_store.get(file_id).data == b"resurrect_me"
+        listed = set(
+            self.blob_store.iter_quarantined(entered_before=t + dt.timedelta(days=999))
+        )
+        assert file_id not in listed
+
+    def test_delete_removes_quarantined_blob(self):
+        """delete() removes a blob even while it sits in quarantine."""
+        t = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        file_id = self.blob_store.put(b"quarantined_then_deleted").file_id
+        self.blob_store.quarantine(file_id, now=t)
+
+        self.blob_store.delete(file_id)
+
+        assert self.blob_store.exists(file_id) is False
+        assert file_id not in set(
+            self.blob_store.iter_quarantined(entered_before=t + dt.timedelta(days=999))
+        )
+
+    def test_incref_decref_track_count(self):
+        """incref/decref return the adjusted approximate count; decref clamps at 0."""
+        file_id = self.blob_store.put(b"counted").file_id
+
+        assert self.blob_store.incref(file_id) == 1
+        assert self.blob_store.incref(file_id) == 2
+        assert self.blob_store.decref(file_id) == 1
+        assert self.blob_store.decref(file_id) == 0
+        # Approximate / best-effort: never goes negative.
+        assert self.blob_store.decref(file_id) == 0
+
+    def test_iter_active_lists_active_blobs_only(self):
+        """iter_active yields active file_ids and excludes quarantined ones."""
+        t = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        active_id = self.blob_store.put(b"i_am_active").file_id
+        quarantined_id = self.blob_store.put(b"i_am_quarantined").file_id
+        self.blob_store.quarantine(quarantined_id, now=t)
+
+        active = set(self.blob_store.iter_active())
+
+        assert active_id in active
+        assert quarantined_id not in active
+
+    def test_get_mtime_reports_recent_write_time(self):
+        """get_mtime returns the blob's last-write time (≈ now at put)."""
+        before = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=5)
+        file_id = self.blob_store.put(b"freshly_written").file_id
+        after = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=5)
+
+        mtime = self.blob_store.get_mtime(file_id)
+
+        assert mtime is not None
+        assert before <= mtime <= after
+
+    def test_get_mtime_missing_returns_none(self):
+        assert self.blob_store.get_mtime("no-such-blob-xyz") is None
+
+    def test_touch_advances_mtime(self):
+        """touch refreshes the blob's mtime forward."""
+        file_id = self.blob_store.put(b"touch_me").file_id
+        m0 = self.blob_store.get_mtime(file_id)
+        assert m0 is not None
+
+        self.blob_store.touch(file_id, now=m0 + dt.timedelta(hours=1))
+
+        m1 = self.blob_store.get_mtime(file_id)
+        assert m1 is not None
+        assert m1 > m0
+
+    def test_decref_to_zero_makes_orphan_candidate(self):
+        """A blob whose count drops to <=0 becomes an orphan candidate eligible
+        for the incremental pass (once older than the modified_before cutoff)."""
+        file_id = self.blob_store.put(b"candidate").file_id
+        self.blob_store.incref(file_id)
+        self.blob_store.decref(file_id)  # back to 0 -> candidate
+
+        cutoff = dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1)
+        candidates = set(self.blob_store.iter_orphan_candidates(modified_before=cutoff))
+        assert file_id in candidates
+
+    def test_incref_clears_orphan_candidate(self):
+        """A re-referenced blob is no longer an orphan candidate."""
+        file_id = self.blob_store.put(b"recandidate").file_id
+        self.blob_store.decref(file_id)  # 0 -> candidate
+        self.blob_store.incref(file_id)  # 1 -> cleared
+
+        cutoff = dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=1)
+        candidates = set(self.blob_store.iter_orphan_candidates(modified_before=cutoff))
+        assert file_id not in candidates
+
+    def test_fresh_orphan_candidate_excluded_by_cutoff(self):
+        """A candidate written after the cutoff (too fresh) is not yielded —
+        this is the T1 grace at the blob-store level."""
+        file_id = self.blob_store.put(b"fresh_candidate").file_id
+        self.blob_store.decref(file_id)  # candidate
+
+        cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
+        candidates = set(self.blob_store.iter_orphan_candidates(modified_before=cutoff))
+        assert file_id not in candidates


### PR DESCRIPTION
Closes #370.

## Problem
Blobs are content-addressed, deduplicated, and shared across resources, revisions, and models — and were **never deleted**. `permanently_delete` removed a resource's metadata/revisions but left its blobs behind, so storage grew unbounded.

## Solution
An explicit, user-scheduled garbage collector (`crud.gc(...)`) with two passes:

- **`reconcile`** (authoritative): rescans every model's revisions for the live `file_id` set, quarantines newly-orphaned blobs (reversible; `t1` grace protects fresh uploads), restores any still-referenced (self-healing), and permanently deletes quarantined blobs that no revision references and that have dwelt past `t2`. Only pass that deletes; backfills bookkeeping so **no migration needed**.
- **`incremental`** (cheap, scan-free): quarantines blobs whose approximate ref count hit zero (fed by `permanently_delete`). Never deletes.

### Safety
- A blob is never deleted while any revision (including soft-deleted) references it.
- Deletion requires a **complete** authoritative scan across **all** models sharing the store (decode failure ⇒ skip delete).
- Quarantine is reversible; a new reference resurrects a blob immediately on the write path.

### What changed
- `IBlobStore` GC primitives across **Memory/Disk/S3**: `delete`, `quarantine`, `restore_from_quarantine`, `iter_quarantined`, `iter_active`, `get_mtime`, `touch`, `incref`, `decref`, `iter_orphan_candidates`; plus active-miss fall-through on `get`/`exists`.
- Ref accounting wired best-effort: `incref`/`touch`/resurrection on the write chokepoint (`_process_binary_fields`), `decref` on `permanently_delete` (deduped per revision). Reconcile is the source of truth.
- `SpecStar.gc(mode, t1, t2, now) -> GcStats`.
- Docs: design doc (`docs/design/blob-refcount-gc.md`) + how-to (`docs/en/howto/binary-data.md`).

### Tests
- Cross-backend `IBlobStore` contract tests for all new primitives.
- End-to-end (`tests/test_blob_gc.py`): orphan reclaimed after T2, cross-model union keeps shared blob, soft-delete keeps blob, T1 protects fresh blob, resurrection, incremental→reconcile, count-driven skip of still-referenced.
- Full non-integration suite: **3104 passed, 0 failed**.

### Note
Potential conflict with #387 (disk `_sh/<ab>/<cd>/` sharding): this PR's Disk paths assume flat layout; `iter_active`/quarantine/sidecars will need aligning on merge (documented in the design doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)