### PR TITLE
feat(crud): prune old revisions to reclaim storage (#377)

### DIFF
--- a/scripts/gen_events_stub.py
+++ b/scripts/gen_events_stub.py
@@ -313,6 +313,22 @@ def main() -> None:
     out.append(
         "def do(func: ContextFunc | list[ContextFunc]) -> SimpleEventHandlerBuilder: ..."
     )
+    out.append("")
+    # Hand-written runtime handler with no defstruct backing — mirror it so the
+    # stub stays a complete view of ``events.py``'s public surface.
+    out.append("class StringRefEventHandler(IEventHandler):")
+    out.append("    target: str")
+    out.append("    phase: str")
+    out.append("    action: ResourceAction")
+    out.append("    def __init__(")
+    out.append("        self,")
+    out.append("        target: str,")
+    out.append("        *,")
+    out.append("        phase: str,")
+    out.append("        action: ResourceAction,")
+    out.append("    ) -> None: ...")
+    out.append("    def is_supported(self, context: EventContext) -> bool: ...")
+    out.append("    def handle_event(self, context: EventContext) -> None: ...")
 
     sys.stdout.write("\n".join(out) + "\n")
 

--- a/specstar/events.py
+++ b/specstar/events.py
@@ -829,6 +829,63 @@ OnFailurePermanentlyDelete = defstruct(
 
 
 # ============================================================================
+# Prune Context Classes
+# ============================================================================
+
+_prune_context: list[_DefstructField] = [
+    ("action", Literal[ResourceAction.prune], ResourceAction.prune),
+    ("resource_id", str),
+    ("keep_last_n", int | UnsetType, UNSET),
+    ("before", dt.datetime | UnsetType, UNSET),
+]
+
+BeforePrune = defstruct(
+    "BeforePrune",
+    [
+        *_before_context,
+        *_prune_context,
+    ],
+    kw_only=True,
+    tag=True,
+    tag_field="context_type",
+)
+
+AfterPrune = defstruct(
+    "AfterPrune",
+    [
+        *_after_context,
+        *_prune_context,
+    ],
+    kw_only=True,
+    tag=True,
+    tag_field="context_type",
+)
+
+OnSuccessPrune = defstruct(
+    "OnSuccessPrune",
+    [
+        *_on_success_context,
+        *_prune_context,
+        ("pruned", list[str]),
+    ],
+    kw_only=True,
+    tag=True,
+    tag_field="context_type",
+)
+
+OnFailurePrune = defstruct(
+    "OnFailurePrune",
+    [
+        *_on_failure_context,
+        *_prune_context,
+    ],
+    kw_only=True,
+    tag=True,
+    tag_field="context_type",
+)
+
+
+# ============================================================================
 # Restore Context Classes
 # ============================================================================
 
@@ -1090,6 +1147,10 @@ EventContext = (
     | AfterPermanentlyDelete
     | OnSuccessPermanentlyDelete
     | OnFailurePermanentlyDelete
+    | BeforePrune
+    | AfterPrune
+    | OnSuccessPrune
+    | OnFailurePrune
     | BeforeRestore
     | AfterRestore
     | OnSuccessRestore
@@ -1261,6 +1322,7 @@ __all__ = [
     "AfterModify",
     "AfterPatch",
     "AfterPermanentlyDelete",
+    "AfterPrune",
     "AfterRestore",
     "AfterSearchResources",
     "AfterSwitch",
@@ -1277,6 +1339,7 @@ __all__ = [
     "BeforeModify",
     "BeforePatch",
     "BeforePermanentlyDelete",
+    "BeforePrune",
     "BeforeRestore",
     "BeforeSearchResources",
     "BeforeSwitch",
@@ -1302,6 +1365,7 @@ __all__ = [
     "OnFailureModify",
     "OnFailurePatch",
     "OnFailurePermanentlyDelete",
+    "OnFailurePrune",
     "OnFailureRestore",
     "OnFailureSearchResources",
     "OnFailureSwitch",
@@ -1318,6 +1382,7 @@ __all__ = [
     "OnSuccessModify",
     "OnSuccessPatch",
     "OnSuccessPermanentlyDelete",
+    "OnSuccessPrune",
     "OnSuccessRestore",
     "OnSuccessSearchResources",
     "OnSuccessSwitch",

--- a/specstar/events.pyi
+++ b/specstar/events.pyi
@@ -63,6 +63,7 @@ class BeforeCreate(
     action: Literal[ResourceAction.create] = ResourceAction.create
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    if_not_exists: bool | UnsetType = UNSET
 
 class AfterCreate(Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -72,6 +73,7 @@ class AfterCreate(Struct, Generic[T], kw_only=True, tag=True, tag_field="context
     action: Literal[ResourceAction.create] = ResourceAction.create
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    if_not_exists: bool | UnsetType = UNSET
 
 class OnSuccessCreate(
     Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"
@@ -83,6 +85,7 @@ class OnSuccessCreate(
     action: Literal[ResourceAction.create] = ResourceAction.create
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    if_not_exists: bool | UnsetType = UNSET
     info: RevisionInfo
 
 class OnFailureCreate(
@@ -97,6 +100,7 @@ class OnFailureCreate(
     action: Literal[ResourceAction.create] = ResourceAction.create
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    if_not_exists: bool | UnsetType = UNSET
 
 class BeforeDelete(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["before"] = "before"
@@ -426,6 +430,8 @@ class BeforeModify(
     resource_id: str
     data: T | UnsetType = UNSET
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class AfterModify(Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -436,6 +442,8 @@ class AfterModify(Struct, Generic[T], kw_only=True, tag=True, tag_field="context
     resource_id: str
     data: T | UnsetType = UNSET
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class OnSuccessModify(
     Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"
@@ -448,6 +456,8 @@ class OnSuccessModify(
     resource_id: str
     data: T | UnsetType = UNSET
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
     revision_info: RevisionInfo
 
 class OnFailureModify(
@@ -463,6 +473,8 @@ class OnFailureModify(
     resource_id: str
     data: T | UnsetType = UNSET
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class BeforePatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["before"] = "before"
@@ -472,6 +484,8 @@ class BeforePatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     action: Literal[ResourceAction.patch] = ResourceAction.patch
     resource_id: str
     patch_data: JsonPatch
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class AfterPatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -481,6 +495,8 @@ class AfterPatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     action: Literal[ResourceAction.patch] = ResourceAction.patch
     resource_id: str
     patch_data: JsonPatch
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class OnSuccessPatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["on_success"] = "on_success"
@@ -490,6 +506,8 @@ class OnSuccessPatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     action: Literal[ResourceAction.patch] = ResourceAction.patch
     resource_id: str
     patch_data: JsonPatch
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
     revision_info: RevisionInfo
 
 class OnFailurePatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
@@ -502,6 +520,8 @@ class OnFailurePatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     action: Literal[ResourceAction.patch] = ResourceAction.patch
     resource_id: str
     patch_data: JsonPatch
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class BeforePermanentlyDelete(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["before"] = "before"
@@ -549,6 +569,49 @@ class OnFailurePermanentlyDelete(
         ResourceAction.permanently_delete
     )
     resource_id: str
+
+class BeforePrune(Struct, kw_only=True, tag=True, tag_field="context_type"):
+    phase: Literal["before"] = "before"
+    user: str | UnsetType
+    now: dt.datetime | UnsetType
+    resource_name: str
+    action: Literal[ResourceAction.prune] = ResourceAction.prune
+    resource_id: str
+    keep_last_n: int | UnsetType = UNSET
+    before: dt.datetime | UnsetType = UNSET
+
+class AfterPrune(Struct, kw_only=True, tag=True, tag_field="context_type"):
+    phase: Literal["after"] = "after"
+    user: str | UnsetType
+    now: dt.datetime | UnsetType
+    resource_name: str
+    action: Literal[ResourceAction.prune] = ResourceAction.prune
+    resource_id: str
+    keep_last_n: int | UnsetType = UNSET
+    before: dt.datetime | UnsetType = UNSET
+
+class OnSuccessPrune(Struct, kw_only=True, tag=True, tag_field="context_type"):
+    phase: Literal["on_success"] = "on_success"
+    user: str | UnsetType
+    now: dt.datetime | UnsetType
+    resource_name: str
+    action: Literal[ResourceAction.prune] = ResourceAction.prune
+    resource_id: str
+    keep_last_n: int | UnsetType = UNSET
+    before: dt.datetime | UnsetType = UNSET
+    pruned: list[str]
+
+class OnFailurePrune(Struct, kw_only=True, tag=True, tag_field="context_type"):
+    phase: Literal["on_failure"] = "on_failure"
+    user: str | UnsetType
+    now: dt.datetime | UnsetType
+    resource_name: str
+    error: str
+    stack_trace: str | None = None
+    action: Literal[ResourceAction.prune] = ResourceAction.prune
+    resource_id: str
+    keep_last_n: int | UnsetType = UNSET
+    before: dt.datetime | UnsetType = UNSET
 
 class BeforeRestore(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["before"] = "before"
@@ -674,6 +737,8 @@ class BeforeUpdate(
     resource_id: str
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class AfterUpdate(Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -684,6 +749,8 @@ class AfterUpdate(Struct, Generic[T], kw_only=True, tag=True, tag_field="context
     resource_id: str
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 class OnSuccessUpdate(
     Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"
@@ -696,6 +763,8 @@ class OnSuccessUpdate(
     resource_id: str
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
     revision_info: RevisionInfo
 
 class OnFailureUpdate(
@@ -711,6 +780,8 @@ class OnFailureUpdate(
     resource_id: str
     data: T
     status: RevisionStatus | UnsetType = UNSET
+    expected_revision_id: str | UnsetType = UNSET
+    expected_etag: str | UnsetType = UNSET
 
 # ── Union of every event-context class ───────────────────
 EventContext = (
@@ -762,6 +833,10 @@ EventContext = (
     | AfterPermanentlyDelete
     | OnSuccessPermanentlyDelete
     | OnFailurePermanentlyDelete
+    | BeforePrune
+    | AfterPrune
+    | OnSuccessPrune
+    | OnFailurePrune
     | BeforeRestore
     | AfterRestore
     | OnSuccessRestore
@@ -813,6 +888,8 @@ class SimpleEventHandlerBuilder(Sequence[SimpleEventHandler]):
     def on_success(self, action: ResourceAction) -> Self: ...
     def on_failure(self, action: ResourceAction) -> Self: ...
 
+def do(func: ContextFunc | list[ContextFunc]) -> SimpleEventHandlerBuilder: ...
+
 class StringRefEventHandler(IEventHandler):
     target: str
     phase: str
@@ -826,5 +903,3 @@ class StringRefEventHandler(IEventHandler):
     ) -> None: ...
     def is_supported(self, context: EventContext) -> bool: ...
     def handle_event(self, context: EventContext) -> None: ...
-
-def do(func: ContextFunc | list[ContextFunc]) -> SimpleEventHandlerBuilder: ...

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -1329,6 +1329,32 @@ class IResourceStore(ABC):
             "Override this method to support permanent deletion."
         )
 
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete a specific set of revisions for a resource.
+
+        Removes the listed revisions (all of their schema versions) and the
+        underlying uid payload once no surviving revision still references it
+        — the same reference-counted cleanup ``purge_resource`` performs, but
+        scoped to *revision_ids* instead of the whole resource.  This is the
+        physical primitive behind :meth:`IResourceManager.prune_revisions`.
+
+        Implementations must be idempotent: revision ids that do not exist are
+        silently skipped, so a concurrent prune / delete cannot raise here.
+        Callers are responsible for never asking to delete a resource's
+        current revision; this method does not consult metadata.
+
+        The base implementation raises :exc:`NotImplementedError`.  Storage
+        backends that support revision pruning must override this method.
+
+        Arguments:
+            resource_id (str): The resource whose revisions to delete.
+            revision_ids (list[str]): The revision ids to remove.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement delete_revisions(). "
+            "Override this method to support revision pruning."
+        )
+
 
 class IStorage(ABC):
     """Interface for unified storage management combining metadata and resource data.
@@ -1614,6 +1640,27 @@ class IStorage(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not implement purge_resource(). "
             "Override this method to support permanent deletion."
+        )
+
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete a specific set of revisions for a resource.
+
+        Delegates to the underlying resource store's
+        :meth:`IResourceStore.delete_revisions`.  Unlike ``purge_resource``
+        this leaves the resource metadata untouched (the current revision and
+        ``total_revision_count`` survive); it only removes the listed
+        revisions' payloads.  Idempotent: unknown revision ids are skipped.
+
+        The base implementation raises :exc:`NotImplementedError`.  Storage
+        backends that support revision pruning must override this method.
+
+        Arguments:
+            resource_id (str): The resource whose revisions to delete.
+            revision_ids (list[str]): The revision ids to remove.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement delete_revisions(). "
+            "Override this method to support revision pruning."
         )
 
     @abstractmethod

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -44,6 +44,7 @@ from specstar.events import (
     AfterModify,
     AfterPatch,
     AfterPermanentlyDelete,
+    AfterPrune,
     AfterRestore,
     AfterSearchResources,
     AfterSwitch,
@@ -60,6 +61,7 @@ from specstar.events import (
     BeforeModify,
     BeforePatch,
     BeforePermanentlyDelete,
+    BeforePrune,
     BeforeRestore,
     BeforeSearchResources,
     BeforeSwitch,
@@ -78,6 +80,7 @@ from specstar.events import (
     OnFailureModify,
     OnFailurePatch,
     OnFailurePermanentlyDelete,
+    OnFailurePrune,
     OnFailureRestore,
     OnFailureSearchResources,
     OnFailureSwitch,
@@ -94,6 +97,7 @@ from specstar.events import (
     OnSuccessModify,
     OnSuccessPatch,
     OnSuccessPermanentlyDelete,
+    OnSuccessPrune,
     OnSuccessRestore,
     OnSuccessSearchResources,
     OnSuccessSwitch,
@@ -370,6 +374,14 @@ class SimpleStorage(IStorage):
         """
         del self._meta_store[resource_id]
         self._resource_store.purge_resource(resource_id)
+
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete a set of revisions, leaving metadata untouched.
+
+        Delegates to the resource store; the meta store (current revision,
+        ``total_revision_count``) is intentionally not modified.
+        """
+        self._resource_store.delete_revisions(resource_id, revision_ids)
 
     def dump_meta(
         self, resource_ids: frozenset[str] | None = None
@@ -3378,14 +3390,120 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         self.storage.purge_resource(resource_id)
         return meta
 
-    def _decref_resource_blobs(self, resource_id: str) -> None:
+    @execute_with_events(
+        (BeforePrune, AfterPrune, OnSuccessPrune, OnFailurePrune),
+        "pruned",
+        context_aware=True,
+    )
+    def prune_revisions(
+        self,
+        resource_id: str,
+        *,
+        keep_last_n: int | UnsetType = UNSET,
+        before: dt.datetime | UnsetType = UNSET,
+        user: str | UnsetType = UNSET,
+        now: dt.datetime | UnsetType = UNSET,
+    ) -> list[str]:
+        """Prune old revisions of a resource to reclaim storage space.
+
+        See :meth:`IResourceManager.prune_revisions`.  The current revision is
+        always preserved; ``total_revision_count`` is left unchanged (it seeds
+        new revision ids).  Pruned revisions' blobs are ``decref``'d so the
+        #370 garbage collector can reclaim them — no blob is deleted here.
+        """
+        if keep_last_n is UNSET and before is UNSET:
+            raise ValueError(
+                "prune_revisions requires at least one of keep_last_n or before"
+            )
+        if keep_last_n is not UNSET and keep_last_n < 1:
+            raise ValueError("keep_last_n must be >= 1")
+
+        meta = self._get_meta_no_check_is_deleted(resource_id)
+        current = meta.current_revision_id
+
+        # Gather revision info for every revision that has retrievable data.
+        # created_time / parent_revision_id are identical across a revision's
+        # schema versions, so any stored version's info will do.
+        infos: dict[str, RevisionInfo] = {}
+        for rid in self.storage.list_revisions(resource_id):
+            sv = self.storage.find_revision_schema_version(resource_id, rid)
+            if sv is UNSET:
+                continue
+            try:
+                infos[rid] = self.storage.get_resource_revision_info(
+                    resource_id, rid, sv
+                )
+            except (KeyError, FileNotFoundError):
+                continue
+        if len(infos) <= 1:
+            return []
+
+        # Lineage = the current revision's ancestry chain (its "直系"/lineal
+        # revisions). Walk parent_revision_id from current to the root.
+        lineage: set[str] = set()
+        cursor: str | None = current
+        while cursor is not None and cursor in infos and cursor not in lineage:
+            lineage.add(cursor)
+            cursor = infos[cursor].parent_revision_id
+
+        # Sort key: lineal first, then newer first. ``created_time`` is the
+        # primary recency signal; the revision sequence number (the trailing
+        # ``:N`` of the default ``<resource_id>:N`` scheme) is a deterministic
+        # tie-breaker so revisions written at the same ``now`` still order by
+        # authoring sequence — otherwise keep_last_n would be non-deterministic
+        # on batch-created history. The current revision is always lineal and
+        # the newest of its own lineage, so it ranks #1.
+        def _seq(revision_id: str) -> int:
+            tail = revision_id.rsplit(":", 1)[-1]
+            return int(tail) if tail.isdigit() else -1
+
+        ordered = sorted(
+            infos,
+            key=lambda r: (r in lineage, infos[r].created_time, _seq(r)),
+            reverse=True,
+        )
+
+        # Union of the two retention floors (conservative): keep the top
+        # ``keep_last_n`` and/or anything newer than ``before``; the current
+        # revision is always kept (the keep_last_n>=1 floor).
+        kept: set[str] = {current}
+        if keep_last_n is not UNSET:
+            kept.update(ordered[:keep_last_n])
+        if before is not UNSET:
+            kept.update(r for r in infos if infos[r].created_time >= before)
+
+        prune_set = [r for r in ordered if r not in kept]
+
+        # Defensive concurrency guard: re-read the current revision right
+        # before deleting and never prune it — a concurrent switch() could
+        # have made an about-to-be-pruned revision the current one.
+        current_now = self._get_meta_no_check_is_deleted(
+            resource_id
+        ).current_revision_id
+        prune_set = [r for r in prune_set if r != current_now]
+        if not prune_set:
+            return []
+
+        # Keep #370 blob refcounts correct before the data disappears.
+        self._decref_resource_blobs(resource_id, only_revisions=set(prune_set))
+        self.storage.delete_revisions(resource_id, prune_set)
+        return prune_set
+
+    def _decref_resource_blobs(
+        self, resource_id: str, *, only_revisions: "set[str] | None" = None
+    ) -> None:
         """Best-effort ``decref`` of every blob referenced by *resource_id*'s
         revisions, once per (revision, file_id).
 
         ``dump_resource`` yields once per (revision, schema_version), so a
         migrated revision appears multiple times; we dedupe by ``revision_id``
         so the decref count matches ``incref`` (which fires once per logical
-        revision write)."""
+        revision write).
+
+        When *only_revisions* is given, only those revisions are decref'd —
+        used by :meth:`prune_revisions` so pruning a subset of a resource's
+        history keeps the #370 blob refcounts correct (the pruned revisions'
+        ``incref`` would otherwise never be matched and their blobs leak)."""
         store = self.blob_store
         if store is None or self._binary_processor._collector is None:
             return
@@ -3394,6 +3512,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         decremented: dict[str, set[str]] = {}
         try:
             for info, data_io in self.storage.dump_resource(resource_id):
+                if (
+                    only_revisions is not None
+                    and info.revision_id not in only_revisions
+                ):
+                    continue
                 try:
                     file_ids = collect(decode(data_io.read()))
                 except Exception:

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -372,6 +372,47 @@ class PostgresResourceStore(IResourceStore):
                         (uid,),
                     )
 
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete specific revisions, ref-counting shared uids.
+
+        Mirrors ``purge_resource`` but scoped to *revision_ids* (all of their
+        schema versions). Idempotent: revision ids without index rows are
+        no-ops. A data row is removed only once no surviving index row — for
+        any resource — still references its uid.
+        """
+        if not revision_ids:
+            return
+        rev_list = list(revision_ids)
+        with self._transaction() as cur:
+            # UIDs referenced by the revisions we're about to drop.
+            cur.execute(
+                f'SELECT DISTINCT uid FROM "{self._index_table}" '
+                f"WHERE resource_id = %s AND revision_id = ANY(%s)",
+                (resource_id, rev_list),
+            )
+            uids = [row[0] for row in cur.fetchall()]
+            if not uids:
+                return
+
+            # Remove index rows first (FK constraint).
+            cur.execute(
+                f'DELETE FROM "{self._index_table}" '
+                f"WHERE resource_id = %s AND revision_id = ANY(%s)",
+                (resource_id, rev_list),
+            )
+
+            # Remove data rows only if no other index references them.
+            for uid in uids:
+                cur.execute(
+                    f'SELECT 1 FROM "{self._index_table}" WHERE uid = %s LIMIT 1',
+                    (uid,),
+                )
+                if cur.fetchone() is None:
+                    cur.execute(
+                        f'DELETE FROM "{self._data_table}" WHERE uid = %s',
+                        (uid,),
+                    )
+
     def cleanup(self) -> None:
         """Remove all data (both tables). Useful for test teardown."""
         with self._transaction() as cur:

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -118,6 +118,34 @@ class MemoryResourceStore(IResourceStore):
                 self._raw_info_store.pop(uid, None)
         del self._store[resource_id]
 
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete specific revisions, ref-counting shared uids.
+
+        Idempotent: unknown revision ids are skipped. A uid payload is only
+        dropped once no surviving revision (across every resource, honouring
+        cross-resource uid dedup) still references it.
+        """
+        res = self._store.get(resource_id)
+        if not res:
+            return
+        candidate_uids: set[UID] = set()
+        for revision_id in revision_ids:
+            rev = res.pop(revision_id, None)
+            if rev:
+                candidate_uids.update(rev.values())
+        if not candidate_uids:
+            return
+        live_uids: set[UID] = {
+            uid
+            for resource in self._store.values()
+            for rev in resource.values()
+            for uid in rev.values()
+        }
+        for uid in candidate_uids:
+            if uid not in live_uids:
+                self._raw_data_store.pop(uid, None)
+                self._raw_info_store.pop(uid, None)
+
 
 def relative_walk_up(path: Path, start: Path) -> Path:
     """Compute a relative path from *start* to *path*, walking up if needed.
@@ -450,6 +478,55 @@ class DiskResourceStore(IResourceStore):
             for real_dir in self._realdir_candidates(uid):
                 if real_dir.exists():
                     shutil.rmtree(real_dir)
+
+    def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
+        """Hard-delete specific revisions from disk, ref-counting shared uids.
+
+        Mirrors ``purge_resource`` but scoped to *revision_ids*: removes each
+        listed revision's symlink subtree (all schema versions) across both
+        the sharded (#387) and legacy flat layouts, then reclaims a
+        ``store/<uid>`` payload only once no surviving symlink — in any
+        resource — still points at it. Idempotent: unknown revisions are
+        skipped.
+        """
+        import shutil
+
+        targets = set(revision_ids)
+        if not targets:
+            return
+        rid_dirs = [d for d in self._rid_dir_candidates(resource_id) if d.exists()]
+        if not rid_dirs:
+            return
+        # Collect the uids the to-be-removed revisions point at, then drop the
+        # revision symlink subtrees.
+        candidate_uids: set[str] = set()
+        for resource_dir in rid_dirs:
+            for revision_dir in list(resource_dir.iterdir()):
+                if revision_dir.name not in targets or not revision_dir.is_dir():
+                    continue
+                for schema_dir in revision_dir.iterdir():
+                    if not schema_dir.is_dir():
+                        continue
+                    with suppress(OSError):
+                        candidate_uids.add(schema_dir.resolve().name)
+                shutil.rmtree(revision_dir)
+        if not candidate_uids:
+            return
+        # Reference-count across every surviving revision (both layouts, all
+        # resources) so cross-revision / cross-resource uid sharing is honoured.
+        live_uids: set[str] = set()
+        for rid_dir in self._iter_rid_dirs():
+            for rev_dir in rid_dir.iterdir():
+                if not rev_dir.is_dir():
+                    continue
+                for ver_link in rev_dir.iterdir():
+                    with suppress(OSError):
+                        live_uids.add(ver_link.resolve().name)
+        for uid in candidate_uids:
+            if uid not in live_uids:
+                for real_dir in self._realdir_candidates(uid):
+                    if real_dir.exists():
+                        shutil.rmtree(real_dir)
 
     def migrate_layout(self, *, dry_run: bool = False) -> int:
         """Relocate pre-#387 flat resource/store data into the sharded trees.

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -966,6 +966,7 @@ class ResourceAction(Flag):
     load = auto()
     migrate = auto()
     modify = auto()
+    prune = auto()
 
     create_or_update = create | update | modify
 
@@ -1796,6 +1797,59 @@ class IResourceManager(ABC, Generic[T]):
         The resource cannot be restored after this operation.
         This method does NOT require the resource to be soft-deleted first;
         it can permanently delete both active and soft-deleted resources.
+        """
+
+    @abstractmethod
+    def prune_revisions(
+        self,
+        resource_id: str,
+        *,
+        keep_last_n: int | UnsetType = UNSET,
+        before: dt.datetime | UnsetType = UNSET,
+        user: str | UnsetType = UNSET,
+        now: dt.datetime | UnsetType = UNSET,
+    ) -> list[str]:
+        """Prune old revisions of a resource to reclaim storage space.
+
+        Hard-deletes historical revisions that are no longer worth keeping
+        while always preserving the resource's current revision.  The set to
+        delete is selected by two optional, composable knobs:
+
+        Args:
+            resource_id (str): the id of the resource whose revisions to prune.
+            keep_last_n: keep the *n* most important revisions and prune the
+                rest.  Importance is ranked by the sort key
+                ``(is_lineal, created_time)`` descending — revisions on the
+                current revision's ancestry chain (``parent_revision_id``) rank
+                above collateral branches, and newer above older.  The current
+                revision is always rank 1, so it is never pruned.  Must be
+                ``>= 1``.
+            before: prune revisions created strictly before this timestamp.
+            user: The user performing the action.
+            now: The current timestamp.
+
+        Returns:
+            list[str]: the revision ids that were pruned (empty when nothing
+                matched).
+
+        Raises:
+            ResourceIDNotFoundError: if resource id does not exist.
+            ValueError: if neither ``keep_last_n`` nor ``before`` is given, or
+                if ``keep_last_n < 1``.
+
+        ---
+
+        When both knobs are given the kept set is their **union** (the
+        conservative choice): a revision is pruned only when it is *both*
+        beyond ``keep_last_n`` *and* older than ``before``.  The current
+        revision is always retained regardless of the knobs.
+
+        Like ``permanently_delete``, this only removes revision payload data
+        (and underlying uid data once no surviving revision references it); it
+        never touches blob-store contents — orphaned blobs are reclaimed
+        separately (see #370).  ``total_revision_count`` is intentionally left
+        unchanged because it seeds new ``revision_id`` values and must stay
+        monotonic.  Works on soft-deleted resources too.
         """
 
     @abstractmethod

--- a/tests/test_postgres_prune_revisions.py
+++ b/tests/test_postgres_prune_revisions.py
@@ -1,0 +1,178 @@
+"""Postgres-backed revision pruning — issue #377 (integration).
+
+Auto-marked ``integration`` by the conftest file-pattern rule
+(``test_postgres_*.py``), so excluded from the fast CI lane. Requires a live
+Postgres at ``SPECSTAR_TEST_PG_DSN`` (defaults to the repo's local DSN).
+"""
+
+import datetime as dt
+import io
+import os
+import uuid
+
+import pytest
+from msgspec import Struct
+
+from specstar.resource_manager.basic import Encoding
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.types import RevisionInfo, RevisionStatus
+
+try:
+    import psycopg2
+
+    from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+    from specstar.resource_manager.resource_store.postgres import PostgresResourceStore
+except ImportError:  # pragma: no cover
+    pytest.skip("psycopg2 not installed", allow_module_level=True)
+
+PG_DSN = os.environ.get(
+    "SPECSTAR_TEST_PG_DSN",
+    "postgresql://admin:password@localhost:5432/your_database",
+)
+
+UTC = dt.timezone.utc
+
+
+def _pg_reachable() -> bool:
+    try:
+        conn = psycopg2.connect(PG_DSN, connect_timeout=3)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pg_reachable(), reason="no live Postgres at SPECSTAR_TEST_PG_DSN"
+)
+
+
+class Item(Struct):
+    name: str
+    value: int = 0
+
+
+def t(minute: int) -> dt.datetime:
+    return dt.datetime(2025, 1, 1, tzinfo=UTC) + dt.timedelta(minutes=minute)
+
+
+def _suffixes(revs) -> list[int]:
+    return sorted(int(r.rsplit(":", 1)[-1]) for r in revs)
+
+
+def _drop(prefix: str) -> None:
+    conn = psycopg2.connect(PG_DSN)
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            for table in (
+                f"{prefix}resource_index",
+                f"{prefix}resource_data",
+                f"{prefix}resource_meta",
+            ):
+                cur.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def prefix():
+    p = f"t377_{uuid.uuid4().hex[:8]}_"
+    yield p
+    _drop(p)
+
+
+@pytest.fixture
+def pg_resource_store(prefix):
+    return PostgresResourceStore(
+        pg_dsn=PG_DSN, encoding=Encoding.json, table_prefix=prefix
+    )
+
+
+@pytest.fixture
+def pg_rm(prefix):
+    storage = SimpleStorage(
+        PostgresMetaStore(
+            pg_dsn=PG_DSN, encoding=Encoding.json, table_name=f"{prefix}resource_meta"
+        ),
+        PostgresResourceStore(
+            pg_dsn=PG_DSN, encoding=Encoding.json, table_prefix=prefix
+        ),
+    )
+    return ResourceManager(Item, storage=storage)
+
+
+def _info(resource_id, revision_id, uid, *, created=None):
+    now = created or dt.datetime.now(UTC)
+    return RevisionInfo(
+        uid=uid,
+        resource_id=resource_id,
+        revision_id=revision_id,
+        schema_version=None,
+        status=RevisionStatus.stable,
+        created_time=now,
+        updated_time=now,
+        created_by="u",
+        updated_by="u",
+        parent_revision_id=None,
+        data_hash="h",
+    )
+
+
+# ── store-level primitive ─────────────────────────────────────────────
+
+
+def test_delete_revisions_removes_listed_only(pg_resource_store):
+    rid = "res"
+    for n in range(1, 4):
+        pg_resource_store.save(
+            _info(rid, f"{rid}:{n}", uuid.uuid4()), io.BytesIO(f"d{n}".encode())
+        )
+    pg_resource_store.delete_revisions(rid, [f"{rid}:1", f"{rid}:2"])
+    assert sorted(pg_resource_store.list_revisions(rid)) == [f"{rid}:3"]
+
+
+def test_delete_revisions_idempotent(pg_resource_store):
+    rid = "res"
+    pg_resource_store.save(_info(rid, f"{rid}:1", uuid.uuid4()), io.BytesIO(b"d"))
+    pg_resource_store.delete_revisions(rid, [f"{rid}:9"])  # unknown → no-op
+    pg_resource_store.delete_revisions(rid, [f"{rid}:1"])
+    pg_resource_store.delete_revisions(rid, [f"{rid}:1"])  # again → no-op
+    assert list(pg_resource_store.list_revisions(rid)) == []
+
+
+def test_delete_revisions_refcounts_shared_uid(pg_resource_store):
+    """Two revisions share a uid (the store dedups identical payloads): the
+    data row survives until the last referencing index row is deleted."""
+    rid = "res"
+    shared = uuid.uuid4()
+    pg_resource_store.save(_info(rid, f"{rid}:1", shared), io.BytesIO(b"shared"))
+    pg_resource_store.save(_info(rid, f"{rid}:2", shared), io.BytesIO(b"shared"))
+
+    pg_resource_store.delete_revisions(rid, [f"{rid}:1"])
+    with pg_resource_store.get_data_bytes(rid, f"{rid}:2", None) as fh:
+        assert fh.read() == b"shared"
+
+    pg_resource_store.delete_revisions(rid, [f"{rid}:2"])
+    assert list(pg_resource_store.list_revisions(rid)) == []
+
+
+# ── manager-level prune ───────────────────────────────────────────────
+
+
+def test_prune_keep_last_n(pg_rm):
+    with pg_rm.using(user="a") as op:
+        info = op.create(Item(name="v1"), now=t(1))
+        rid = info.resource_id
+        for i in range(2, 6):
+            op.update(rid, Item(name=f"v{i}"), now=t(i))
+
+    before = pg_rm.get_meta(rid)
+    pruned = pg_rm.prune_revisions(rid, keep_last_n=2, user="a", now=t(50))
+    after = pg_rm.get_meta(rid)
+
+    assert _suffixes(pruned) == [1, 2, 3]
+    assert _suffixes(pg_rm.list_revisions(rid)) == [4, 5]
+    assert after.current_revision_id == before.current_revision_id
+    assert after.total_revision_count == 5  # monotonic
+    assert pg_rm.get(rid).data.name == "v5"

--- a/tests/test_prune_revisions.py
+++ b/tests/test_prune_revisions.py
@@ -1,0 +1,373 @@
+"""Tests for revision pruning — issue #377.
+
+Covers the ResourceManager-level :meth:`prune_revisions` selection semantics
+and the store-level :meth:`delete_revisions` primitive (memory + disk).
+Postgres lives in ``test_postgres_prune_revisions.py`` (integration).
+"""
+
+import datetime as dt
+import io
+from uuid import uuid4
+
+import msgspec
+import pytest
+from msgspec import Struct
+from xxhash import xxh3_128_hexdigest
+
+from specstar.crud.core import SpecStar
+from specstar.events import IEventHandler
+from specstar.resource_manager.basic import Encoding, IResourceStore
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import DiskMetaStore, MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import (
+    DiskResourceStore,
+    MemoryResourceStore,
+)
+from specstar.types import Binary, ResourceIDNotFoundError, RevisionInfo, RevisionStatus
+
+UTC = dt.timezone.utc
+
+
+class Item(Struct):
+    name: str
+    value: int = 0
+
+
+def t(minute: int) -> dt.datetime:
+    return dt.datetime(2025, 1, 1, tzinfo=UTC) + dt.timedelta(minutes=minute)
+
+
+def _suffixes(revs) -> list[int]:
+    """The trailing ``:N`` sequence numbers of a set of revision ids."""
+    return sorted(int(r.rsplit(":", 1)[-1]) for r in revs)
+
+
+# ── Parametrised over the two pruning-capable simple backends ──────────
+
+
+@pytest.fixture(params=["memory", "disk"])
+def storage(request, tmp_path):
+    if request.param == "memory":
+        return SimpleStorage(MemoryMetaStore(), MemoryResourceStore())
+    return SimpleStorage(
+        DiskMetaStore(rootdir=tmp_path / "meta"),
+        DiskResourceStore(rootdir=tmp_path / "data"),
+    )
+
+
+def make_rm(storage, **kwargs) -> ResourceManager:
+    return ResourceManager(Item, storage=storage, **kwargs)
+
+
+def seed(rm, n: int = 5) -> str:
+    """Create a resource with revisions v1..vn at times t(1)..t(n)."""
+    with rm.using(user="a") as op:
+        info = op.create(Item(name="v1"), now=t(1))
+        rid = info.resource_id
+        for i in range(2, n + 1):
+            op.update(rid, Item(name=f"v{i}"), now=t(i))
+    return rid
+
+
+# ── prune_revisions: keep_last_n ──────────────────────────────────────
+
+
+class TestKeepLastN:
+    def test_keeps_newest_n(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        pruned = rm.prune_revisions(rid, keep_last_n=2, user="a", now=t(50))
+        assert _suffixes(pruned) == [1, 2, 3]
+        assert _suffixes(rm.list_revisions(rid)) == [4, 5]
+
+    def test_preserves_current_and_count_is_monotonic(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        before = rm.get_meta(rid)
+        rm.prune_revisions(rid, keep_last_n=2, user="a", now=t(50))
+        after = rm.get_meta(rid)
+        assert after.current_revision_id == before.current_revision_id
+        # total_revision_count seeds new revision ids — must never shrink.
+        assert after.total_revision_count == before.total_revision_count == 5
+        # current revision still fully readable after the prune.
+        assert rm.get(rid).data.name == "v5"
+
+    def test_next_write_does_not_collide_after_prune(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50))
+        with rm.using(user="a") as op:
+            info = op.update(rid, Item(name="v6"), now=t(51))
+        # Sequence keeps climbing from total_revision_count, not the live count.
+        assert info.revision_id == f"{rid}:6"
+        assert rm.get(rid).data.name == "v6"
+
+    def test_pruned_revision_data_is_gone(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        pruned = rm.prune_revisions(rid, keep_last_n=2, user="a", now=t(50))
+        for r in pruned:
+            assert rm.revision_exists(rid, r) is False
+        for r in rm.list_revisions(rid):
+            assert rm.revision_exists(rid, r) is True
+
+    def test_floor_is_one_current_always_survives(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 3)
+        pruned = rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50))
+        assert _suffixes(pruned) == [1, 2]
+        assert _suffixes(rm.list_revisions(rid)) == [3]
+
+
+# ── prune_revisions: before (age) ─────────────────────────────────────
+
+
+class TestBefore:
+    def test_prunes_strictly_older(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        pruned = rm.prune_revisions(rid, before=t(3), user="a", now=t(50))
+        # created at t(1), t(2) are < t(3); t(3..5) are kept.
+        assert _suffixes(pruned) == [1, 2]
+        assert _suffixes(rm.list_revisions(rid)) == [3, 4, 5]
+
+    def test_never_prunes_current_even_when_old(self, storage):
+        """Switch current back to an old revision, then age-prune everything
+        before 'now': the current revision is retained regardless."""
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        rm.switch(rid, f"{rid}:2", user="a", now=t(20))
+        pruned = rm.prune_revisions(rid, before=t(50), user="a", now=t(60))
+        remaining = rm.list_revisions(rid)
+        assert f"{rid}:2" in remaining  # current survived the age cutoff
+        assert f"{rid}:2" not in pruned
+        assert rm.get(rid).data.name == "v2"
+
+
+# ── prune_revisions: union of both knobs ──────────────────────────────
+
+
+class TestUnion:
+    def test_union_is_conservative(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        # keep top-2 {4,5} ∪ {created>=t(3)} {3,4,5} = {3,4,5}.
+        # Pruned only when beyond N AND older than before → {1,2}.
+        pruned = rm.prune_revisions(
+            rid, keep_last_n=2, before=t(3), user="a", now=t(50)
+        )
+        assert _suffixes(pruned) == [1, 2]
+        assert _suffixes(rm.list_revisions(rid)) == [3, 4, 5]
+
+
+# ── prune_revisions: lineage / 直系 ranking ───────────────────────────
+
+
+class TestLineage:
+    def test_lineal_ancestors_outrank_collateral_branches(self, storage):
+        """After switching current to v3, the lineage is {1,2,3} and {4,5} are
+        collateral. keep_last_n=2 keeps the current's recent ancestry, not the
+        chronologically newer collateral branch."""
+        rm = make_rm(storage)
+        rid = seed(rm, 5)
+        rm.switch(rid, f"{rid}:3", user="a", now=t(20))
+        pruned = rm.prune_revisions(rid, keep_last_n=2, user="a", now=t(50))
+        # ordered by (lineal, time): [3,2,1] then [5,4]; top-2 = {3,2}.
+        assert _suffixes(pruned) == [1, 4, 5]
+        assert _suffixes(rm.list_revisions(rid)) == [2, 3]
+        assert rm.get(rid).data.name == "v3"
+
+    def test_same_timestamp_orders_by_sequence(self, storage):
+        """Revisions written at one ``now`` still order by authoring sequence,
+        so keep_last_n is deterministic on batch-created history."""
+        rm = make_rm(storage)
+        with rm.using(user="a", now=t(7)) as op:  # every revision shares t(7)
+            info = op.create(Item(name="v1"))
+            rid = info.resource_id
+            for i in range(2, 5):
+                op.update(rid, Item(name=f"v{i}"))
+        pruned = rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50))
+        assert _suffixes(pruned) == [1, 2, 3]
+        assert _suffixes(rm.list_revisions(rid)) == [4]
+
+
+# ── prune_revisions: validation, no-op, errors, soft-delete ───────────
+
+
+class TestEdges:
+    def test_requires_a_knob(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 2)
+        with pytest.raises(ValueError):
+            rm.prune_revisions(rid, user="a", now=t(50))
+
+    def test_keep_last_n_must_be_positive(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 2)
+        with pytest.raises(ValueError):
+            rm.prune_revisions(rid, keep_last_n=0, user="a", now=t(50))
+
+    def test_noop_when_nothing_matches(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 3)
+        assert rm.prune_revisions(rid, keep_last_n=10, user="a", now=t(50)) == []
+        assert _suffixes(rm.list_revisions(rid)) == [1, 2, 3]
+
+    def test_single_revision_is_noop(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 1)
+        assert rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50)) == []
+
+    def test_missing_resource_raises(self, storage):
+        rm = make_rm(storage)
+        with pytest.raises(ResourceIDNotFoundError):
+            rm.prune_revisions("nope", keep_last_n=1, user="a", now=t(50))
+
+    def test_soft_deleted_resource_is_prunable(self, storage):
+        rm = make_rm(storage)
+        rid = seed(rm, 4)
+        rm.delete(rid, user="a", now=t(10))
+        assert rm.get_meta(rid, include_deleted=True).is_deleted is True
+        pruned = rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50))
+        assert _suffixes(pruned) == [1, 2, 3]
+        assert _suffixes(rm.list_revisions(rid)) == [4]
+
+
+# ── prune_revisions: events ───────────────────────────────────────────
+
+
+class _Spy(IEventHandler):
+    def __init__(self):
+        self.seen = []
+
+    def is_supported(self, ctx) -> bool:
+        return type(ctx).__name__.endswith("Prune")
+
+    def handle_event(self, ctx) -> None:
+        self.seen.append((type(ctx).__name__, getattr(ctx, "pruned", None)))
+
+
+class TestEvents:
+    def test_lifecycle_events_fire_with_pruned_payload(self, storage):
+        spy = _Spy()
+        rm = make_rm(storage, event_handlers=[spy])
+        rid = seed(rm, 4)
+        pruned = rm.prune_revisions(rid, keep_last_n=1, user="a", now=t(50))
+        names = [n for n, _ in spy.seen]
+        assert "BeforePrune" in names
+        assert "OnSuccessPrune" in names
+        assert "AfterPrune" in names
+        success_payload = next(p for n, p in spy.seen if n == "OnSuccessPrune")
+        assert sorted(success_payload) == sorted(pruned)
+
+
+# ── store-level delete_revisions primitive ────────────────────────────
+
+
+def _info(resource_id, revision_id, uid, *, schema_version=None, created=None):
+    now = created or dt.datetime.now(UTC)
+    return RevisionInfo(
+        uid=uid,
+        resource_id=resource_id,
+        revision_id=revision_id,
+        schema_version=schema_version,
+        status=RevisionStatus.stable,
+        created_time=now,
+        updated_time=now,
+        created_by="u",
+        updated_by="u",
+        parent_revision_id=None,
+        data_hash="h",
+    )
+
+
+@pytest.fixture(params=["memory", "disk"])
+def resource_store(request, tmp_path) -> IResourceStore:
+    if request.param == "memory":
+        return MemoryResourceStore(encoding=Encoding.json)
+    return DiskResourceStore(encoding=Encoding.json, rootdir=tmp_path)
+
+
+class TestDeleteRevisionsPrimitive:
+    def test_removes_listed_revisions_only(self, resource_store):
+        rid = "res"
+        for n in range(1, 4):
+            resource_store.save(
+                _info(rid, f"{rid}:{n}", uuid4()), io.BytesIO(f"d{n}".encode())
+            )
+        resource_store.delete_revisions(rid, [f"{rid}:1", f"{rid}:2"])
+        assert sorted(resource_store.list_revisions(rid)) == [f"{rid}:3"]
+
+    def test_idempotent_on_unknown_revisions(self, resource_store):
+        rid = "res"
+        resource_store.save(_info(rid, f"{rid}:1", uuid4()), io.BytesIO(b"d"))
+        # Deleting a non-existent revision (or twice) must not raise.
+        resource_store.delete_revisions(rid, [f"{rid}:9"])
+        resource_store.delete_revisions(rid, [f"{rid}:1"])
+        resource_store.delete_revisions(rid, [f"{rid}:1"])
+        assert list(resource_store.list_revisions(rid)) == []
+
+    def test_shared_uid_payload_is_refcounted(self, resource_store):
+        """Two revisions backed by the same uid: deleting one must keep the
+        shared payload alive until the last referrer is gone."""
+        rid = "res"
+        shared = uuid4()
+        resource_store.save(_info(rid, f"{rid}:1", shared), io.BytesIO(b"shared"))
+        resource_store.save(_info(rid, f"{rid}:2", shared), io.BytesIO(b"shared"))
+        resource_store.save(_info(rid, f"{rid}:3", uuid4()), io.BytesIO(b"solo"))
+
+        resource_store.delete_revisions(rid, [f"{rid}:1"])
+        # rev2 still references the shared uid → its data is intact.
+        with resource_store.get_data_bytes(rid, f"{rid}:2", None) as fh:
+            assert fh.read() == b"shared"
+
+        resource_store.delete_revisions(rid, [f"{rid}:2"])
+        # Last referrer gone → shared payload reclaimed; solo rev untouched.
+        with resource_store.get_data_bytes(rid, f"{rid}:3", None) as fh:
+            assert fh.read() == b"solo"
+
+
+# ── blob decref integration (#370) ────────────────────────────────────
+
+
+class Doc(msgspec.Struct):
+    title: str
+    file: Binary | None = None
+
+
+class TestBlobDecref:
+    def test_prune_decrefs_only_pruned_revisions_blobs(self):
+        spec = SpecStar()
+        spec.add_model(Doc)
+        rm = spec.resource_managers["doc"]
+        ref = dt.datetime.now(UTC)
+        seed_time = dt.datetime(2026, 1, 1, tzinfo=UTC)
+
+        fid_a = xxh3_128_hexdigest(b"payload-A")
+        fid_b = xxh3_128_hexdigest(b"payload-B")
+        with rm.using("alice", seed_time) as op:
+            info = op.create(Doc(title="a", file=Binary(data=b"payload-A")))
+            rid = info.resource_id
+            op.update(rid, Doc(title="b", file=Binary(data=b"payload-B")))
+
+        assert spec.blob_store.exists(fid_a)
+        pruned = rm.prune_revisions(rid, keep_last_n=1, user="alice", now=seed_time)
+        assert _suffixes(pruned) == [1]
+
+        # The pruned revision's blob is now orphaned and gets collected; the
+        # current revision's blob is retained (still referenced).
+        spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=2))
+        spec.gc(mode="reconcile", now=ref + dt.timedelta(hours=27))
+        assert spec.blob_store.exists(fid_a) is False
+        assert spec.blob_store.exists(fid_b) is True
+        assert rm.get(rid).data.title == "b"
+
+
+# ── S3 explicitly defers to a follow-up (#377 scope) ──────────────────
+
+
+def test_s3_does_not_implement_delete_revisions():
+    s3 = pytest.importorskip("specstar.resource_manager.resource_store.s3")
+    # S3 inherits the base NotImplementedError stub (parity with its missing
+    # purge_resource); revision pruning on S3 is deliberately out of scope.
+    assert s3.S3ResourceStore.delete_revisions is IResourceStore.delete_revisions


### PR DESCRIPTION
Closes #377.

Adds a manual per-resource revision-pruning primitive to reclaim storage space.

## API
- `ResourceManager.prune_revisions(resource_id, *, keep_last_n>=1, before=...)` → returns the pruned revision ids.
- Store-level `IResourceStore.delete_revisions(resource_id, revision_ids)` (memory, disk, postgres). S3 inherits the base `NotImplementedError`, consistent with its still-missing `purge_resource`.

## Selection semantics
- Revisions rank by `(is-lineal, created_time, sequence)` descending. *Lineal* = on the current revision's `parent_revision_id` ancestry chain. The current revision is always rank 1, so the `keep_last_n >= 1` floor always protects it.
- `keep_last_n` and `before` compose as a **union** (conservative): a revision is pruned only when it is *both* beyond `keep_last_n` *and* older than `before`.
- The sequence-number tie-break keeps `keep_last_n` deterministic on history batch-created at one timestamp.

## Invariants & safety
- `total_revision_count` is left unchanged — it seeds new `revision_id`s and must stay monotonic. Live count is `len(list_revisions())`.
- Pruned revisions' blobs are `decref`'d so the #370 GC reclaims them; no blob is deleted directly. Shared `uid` payloads are reference-counted (dropped only once no surviving revision references them).
- Defensive concurrency guard: the current revision is re-read and excluded right before deletion; `delete_revisions` is idempotent.
- Works on soft-deleted resources. Strict arg validation; an empty prune set is a successful no-op.

## Scope
Lands the **primitive + lifecycle events** (`Before/After/OnSuccess/OnFailurePrune`). Deferred to follow-ups: wiring `ResourceAction.prune` into permissions/HTTP routes, an automatic retention policy (max_revisions / TTL), and S3 support.

## Incidental fix
`scripts/gen_events_stub.py` now emits `StringRefEventHandler` (previously only hand-patched into the committed `events.pyi`, leaving the stub drifted from its generator); `events.pyi` regenerated so `make stubs-check` is truly in sync.

## Tests
- `tests/test_prune_revisions.py` — memory + disk (fast CI): keep_last_n, before, union, lineage/switch, same-timestamp ordering, floor, validation, no-op, soft-delete, events, store-level idempotency & shared-uid refcount, blob decref/GC integration, S3 NotImplementedError.
- `tests/test_postgres_prune_revisions.py` — Postgres (integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
