### PR TITLE
docs(crud): document prune_revisions revision pruning (#396)

### DIFF
--- a/docs/en/howto/binary-data.md
+++ b/docs/en/howto/binary-data.md
@@ -190,5 +190,6 @@ In most stored resources, the raw byte content is not kept inline.
 
 - [API conventions](/specstar/howto/api-conventions)
 - [Routes generation](/specstar/howto/routes)
+- [Prune old revisions](/specstar/howto/prune-revisions) — decrefs blobs for GC to reclaim
 - [From demo to production](/specstar/guides/from-demo-to-production)
 - [Examples](/specstar/examples/)

--- a/docs/en/howto/index.md
+++ b/docs/en/howto/index.md
@@ -34,6 +34,7 @@ Use it when you already know what you want to do in SpecStar and need the shorte
 - [GraphQL](/specstar/howto/graphql)
 - [Binary data](/specstar/howto/binary-data)
 - [Backup and restore](/specstar/howto/backup-restore)
+- [Prune old revisions](/specstar/howto/prune-revisions)
 - [Web UI](/specstar/howto/web-ui)
 
 ### Spec-driven authoring

--- a/docs/en/howto/prune-revisions.md
+++ b/docs/en/howto/prune-revisions.md
@@ -1,0 +1,175 @@
+# Prune old revisions
+
+SpecStar keeps every change as a new revision (see
+[Data versioning](/specstar/quickstart/data-versioning)). That history is the
+point — but on long-lived resources it also accumulates storage you may no
+longer need. `prune_revisions` hard-deletes selected historical revisions to
+reclaim space, while **always keeping the current revision**.
+
+> **Python API only (for now).** `prune_revisions` is a `ResourceManager`
+> method. There is no generated HTTP route and no permission gate for it yet —
+> call it from trusted server-side code (a maintenance job, a CLI command, a
+> scheduled task). It *does* emit a `prune` event, so any
+> [event handler](/specstar/howto/event-handlers) you have registered observes
+> it like any other action.
+
+---
+
+## The API
+
+```python
+pruned_ids = mgr.prune_revisions(
+    resource_id,
+    *,
+    keep_last_n=...,   # int >= 1, optional
+    before=...,        # aware datetime, optional
+    user=...,          # who performed the prune (for the event), optional
+    now=...,           # clock for the event, optional
+)
+```
+
+- Returns `list[str]` — the revision ids that were pruned (empty when nothing
+  matched).
+- Raises `ValueError` if you pass **neither** `keep_last_n` **nor** `before`, or
+  if `keep_last_n < 1`.
+- Raises `ResourceIDNotFoundError` if the resource id does not exist.
+- Works on soft-deleted resources too.
+
+You must supply at least one of `keep_last_n` or `before`; there is no
+"prune everything" mode, because the current revision is never prunable.
+
+---
+
+## What gets kept
+
+Two knobs select what to **keep**; everything else is pruned.
+
+`keep_last_n` keeps the *n* most important revisions, ranked from most to least
+important by:
+
+1. **Lineal first** — revisions on the current revision's ancestry chain (follow
+   `parent_revision_id` from the current revision back to the root) rank above
+   collateral branches. Collateral branches appear when you `switch()` to an old
+   revision and then edit, forking the history.
+2. **Newer first** — within the same lineage, more recently created wins.
+
+The current revision is always lineal and the newest of its own line, so it is
+always rank 1 and never pruned. (A deterministic tie-break on the revision
+sequence number keeps `keep_last_n` stable when several revisions share a
+timestamp: the full sort key is `(is_lineal, created_time, sequence)`, ranked
+descending.)
+
+`before` keeps every revision created **at or after** the given timestamp and
+prunes those created strictly before it.
+
+> **`total_revision_count` never decreases.** It seeds new revision ids and must
+> stay monotonic, so pruning leaves it untouched. The *live* number of revisions
+> is `len(mgr.list_revisions(resource_id))`; `mgr.get_meta(resource_id).total_revision_count`
+> is the running total ever created, which keeps climbing.
+
+---
+
+## Example
+
+Take a `Config` resource that has been edited many times. We stamp explicit
+timestamps so the `before` example is reproducible.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+import msgspec
+from fastapi import FastAPI
+
+from specstar import spec, Schema
+
+
+class Config(msgspec.Struct):
+    value: str
+
+
+app = FastAPI()
+spec.configure(default_user="ops", default_now=lambda: datetime.now(timezone.utc))
+spec.add_model(Schema(Config, "v1"))
+spec.apply(app)
+
+mgr = spec.get_resource_manager(Config)
+
+# 8 revisions, one per day: rev 1 (oldest) ... rev 8 (current).
+base = datetime(2025, 1, 1, tzinfo=timezone.utc)
+info = mgr.create(Config(value="v0"), now=base)
+rid = info.resource_id
+for i in range(1, 8):
+    mgr.update(rid, Config(value=f"v{i}"), now=base + timedelta(days=i))
+
+print(len(mgr.list_revisions(rid)))            # 8  -> live revision count
+print(mgr.get_meta(rid).total_revision_count)  # 8  -> running total
+```
+
+### Keep the last N
+
+```python
+pruned = mgr.prune_revisions(rid, keep_last_n=3)
+
+print(len(pruned))                             # 5  -> the 5 oldest were pruned
+print(len(mgr.list_revisions(rid)))            # 3  -> current + 2 newest survive
+print(mgr.get_meta(rid).total_revision_count)  # 8  -> unchanged (monotonic)
+```
+
+The current revision is still readable, untouched:
+
+```python
+print(mgr.get(rid).data.value)                 # "v7"
+```
+
+### Prune everything older than a date
+
+On a fresh 8-revision resource:
+
+```python
+cutoff = base + timedelta(days=4)              # keep rev 5..8, prune rev 1..4
+pruned = mgr.prune_revisions(rid, before=cutoff)
+
+print(len(pruned))                             # 4
+print(len(mgr.list_revisions(rid)))            # 4
+```
+
+### Combine both knobs (conservative union)
+
+When you pass both, the kept sets **union**: a revision survives if *either*
+knob would keep it. Equivalently, a revision is pruned only when it is *both*
+beyond `keep_last_n` *and* older than `before`.
+
+```python
+# keep_last_n=2 alone would prune 6 (keep rev 7, 8).
+# before=cutoff alone would prune 4 (keep rev 5..8).
+# Union keeps rev 5..8 -> prunes only 4. rev 5, 6 survive because `before`
+# keeps them even though keep_last_n=2 would have dropped them.
+pruned = mgr.prune_revisions(rid, keep_last_n=2, before=base + timedelta(days=4))
+
+print(len(pruned))                             # 4
+```
+
+---
+
+## Blob interplay
+
+If your resources carry [binary data](/specstar/howto/binary-data), pruning a
+revision **decrements** the reference count of the blobs that revision pointed
+at — it never deletes blob contents directly. A blob is only reclaimed once no
+surviving revision references it, and reclamation happens in a separate
+garbage-collection pass you run yourself with `spec.gc(...)`.
+
+So the storage from pruned revision payloads is freed immediately, but the
+underlying blob bytes are freed on the next GC. See
+[Binary data → Blob lifecycle and garbage collection](/specstar/howto/binary-data)
+for how and when to run `gc()`.
+
+---
+
+## Related pages
+
+- [Data versioning](/specstar/quickstart/data-versioning) — how revisions are
+  created and read in the first place
+- [Binary data](/specstar/howto/binary-data) — blob storage and the `gc()` pass
+  that reclaims unreferenced blobs
+- [Event handlers](/specstar/howto/event-handlers) — observe the `prune` event

--- a/docs/en/quickstart/data-versioning.md
+++ b/docs/en/quickstart/data-versioning.md
@@ -212,6 +212,7 @@ Next Steps:
 
 - [Set up backend persistence and storage](/specstar/guides/backend-setup)
 - [Handle schema evolution safely](/specstar/quickstart/schema-migration)
+- [Prune old revisions to reclaim storage](/specstar/howto/prune-revisions)
 - [Move from demo to production](/specstar/guides/from-demo-to-production)
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,7 @@ plugins:
                 - howto/vector-search.md
                 - howto/pydantic-integration.md
                 - howto/backup-restore.md
+                - howto/prune-revisions.md
                 - howto/web-ui.md
                 - howto/relationships.md
                 - howto/constraints.md

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -190,3 +190,98 @@ def test_delete_returns_resource_meta_not_revision_info(tmp_path):
     assert meta.is_deleted is True
     assert isinstance(meta.current_revision_id, str)
     assert not hasattr(meta, "revision_id")
+
+
+# --- Prune revisions how-to (docs/en/howto/prune-revisions.md) ---
+
+
+class _Cfg(Struct):
+    value: str
+
+
+def _cfg_history(tmp_path, n=8):
+    """A resource with ``n`` revisions stamped one day apart (rev 1 oldest ...
+    rev n current), mirroring the how-to's example. Returns (mgr, rid, base)."""
+    sp = _fresh(tmp_path)
+    app = FastAPI()
+    sp.add_model(Schema(_Cfg, "v1"))
+    sp.apply(app)
+    mgr = sp.get_resource_manager(_Cfg)
+    base = dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc)
+    info = mgr.create(_Cfg(value="v0"), now=base)
+    rid = info.resource_id
+    for i in range(1, n):
+        mgr.update(rid, _Cfg(value=f"v{i}"), now=base + dt.timedelta(days=i))
+    return mgr, rid, base
+
+
+def test_prune_keep_last_n_drops_oldest_and_keeps_current(tmp_path):
+    """keep_last_n keeps the current + the (n-1) newest; the rest are pruned."""
+    mgr, rid, _ = _cfg_history(tmp_path)
+    assert len(mgr.list_revisions(rid)) == 8
+    assert mgr.get_meta(rid).total_revision_count == 8
+
+    pruned = mgr.prune_revisions(rid, keep_last_n=3)
+
+    assert isinstance(pruned, list) and all(isinstance(r, str) for r in pruned)
+    assert len(pruned) == 5
+    assert len(mgr.list_revisions(rid)) == 3
+    # the current revision is never pruned and stays readable
+    assert mgr.get(rid).data.value == "v7"
+
+
+def test_prune_leaves_total_revision_count_monotonic(tmp_path):
+    """The live count is len(list_revisions()); total_revision_count never drops
+    (it seeds new revision ids)."""
+    mgr, rid, _ = _cfg_history(tmp_path)
+    mgr.prune_revisions(rid, keep_last_n=3)
+    assert len(mgr.list_revisions(rid)) == 3
+    assert mgr.get_meta(rid).total_revision_count == 8
+
+
+def test_prune_before_drops_strictly_older(tmp_path):
+    """before keeps revisions created at/after the cutoff, prunes strictly older
+    ones."""
+    mgr, rid, base = _cfg_history(tmp_path)
+    cutoff = base + dt.timedelta(days=4)  # keep rev 5..8 (v4..v7), prune v0..v3
+    pruned = mgr.prune_revisions(rid, before=cutoff)
+    assert len(pruned) == 4
+    survivors = {
+        mgr.get(rid, revision_id=r).data.value for r in mgr.list_revisions(rid)
+    }
+    assert survivors == {"v4", "v5", "v6", "v7"}
+
+
+def test_prune_union_is_conservative(tmp_path):
+    """With both knobs the kept sets union: a revision survives if *either* knob
+    keeps it, so combining prunes no more than either knob alone."""
+    # keep_last_n=2 alone would prune 6 (keep only v6, v7) ...
+    mgr_a, rid_a, _ = _cfg_history(tmp_path)
+    assert len(mgr_a.prune_revisions(rid_a, keep_last_n=2)) == 6
+
+    # ... but unioned with before=day4 (which keeps v4..v7), only v0..v3 are
+    # pruned: v4, v5 survive because `before` keeps them.
+    mgr_b, rid_b, base = _cfg_history(tmp_path)
+    pruned = mgr_b.prune_revisions(
+        rid_b, keep_last_n=2, before=base + dt.timedelta(days=4)
+    )
+    assert len(pruned) == 4
+    survivors = {
+        mgr_b.get(rid_b, revision_id=r).data.value
+        for r in mgr_b.list_revisions(rid_b)
+    }
+    assert survivors == {"v4", "v5", "v6", "v7"}
+
+
+def test_prune_requires_a_knob_and_validates(tmp_path):
+    """Neither knob, or keep_last_n < 1, raises ValueError; an unknown resource
+    id raises ResourceIDNotFoundError."""
+    from specstar.types import ResourceIDNotFoundError
+
+    mgr, rid, _ = _cfg_history(tmp_path)
+    with pytest.raises(ValueError):
+        mgr.prune_revisions(rid)  # neither keep_last_n nor before
+    with pytest.raises(ValueError):
+        mgr.prune_revisions(rid, keep_last_n=0)
+    with pytest.raises(ResourceIDNotFoundError):
+        mgr.prune_revisions(rid.split(":")[0] + ":nonexistent", keep_last_n=1)


### PR DESCRIPTION
Follow-up to #377 / #391: `prune_revisions` shipped with docstrings but no user-facing docs. This adds them.

## What's here
- **New How-to page** `docs/en/howto/prune-revisions.md` covering everything #396 asked for:
  - the API — `prune_revisions(resource_id, *, keep_last_n>=1, before=...)`, return type, and the `ValueError` / `ResourceIDNotFoundError` guards
  - selection semantics — `(is_lineal, created_time, sequence)` ranking, current revision always kept, `keep_last_n` + `before` compose as a conservative **union**
  - the `total_revision_count` monotonicity invariant (live count is `len(list_revisions())`)
  - the blob interplay — pruning `decref`s blobs for the #370 GC; no blob is deleted directly (links to the binary-data GC section)
  - a runnable 3-part example (keep_last_n / before / union) that demonstrates the count invariant in code
  - a callout scoping it as Python-API-only for now (no HTTP route / permission gate yet; it does emit a `prune` event)
- **Wiring**: added to the How-to nav (`mkdocs.yml`) and index, cross-linked from the data-versioning quickstart and the binary-data page.
- **Contract tests**: 5 new `test_docs_contract` cases lock the documented behaviors (keep_last_n, before, conservative union, current-revision survival, count monotonicity, error guards).

## Verification
- `uv run pytest tests/test_docs_contract.py` → 13 passed (8 existing + 5 new).
- Ran the doc's example verbatim — output matches the documented numbers.
- `uv run --extra docs mkdocs build --clean` succeeds; the new page renders and its links follow the existing absolute-link convention (no new broken links).

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)