### PR TITLE
feat(permission): resource-aware write authorization via current_resource (#398, part B)

### DIFF
--- a/docs/en/howto/permissions.md
+++ b/docs/en/howto/permissions.md
@@ -147,6 +147,64 @@ Use this when you want a convenient starting point and plan to build out the rul
 
 ---
 
+## Resource-aware write authorization
+
+For write actions (`update`, `modify`, `patch`, `delete`) a checker can read the
+**current, already-stored** resource — its `meta`, `data`, and revision `info` —
+to make data- or owner-based decisions. SpecStar loads that snapshot into
+`context.current_resource` *before* running the before-phase check.
+
+A checker only pays for what it declares. Use `required_resource_parts(action)`
+(or the `@requires_resource_parts(...)` marker on a `CheckFunc`) to opt in to the
+slices you actually read — an owner check stays a cheap `meta` read and never
+loads the data blob:
+
+```python
+from specstar.permission import (
+    ActionBasedPermissionChecker,
+    ResourcePart,
+    any_authenticated,
+    owner_self,
+    requires_resource_parts,
+)
+from specstar.types import ResourceAction
+
+
+# Built-in: owner_self reads current_resource.meta.created_by.
+# Custom: read an embedded field on the stored data.
+@requires_resource_parts(ResourcePart.DATA)
+def only_if_public(context):
+    current = context.current_resource
+    return (
+        PermissionResult.allow
+        if current.data.visibility == "public"
+        else PermissionResult.deny
+    )
+
+
+checker = ActionBasedPermissionChecker.from_dict(
+    {
+        ResourceAction.read: any_authenticated,  # internal reads writes perform
+        ResourceAction.update: owner_self,       # needs meta → loaded for you
+        ResourceAction.delete: owner_self,
+    }
+)
+```
+
+Notes:
+
+- The snapshot carries only the declared slices; the rest stay `UNSET`. Models
+  with no resource-aware checker pay **no** extra read.
+- On a write, `context.data` is the *incoming* (new) value while
+  `context.current_resource.data` is the *stored* (old) value — handy for
+  "this field is immutable" rules.
+- If the resource doesn't exist, the write fails with the usual not-found
+  (404) **before** the permission verdict is reached.
+- Reads/lists are out of scope here — filter those with a read access-scope
+  predicate instead.
+
+---
+
 ## What actions can be protected
 
 Permission checks are tied to `ResourceAction` values such as:

--- a/scripts/gen_events_stub.py
+++ b/scripts/gen_events_stub.py
@@ -229,6 +229,7 @@ def main() -> None:
     out.append("from specstar.types import ResourceMeta as ResourceMeta")
     out.append("from specstar.types import RevisionInfo as RevisionInfo")
     out.append("from specstar.types import RevisionStatus as RevisionStatus")
+    out.append("from specstar.types import SearchedResource as SearchedResource")
     out.append("")
     out.append('T = TypeVarExt("T", default=None)')
     out.append("")

--- a/specstar/events.py
+++ b/specstar/events.py
@@ -33,6 +33,7 @@ from specstar.types import (
     ResourceMeta,
     RevisionInfo,
     RevisionStatus,
+    SearchedResource,
 )
 
 T = TypeVarExt("T", default=None)
@@ -130,6 +131,19 @@ _on_failure_context: list[_DefstructField] = [
     ("error", str),
     ("stack_trace", str | None, None),
 ]
+
+# Snapshot of the *current* (pre-write) resource, attached to write
+# before-contexts (update/modify/patch/delete) so a permission checker can make
+# data/owner-based decisions on the already-stored resource. The ResourceManager
+# populates only the slices a checker declares via
+# ``IPermissionChecker.required_resource_parts`` (see specstar.permission
+# .ResourcePart); the rest stay UNSET, and it stays UNSET entirely when no
+# checker needs it. Appended only to the ``Before*`` write structs.
+_current_resource_field: _DefstructField = (
+    "current_resource",
+    SearchedResource[T] | UnsetType,
+    UNSET,
+)
 
 # ============================================================================
 # Create Context Classes
@@ -498,6 +512,7 @@ BeforeUpdate = defstruct(
     [
         *_before_context,
         *_update_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,
@@ -558,6 +573,7 @@ BeforeModify = defstruct(
     [
         *_before_context,
         *_modify_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,
@@ -617,6 +633,7 @@ BeforePatch = defstruct(
     [
         *_before_context,
         *_patch_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,
@@ -728,6 +745,7 @@ BeforeDelete = defstruct(
     [
         *_before_context,
         *_delete_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,

--- a/specstar/events.pyi
+++ b/specstar/events.pyi
@@ -20,6 +20,7 @@ from specstar.types import ResourceAction as ResourceAction
 from specstar.types import ResourceMeta as ResourceMeta
 from specstar.types import RevisionInfo as RevisionInfo
 from specstar.types import RevisionStatus as RevisionStatus
+from specstar.types import SearchedResource as SearchedResource
 
 T = TypeVarExt("T", default=None)
 
@@ -109,6 +110,7 @@ class BeforeDelete(Struct, kw_only=True, tag=True, tag_field="context_type"):
     resource_name: str
     action: Literal[ResourceAction.delete] = ResourceAction.delete
     resource_id: str
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterDelete(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -432,6 +434,7 @@ class BeforeModify(
     status: RevisionStatus | UnsetType = UNSET
     expected_revision_id: str | UnsetType = UNSET
     expected_etag: str | UnsetType = UNSET
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterModify(Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -486,6 +489,7 @@ class BeforePatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     patch_data: JsonPatch
     expected_revision_id: str | UnsetType = UNSET
     expected_etag: str | UnsetType = UNSET
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterPatch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -739,6 +743,7 @@ class BeforeUpdate(
     status: RevisionStatus | UnsetType = UNSET
     expected_revision_id: str | UnsetType = UNSET
     expected_etag: str | UnsetType = UNSET
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterUpdate(Struct, Generic[T], kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"

--- a/specstar/permission/__init__.py
+++ b/specstar/permission/__init__.py
@@ -13,6 +13,8 @@ from specstar.permission.checker import (
     IPermissionChecker,
     PermissionContext,
     PermissionResult,
+    ResourcePart,
+    requires_resource_parts,
 )
 from specstar.permission.composite import (
     CompositePermissionChecker,
@@ -44,6 +46,7 @@ __all__ = [
     "RBACPermissionEntry",
     "ResourceAction",
     "ResourceOwnershipChecker",
+    "ResourcePart",
     "RoleMembership",
     "RootOnly",
     "admin_only",
@@ -51,4 +54,5 @@ __all__ = [
     "any_user",
     "deny_all",
     "owner_self",
+    "requires_resource_parts",
 ]

--- a/specstar/permission/action.py
+++ b/specstar/permission/action.py
@@ -14,6 +14,7 @@ from specstar.permission.checker import (
     IPermissionChecker,
     PermissionContext,
     PermissionResult,
+    ResourcePart,
 )
 from specstar.types import ResourceAction
 
@@ -54,6 +55,19 @@ class ActionBasedPermissionChecker(IPermissionChecker):
                 return result
 
         return PermissionResult.not_applicable
+
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        """Union of the ``@requires_resource_parts`` markers of every CheckFunc
+        registered for ``action``. This is how an action→CheckFunc map declares,
+        per action, which slices of the current resource its checks read."""
+        parts: frozenset[ResourcePart] = frozenset()
+        for a, handlers in self._action_handlers.items():
+            if action in a:  # ty:ignore[unsupported-operator]
+                for h in handlers:
+                    parts |= getattr(h, "_required_resource_parts", frozenset())
+        return parts
 
     @classmethod
     def from_dict(

--- a/specstar/permission/builtins.py
+++ b/specstar/permission/builtins.py
@@ -9,10 +9,14 @@ which the codegen turns into ``specstar.string_ref(...)``.
 
 from __future__ import annotations
 
+from msgspec import UNSET
+
 from specstar.permission.checker import (
     DEFAULT_ROOT_USER,
     PermissionContext,
     PermissionResult,
+    ResourcePart,
+    requires_resource_parts,
 )
 
 
@@ -41,14 +45,23 @@ def deny_all(context: PermissionContext) -> PermissionResult:
     return PermissionResult.deny
 
 
+@requires_resource_parts(ResourcePart.META)
 def owner_self(context: PermissionContext) -> PermissionResult:
-    """Allow when ``context.user`` matches the resource's ``meta.created_by``.
+    """Allow when ``context.user`` matches the current resource's
+    ``meta.created_by``.
 
-    For actions on resources that don't have a meta yet (e.g. create),
-    no owner exists → deny.
+    Reads the pre-write ``current_resource`` snapshot the ResourceManager
+    loads for write checks (update/modify/patch/delete) — the
+    ``@requires_resource_parts(ResourcePart.META)`` marker is what makes that
+    ``meta`` slice available. For actions with no current resource (e.g.
+    create, or read contexts that don't carry the snapshot) no owner exists
+    → deny.
     """
-    meta = getattr(context, "meta", None)
-    if meta is None:
+    current = getattr(context, "current_resource", UNSET)
+    if current is UNSET or current is None:
+        return PermissionResult.deny
+    meta = getattr(current, "meta", UNSET)
+    if meta is UNSET or meta is None:
         return PermissionResult.deny
     created_by = getattr(meta, "created_by", None)
     if created_by is None:

--- a/specstar/permission/checker.py
+++ b/specstar/permission/checker.py
@@ -9,9 +9,14 @@ Defines:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from enum import StrEnum
+from typing import TYPE_CHECKING, TypeVar
 
 from specstar.events import EventContext
+
+if TYPE_CHECKING:
+    from specstar.types import ResourceAction
 
 PermissionContext = EventContext
 
@@ -24,6 +29,47 @@ class PermissionResult(StrEnum):
     allow = "allow"
     deny = "deny"
     not_applicable = "not_applicable"
+
+
+class ResourcePart(StrEnum):
+    """Slices of the *current* (stored) resource a permission checker may need
+    loaded into a write-phase ``PermissionContext.current_resource``.
+
+    A checker declares which slices it reads via
+    :meth:`IPermissionChecker.required_resource_parts`; the ResourceManager
+    loads only those before a write (update/modify/patch/delete) permission
+    check, so an owner-only check stays a cheap ``meta`` read and never pays
+    for the data blob.
+    """
+
+    META = "meta"
+    DATA = "data"
+    INFO = "info"
+
+
+_CF = TypeVar("_CF", bound=Callable[..., "PermissionResult"])
+
+
+def requires_resource_parts(*parts: ResourcePart) -> Callable[[_CF], _CF]:
+    """Mark a ``CheckFunc`` with the :class:`ResourcePart` slices it reads.
+
+    ``ActionBasedPermissionChecker`` (and ``ConditionalPermissionChecker``)
+    aggregate these markers into their own
+    :meth:`IPermissionChecker.required_resource_parts` so the ResourceManager
+    knows what to preload. Unmarked functions need nothing.
+
+    Example::
+
+        @requires_resource_parts(ResourcePart.META)
+        def owner_self(context): ...
+    """
+    frozen = frozenset(parts)
+
+    def deco(func: _CF) -> _CF:
+        func._required_resource_parts = frozen  # type: ignore[attr-defined]
+        return func
+
+    return deco
 
 
 class IPermissionChecker(ABC):
@@ -40,10 +86,25 @@ class IPermissionChecker(ABC):
             PermissionResult: 檢查結果
         """
 
+    def required_resource_parts(
+        self, action: "ResourceAction"
+    ) -> frozenset[ResourcePart]:
+        """Resource slices this checker needs loaded into
+        ``PermissionContext.current_resource`` for a before-phase **write**
+        check of ``action`` (update / modify / patch / delete).
+
+        Default: ``frozenset()`` — nothing is loaded, so existing checkers
+        keep their zero-overhead behaviour. Override (or compose markers via
+        :func:`requires_resource_parts`) to opt in.
+        """
+        return frozenset()
+
 
 __all__ = [
     "DEFAULT_ROOT_USER",
     "IPermissionChecker",
     "PermissionContext",
     "PermissionResult",
+    "ResourcePart",
+    "requires_resource_parts",
 ]

--- a/specstar/permission/composite.py
+++ b/specstar/permission/composite.py
@@ -13,7 +13,9 @@ from specstar.permission.checker import (
     IPermissionChecker,
     PermissionContext,
     PermissionResult,
+    ResourcePart,
 )
+from specstar.types import ResourceAction
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,16 @@ class CompositePermissionChecker(IPermissionChecker):
         # 所有檢查器都不適用，預設拒絕
         return PermissionResult.not_applicable
 
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        """Union of every child checker's needs — any child that reads the
+        current resource forces it to be loaded for the composite check."""
+        parts: frozenset[ResourcePart] = frozenset()
+        for checker in self.checkers:
+            parts |= checker.required_resource_parts(action)
+        return parts
+
 
 class ConditionalPermissionChecker(IPermissionChecker):
     """條件式權限檢查器 - 基於資源內容的動態權限檢查"""
@@ -69,3 +81,14 @@ class ConditionalPermissionChecker(IPermissionChecker):
                 return result
 
         return PermissionResult.not_applicable
+
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        """Union of the ``@requires_resource_parts`` markers across all
+        conditions (conditions aren't keyed by action, so this is
+        action-independent)."""
+        parts: frozenset[ResourcePart] = frozenset()
+        for condition in self._conditions:
+            parts |= getattr(condition, "_required_resource_parts", frozenset())
+        return parts

--- a/specstar/permission/meta_based.py
+++ b/specstar/permission/meta_based.py
@@ -9,6 +9,7 @@ from specstar.permission.checker import (
     IPermissionChecker,
     PermissionContext,
     PermissionResult,
+    ResourcePart,
 )
 from specstar.types import ResourceAction
 
@@ -29,6 +30,16 @@ class ResourceOwnershipChecker(IPermissionChecker):
         self.resource_manager = resource_manager
         self.allowed_actions = allowed_actions
 
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        """Needs the ``meta`` slice for the write actions it guards, so the
+        ResourceManager preloads it into ``current_resource`` (avoiding the
+        explicit ``get_meta`` round-trip below on writes)."""
+        if action in self.allowed_actions:
+            return frozenset({ResourcePart.META})
+        return frozenset()
+
     def check_permission(self, context: PermissionContext) -> PermissionResult:
         """檢查用戶是否為資源擁有者"""
         # 只對特定 action 生效
@@ -41,8 +52,15 @@ class ResourceOwnershipChecker(IPermissionChecker):
             return PermissionResult.not_applicable
 
         try:
-            # 獲取資源元資料
-            meta = self.resource_manager.get_meta(resource_id)
+            # Prefer the pre-loaded write-phase snapshot; fall back to an
+            # explicit read for read-phase / non-write contexts that don't
+            # carry it.
+            meta = UNSET
+            current = getattr(context, "current_resource", UNSET)
+            if current is not UNSET and current is not None:
+                meta = getattr(current, "meta", UNSET)
+            if meta is UNSET or meta is None:
+                meta = self.resource_manager.get_meta(resource_id)
 
             # 檢查創建者
             if meta.created_by == context.user:

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -152,7 +152,7 @@ if TYPE_CHECKING:
     from specstar.permission.checker import IPermissionChecker
     from specstar.schema import Schema
 
-from specstar.permission.checker import PermissionResult
+from specstar.permission.checker import PermissionResult, ResourcePart
 from specstar.query import Query
 from specstar.resource_manager.basic import (
     Ctx,
@@ -672,7 +672,9 @@ def execute_with_events(
                             del inputs_[k]
                         else:
                             inputs_[k] = get_from_path(func_inputs, v)
-                self._handle_event(contexts.before(**inputs_))
+                before_ctx = contexts.before(**inputs_)
+                self._maybe_load_current_resource(before_ctx)
+                self._handle_event(before_ctx)
                 try:
                     result = func(self, *args, **kwargs)
                     built_result = _build_result(result)
@@ -1704,6 +1706,65 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return self.storage.get_meta(resource_id)
         except KeyError:
             raise ResourceIDNotFoundError(resource_id) from None
+
+    def _required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        """Union of resource slices every registered permission checker needs
+        loaded into ``current_resource`` for a before-phase **write** check of
+        ``action``. Empty when no checker opts in — keeping writes free of any
+        extra read for models without resource-aware ACLs.
+        """
+        parts: frozenset[ResourcePart] = frozenset()
+        for eh in self.event_handlers:
+            if isinstance(eh, PermissionEventHandler):
+                parts |= eh.permission_checker.required_resource_parts(action)
+        return parts
+
+    def _load_current_resource(
+        self, resource_id: str, parts: frozenset[ResourcePart]
+    ) -> SearchedResource:
+        """Assemble a ``SearchedResource`` carrying only ``parts`` of the
+        current (stored) resource.
+
+        Uses NON-event reads (``_get_meta_no_check_is_deleted`` + raw storage)
+        so it never fires a nested before-event / permission check — going
+        through the event-emitting ``get`` / ``get_meta`` would recurse. A
+        missing resource raises ``ResourceIDNotFoundError`` here, i.e. before
+        the write permission verdict, which is the intended behaviour.
+        """
+        current: SearchedResource = SearchedResource()
+        meta = self._get_meta_no_check_is_deleted(resource_id)
+        if ResourcePart.META in parts:
+            current.meta = meta
+        if ResourcePart.INFO in parts:
+            current.info = self.storage.get_resource_revision_info(
+                resource_id, meta.current_revision_id, meta.schema_version
+            )
+        if ResourcePart.DATA in parts:
+            with self.storage.get_data_bytes(
+                resource_id, meta.current_revision_id, meta.schema_version
+            ) as fh:
+                current.data = self._data_serializer.decode(fh.read())
+        return current
+
+    def _maybe_load_current_resource(self, before_ctx: Any) -> None:
+        """Populate ``before_ctx.current_resource`` for a write before-context
+        when a permission checker declares it needs it.
+
+        No-op for every non-write context (only the update/modify/patch/delete
+        ``Before*`` structs carry the field — presence is the gate) and when no
+        registered checker opts in, so the overhead is paid only where an
+        actual resource-aware write ACL is wired.
+        """
+        if not hasattr(before_ctx, "current_resource"):
+            return
+        parts = self._required_resource_parts(before_ctx.action)
+        if not parts:
+            return
+        before_ctx.current_resource = self._load_current_resource(
+            before_ctx.resource_id, parts
+        )
 
     def exists(self, resource_id: str) -> bool:
         """

--- a/tests/permission/test_builtins.py
+++ b/tests/permission/test_builtins.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+from msgspec import UNSET
+
 from specstar.permission.builtins import (
     admin_only,
     any_authenticated,
@@ -16,7 +18,11 @@ from specstar.permission.builtins import (
     deny_all,
     owner_self,
 )
-from specstar.permission.checker import DEFAULT_ROOT_USER, PermissionResult
+from specstar.permission.checker import (
+    DEFAULT_ROOT_USER,
+    PermissionResult,
+    ResourcePart,
+)
 
 
 def test_any_authenticated_allows_non_empty_user() -> None:
@@ -57,13 +63,32 @@ def test_deny_all_rejects_everyone() -> None:
     assert deny_all(ctx) is PermissionResult.deny
 
 
+def test_owner_self_declares_meta_requirement() -> None:
+    # The marker is what makes the ResourceManager preload the ``meta`` slice
+    # into ``current_resource`` for write checks.
+    assert owner_self._required_resource_parts == frozenset({ResourcePart.META})
+
+
 def test_owner_self_allows_when_user_matches_created_by() -> None:
-    # owner_self matches against the canonical ``meta.created_by``
-    # field that ResourceManager writes on create.
-    ctx = Mock(user="alice", meta=Mock(created_by="alice"))
+    # owner_self matches against the pre-write ``current_resource.meta
+    # .created_by`` snapshot the ResourceManager loads for write checks.
+    ctx = Mock(user="alice", current_resource=Mock(meta=Mock(created_by="alice")))
     assert owner_self(ctx) is PermissionResult.allow
 
 
 def test_owner_self_denies_when_user_differs() -> None:
-    ctx = Mock(user="bob", meta=Mock(created_by="alice"))
+    ctx = Mock(user="bob", current_resource=Mock(meta=Mock(created_by="alice")))
+    assert owner_self(ctx) is PermissionResult.deny
+
+
+def test_owner_self_denies_without_current_resource() -> None:
+    # No snapshot loaded (e.g. create, or a checker that didn't opt in) → no
+    # owner can be established → deny.
+    ctx = Mock(user="alice", current_resource=UNSET)
+    assert owner_self(ctx) is PermissionResult.deny
+
+
+def test_owner_self_denies_when_meta_slice_absent() -> None:
+    # current_resource present but ``meta`` slice not loaded → deny.
+    ctx = Mock(user="alice", current_resource=Mock(meta=UNSET))
     assert owner_self(ctx) is PermissionResult.deny

--- a/tests/permission/test_current_resource.py
+++ b/tests/permission/test_current_resource.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Tests for write-phase ``current_resource`` injection (#398, part B).
+
+For write verbs (update / modify / patch / delete) a permission checker can
+declare — per action — which slices of the *current* (stored) resource it
+reads via :meth:`IPermissionChecker.required_resource_parts`. The
+ResourceManager loads only those slices into
+``PermissionContext.current_resource`` before running the before-phase check,
+so a checker stays a pure function of its context and ``owner_self`` /
+embedded-field write ACLs work without each checker doing its own read.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+import pytest
+from msgspec import UNSET
+
+from specstar.permission.action import ActionBasedPermissionChecker
+from specstar.permission.builtins import any_user, owner_self
+from specstar.permission.checker import (
+    IPermissionChecker,
+    PermissionContext,
+    PermissionResult,
+    ResourcePart,
+    requires_resource_parts,
+)
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import (
+    PermissionDeniedError,
+    ResourceAction,
+    ResourceIDNotFoundError,
+)
+
+NOW = dt.datetime(2026, 1, 1, 12, 0, 0)
+
+
+@dataclass
+class Doc:
+    title: str
+    level: str = "public"
+
+
+def make_rm(permission_checker: IPermissionChecker) -> ResourceManager:
+    storage = SimpleStorage(
+        meta_store=MemoryMetaStore(),
+        resource_store=MemoryResourceStore(Doc),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(Doc, storage=storage, permission_checker=permission_checker)
+
+
+def _seed(rm: ResourceManager, user: str = "alice", level: str = "public") -> str:
+    with rm.using(user, NOW):
+        return rm.create(Doc(title="orig", level=level)).resource_id
+
+
+# ---------------------------------------------------------------------------
+# owner_self now works end-to-end on writes (previously always denied because
+# the before-context carried no meta).
+# ---------------------------------------------------------------------------
+
+
+def _owner_checker() -> ActionBasedPermissionChecker:
+    # ``read`` (= get/get_meta/...) must be allowed so the internal reads each
+    # write performs aren't denied by the cascade.
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.read: any_user,
+            ResourceAction.update: owner_self,
+            ResourceAction.delete: owner_self,
+        }
+    )
+
+
+def test_owner_can_update_own_resource() -> None:
+    rm = make_rm(_owner_checker())
+    rid = _seed(rm, "alice")
+    with rm.using("alice", NOW):
+        info = rm.update(rid, Doc(title="new"))
+    assert info.resource_id == rid
+
+
+def test_non_owner_cannot_update() -> None:
+    rm = make_rm(_owner_checker())
+    rid = _seed(rm, "alice")
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.update(rid, Doc(title="hijack"))
+
+
+def test_owner_can_delete_but_other_cannot() -> None:
+    rm = make_rm(_owner_checker())
+    rid = _seed(rm, "alice")
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.delete(rid)
+    with rm.using("alice", NOW):
+        meta = rm.delete(rid)
+    assert meta.is_deleted is True
+
+
+# ---------------------------------------------------------------------------
+# Granularity: only the declared slices are loaded.
+# ---------------------------------------------------------------------------
+
+
+class _Recorder(IPermissionChecker):
+    """Allows everything; records the ``current_resource`` seen on update."""
+
+    def __init__(self, parts: frozenset[ResourcePart]):
+        self._parts = parts
+        self.seen: object = "NOT-CALLED"
+
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        return self._parts if action == ResourceAction.update else frozenset()
+
+    def check_permission(self, context: PermissionContext) -> PermissionResult:
+        if context.action == ResourceAction.update:
+            self.seen = getattr(context, "current_resource", "NO-ATTR")
+        return PermissionResult.allow
+
+
+@pytest.mark.parametrize(
+    ("parts", "want_meta", "want_data", "want_info"),
+    [
+        (frozenset({ResourcePart.META}), True, False, False),
+        (frozenset({ResourcePart.DATA}), False, True, False),
+        (frozenset({ResourcePart.INFO}), False, False, True),
+        (
+            frozenset({ResourcePart.META, ResourcePart.DATA, ResourcePart.INFO}),
+            True,
+            True,
+            True,
+        ),
+    ],
+)
+def test_only_declared_slices_are_loaded(
+    parts: frozenset[ResourcePart],
+    want_meta: bool,
+    want_data: bool,
+    want_info: bool,
+) -> None:
+    rec = _Recorder(parts)
+    rm = make_rm(rec)
+    rid = _seed(rm, "alice", level="secret")
+    with rm.using("alice", NOW):
+        rm.update(rid, Doc(title="new"))
+
+    current = rec.seen
+    assert current is not UNSET and current != "NOT-CALLED"
+    assert (current.meta is not UNSET) is want_meta
+    assert (current.data is not UNSET) is want_data
+    assert (current.info is not UNSET) is want_info
+    if want_meta:
+        assert current.meta.created_by == "alice"
+    if want_data:
+        assert current.data.level == "secret"
+
+
+def test_no_declaration_means_no_load() -> None:
+    rec = _Recorder(frozenset())
+    rm = make_rm(rec)
+    rid = _seed(rm, "alice")
+    with rm.using("alice", NOW):
+        rm.update(rid, Doc(title="new"))
+    # current_resource left at its UNSET default — nothing was loaded.
+    assert rec.seen is UNSET
+
+
+# ---------------------------------------------------------------------------
+# not-found surfaces before the permission verdict (locked: missing -> 404,
+# deny -> 403).
+# ---------------------------------------------------------------------------
+
+
+class _DenyUpdate(IPermissionChecker):
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        return frozenset({ResourcePart.META})
+
+    def check_permission(self, context: PermissionContext) -> PermissionResult:
+        if context.action == ResourceAction.update:
+            return PermissionResult.deny
+        return PermissionResult.allow
+
+
+def test_missing_resource_raises_not_found_before_deny() -> None:
+    rm = make_rm(_DenyUpdate())
+    # The resource doesn't exist: loading current_resource fails with
+    # not-found *before* the deny verdict is reached.
+    with pytest.raises(ResourceIDNotFoundError):
+        with rm.using("alice", NOW):
+            rm.update("does-not-exist", Doc(title="x"))
+
+
+# ---------------------------------------------------------------------------
+# Embedded-field write ACL on the *stored* resource, and old-vs-new compare.
+# ---------------------------------------------------------------------------
+
+
+@requires_resource_parts(ResourcePart.DATA)
+def _allow_only_public(context: PermissionContext) -> PermissionResult:
+    """Allow the write only if the stored resource is ``level == 'public'``."""
+    current = getattr(context, "current_resource", UNSET)
+    if current is UNSET or current.data is UNSET:
+        return PermissionResult.deny
+    return (
+        PermissionResult.allow
+        if current.data.level == "public"
+        else PermissionResult.deny
+    )
+
+
+def _embedded_checker() -> ActionBasedPermissionChecker:
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.read: any_user,
+            ResourceAction.update: _allow_only_public,
+        }
+    )
+
+
+def test_embedded_field_acl_uses_stored_data() -> None:
+    rm = make_rm(_embedded_checker())
+    public_id = _seed(rm, "alice", level="public")
+    private_id = _seed(rm, "alice", level="private")
+
+    with rm.using("alice", NOW):
+        rm.update(public_id, Doc(title="edited", level="public"))
+
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("alice", NOW):
+            rm.update(private_id, Doc(title="edited", level="private"))
+
+
+@requires_resource_parts(ResourcePart.DATA)
+def _level_is_immutable(context: PermissionContext) -> PermissionResult:
+    """Incoming ``data`` (new) vs ``current_resource.data`` (stored) — reject a
+    write that changes the immutable ``level`` field."""
+    current = getattr(context, "current_resource", UNSET)
+    incoming = getattr(context, "data", UNSET)
+    if current is UNSET or current.data is UNSET or incoming is UNSET:
+        return PermissionResult.deny
+    return (
+        PermissionResult.allow
+        if incoming.level == current.data.level
+        else PermissionResult.deny
+    )
+
+
+def test_incoming_vs_stored_data_compare() -> None:
+    rm = make_rm(
+        ActionBasedPermissionChecker.from_dict(
+            {
+                ResourceAction.create: any_user,
+                ResourceAction.read: any_user,
+                ResourceAction.update: _level_is_immutable,
+            }
+        )
+    )
+    rid = _seed(rm, "alice", level="public")
+    # same level → allowed
+    with rm.using("alice", NOW):
+        rm.update(rid, Doc(title="t", level="public"))
+    # changing level → denied
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("alice", NOW):
+            rm.update(rid, Doc(title="t", level="private"))
+
+
+# ---------------------------------------------------------------------------
+# Aggregation across composite-shaped checkers.
+# ---------------------------------------------------------------------------
+
+
+def test_action_based_aggregates_markers_per_action() -> None:
+    chk = ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.update: owner_self,  # marks META
+            ResourceAction.delete: any_user,  # no marker
+        }
+    )
+    assert chk.required_resource_parts(ResourceAction.update) == frozenset(
+        {ResourcePart.META}
+    )
+    assert chk.required_resource_parts(ResourceAction.delete) == frozenset()


### PR DESCRIPTION
## What & why

Part **B** of #398 (resource-level access control): give write-verb permission
checks the **already-loaded current (stored) resource**, so embedded-field and
owner-based write ACLs become first-class instead of requiring each checker to
re-read the resource itself.

> Part **A** (read/list `access_scope` query injection) is tracked separately;
> this PR is B only and is independently shippable.

## What changed

- **`PermissionContext.current_resource`** — a new optional
  `SearchedResource[T]` field on the four **write** before-contexts
  (`BeforeUpdate` / `BeforeModify` / `BeforePatch` / `BeforeDelete`). Additive
  and backward-compatible (defaults to `UNSET`).
- **Per-action, granular opt-in** — `IPermissionChecker.required_resource_parts(action)`
  (default `frozenset()`) declares which slices (`ResourcePart.META` / `DATA` /
  `INFO`) a checker reads. The ResourceManager loads **only those**, via
  non-event reads, right before the before-phase check. No checker that opts in
  → no extra read, so models without resource-aware ACLs pay nothing.
  - `@requires_resource_parts(...)` marks a plain `CheckFunc`;
    `ActionBasedPermissionChecker` / `Composite` / `Conditional` aggregate.
- **Fixes `owner_self`** — it read `context.meta`, which never existed on
  before-contexts, so it **always denied** on writes. It now reads
  `current_resource.meta.created_by` (and declares it needs `META`), so
  owner-based update/delete actually works. ⚠️ behavior change: setups that
  mapped `owner_self` to a write action were effectively deny-all and will now
  allow the owner.
- `ResourceOwnershipChecker` prefers the preloaded snapshot, falling back to its
  own `get_meta` for read-phase contexts.

## Design decisions (locked during design review)

- Snapshot is **eager but gated** on declared need; double-read with the write
  body is accepted (no load-once cache) — keeps the diff minimal.
- Missing resource → **404 before** the permission verdict; deny stays **403**.
- Scope is **writes only**; reads/lists are A's job.
- `patch` still emits its pre-existing `BeforePatch`→`BeforeGet`→`BeforeUpdate`
  cascade (checker runs 3×) — left untouched here; the cascade re-check is a
  separate latent issue.

## Tests

- `tests/permission/test_current_resource.py` (new): owner_self end-to-end on
  update/delete, per-slice load granularity, no-declaration-no-load,
  not-found-before-deny, embedded-field ACL on stored data, incoming-vs-stored
  compare, per-action marker aggregation.
- Updated `tests/permission/test_builtins.py` for the new `owner_self` contract.
- `specstar/events.pyi` regenerated (`make stubs`); generator now imports
  `SearchedResource`.

Closes part B of #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
