### PR TITLE
feat(crud): per-model read access-scope predicate (#398 part A)

### DIFF
--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -18,6 +18,7 @@ from specstar.backend import (
 )
 from specstar.crud.core import LoadStats, SpecStar
 from specstar.env import env
+from specstar.permission.access_scope import UNRESTRICTED
 from specstar.query import QB
 from specstar.refs import string_ref
 from specstar.resource_manager.pydantic_converter import (
@@ -92,6 +93,7 @@ __all__ = [
     "SearchedResource",
     "SetIndex",
     "SpecStar",
+    "UNRESTRICTED",
     "TaskStatus",
     "UndecodableData",
     "Unique",

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -64,6 +64,7 @@ from specstar.crud.route_templates.switch import SwitchRevisionRouteTemplate
 from specstar.crud.route_templates.update import UpdateRouteTemplate
 from specstar.descriptor import Descriptor
 from specstar.events import IEventHandler
+from specstar.permission.access_scope import AccessScope
 from specstar.permission.checker import IPermissionChecker
 from specstar.permission.rbac import RBACPermissionChecker
 from specstar.permission.simple import AllowAll
@@ -1244,6 +1245,7 @@ class SpecStar:
         indexed_fields: list[str | tuple[str, type] | IndexableField] | None = None,
         event_handlers: Sequence[IEventHandler] | None = None,
         permission_checker: IPermissionChecker | None = None,
+        access_scope: "AccessScope | None" = None,
         encoding: Encoding | None = None,
         default_status: RevisionStatus | UnsetType = UNSET,
         default_user: str | Callable[[], str] | UnsetType = UNSET,
@@ -1298,6 +1300,16 @@ class SpecStar:
             permission_checker:
                 Per-model permission checker. If `self.permission_checker` is configured globally, it
                 takes precedence; otherwise this checker is used.
+            access_scope:
+                Per-model read access-scope predicate (issue #398). A callable
+                ``user -> ConditionBuilder | None | UNRESTRICTED`` that specstar
+                ANDs into every request-originated read (list/search/count and
+                every single-resource GET variant); out-of-scope resources
+                become ``404`` and list/search rows are filtered at the storage
+                layer. Return ``None`` to deny all reads (fail-closed) or
+                ``UNRESTRICTED`` to skip scoping (e.g. admins). Internal
+                ``ResourceManager`` reads are never scoped. Fields referenced by
+                the predicate must be indexed (`indexed_fields`).
             encoding:
                 Encoding for stored payloads. If `None`, uses `self.default_encoding`.
             default_status:
@@ -1590,6 +1602,7 @@ class SpecStar:
             event_handlers=self.event_handlers
             or _flatten_event_handlers(event_handlers),
             permission_checker=self.permission_checker or permission_checker,
+            access_scope=access_scope,
             encoding=encoding,
             name=model_name,
             validator=cast(

--- a/specstar/crud/route_templates/get.py
+++ b/specstar/crud/route_templates/get.py
@@ -78,7 +78,9 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
                     if raw:
                         fields = raw
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.get_meta(
                         resource_id, include_deleted=include_deleted
                     )
@@ -165,7 +167,9 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
                     if raw:
                         fields = raw
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     info = resource_manager.get_revision_info(
                         resource_id,
                         revision_id or UNSET,
@@ -237,30 +241,35 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
                                 "Use only-data, only-meta, or only-revision_info."
                             ),
                         )
-                    meta = resource_manager.get_meta(
-                        resource_id, include_deleted=include_deleted
-                    )
-                    target_revision_id = revision_id or meta.current_revision_id
-                    if section == "data":
-                        bare = resource_manager.get_resource_revision(
-                            resource_id,
-                            target_revision_id,
-                            schema_version=meta.schema_version,
-                        ).data
-                    elif section == "meta":
-                        bare = meta
-                    else:  # revision_info
-                        bare = resource_manager.get_revision_info(
-                            resource_id,
-                            target_revision_id,
-                            schema_version=meta.schema_version,
+                    with resource_manager.using(
+                        current_user, current_time, apply_access_scope=True
+                    ):
+                        meta = resource_manager.get_meta(
+                            resource_id, include_deleted=include_deleted
                         )
-                    return MsgspecResponse(bare)
+                        target_revision_id = revision_id or meta.current_revision_id
+                        if section == "data":
+                            bare = resource_manager.get_resource_revision(
+                                resource_id,
+                                target_revision_id,
+                                schema_version=meta.schema_version,
+                            ).data
+                        elif section == "meta":
+                            bare = meta
+                        else:  # revision_info
+                            bare = resource_manager.get_revision_info(
+                                resource_id,
+                                target_revision_id,
+                                schema_version=meta.schema_version,
+                            )
+                        return MsgspecResponse(bare)
 
                 # Classify partial fields by prefix
                 spec = classify_partial_fields(fields, default_category="data")
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.get_meta(
                         resource_id, include_deleted=include_deleted
                     )
@@ -483,7 +492,9 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
                 # Classify: unprefixed fields default to info
                 spec = classify_partial_fields(fields, default_category="info")
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.get_meta(
                         resource_id, include_deleted=include_deleted
                     )
@@ -669,7 +680,9 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
         ):
             # 獲取資源和元數據
             try:
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     fields = partial or partial_brackets
                     if fields is None:
                         raw = [
@@ -724,7 +737,7 @@ class ReadRouteTemplate(BaseRouteTemplate, Generic[T]):
         ):
             try:
                 # Permission check through get()
-                with resource_manager.using(user=user):
+                with resource_manager.using(user=user, apply_access_scope=True):
                     resource_manager.get(resource_id)
             except Exception as e:
                 raise to_http_exception(e)

--- a/specstar/crud/route_templates/search.py
+++ b/specstar/crud/route_templates/search.py
@@ -132,7 +132,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                 query = build_query(query_params, request)
                 fields = get_partial_fields(request, query_params)
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     results = resource_manager.list_resources(
                         query,
                         returns=["data"],
@@ -238,7 +240,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                         else:
                             meta_partial.append(f)
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     results = resource_manager.list_resources(
                         query,
                         returns=["meta"],
@@ -335,7 +339,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                         else:
                             info_partial.append(f)
 
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     results = resource_manager.list_resources(
                         query,
                         returns=["info"],
@@ -362,7 +368,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                 # Fetch one extra row than requested so we can report whether
                 # more results exist beyond this page without a count query.
                 probe = msgspec.structs.replace(query, limit=query.limit + 1)
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     results = resource_manager.list_resources(
                         probe,
                         returns=returns,
@@ -393,7 +401,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                     count_query = msgspec.structs.replace(
                         query, limit=2**63 - 1, offset=0
                     )
-                    with resource_manager.using(current_user, current_time):
+                    with resource_manager.using(
+                        current_user, current_time, apply_access_scope=True
+                    ):
                         headers["X-Total-Count"] = str(
                             resource_manager.count_resources(count_query)
                         )
@@ -483,7 +493,9 @@ class ListRouteTemplate(BaseRouteTemplate):
                 query = build_query(query_params, request)
                 # count 不應受 limit/offset 影響，移除分頁限制以回傳真實總數
                 query = msgspec.structs.replace(query, limit=2**63 - 1, offset=0)
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     count = resource_manager.count_resources(query)
                 return count
             except Exception as e:

--- a/specstar/permission/__init__.py
+++ b/specstar/permission/__init__.py
@@ -1,5 +1,6 @@
 """Public permission API for end-user composition."""
 
+from specstar.permission.access_scope import UNRESTRICTED, AccessScope
 from specstar.permission.acl import ACLPermission, ACLPermissionChecker, Policy
 from specstar.permission.action import ActionBasedPermissionChecker
 from specstar.permission.builtins import (
@@ -31,8 +32,10 @@ from specstar.types import ResourceAction
 __all__ = [
     "ACLPermission",
     "ACLPermissionChecker",
+    "AccessScope",
     "ActionBasedPermissionChecker",
     "AllowAll",
+    "UNRESTRICTED",
     "CompositePermissionChecker",
     "ConditionalPermissionChecker",
     "FieldLevelPermissionChecker",

--- a/specstar/permission/access_scope.py
+++ b/specstar/permission/access_scope.py
@@ -1,0 +1,56 @@
+"""Per-model read/list access-scope predicate (issue #398, part A).
+
+An ``access_scope`` is a per-model callable that maps the request user to a
+row-level visibility predicate. specstar ANDs it into *every* read query
+(list/search/count and every single-resource GET variant) at the
+ResourceManager read layer, but only for request-originated reads — internal
+``ResourceManager`` calls stay unscoped (see ``ResourceManager.using`` /
+``apply_access_scope``).
+
+The callable returns one of three things:
+
+* a :class:`~specstar.query.ConditionBuilder` — restrict reads to rows matching
+  the predicate (out-of-scope single GETs become ``404``; list/search/count are
+  filtered at the storage layer);
+* ``None`` — **deny all** (fail-closed): list/search/count return empty without
+  hitting storage and single GETs return ``404``;
+* :data:`UNRESTRICTED` — no restriction at all (admin / privileged users).
+
+``None`` is fail-closed on purpose: a misconfigured predicate that accidentally
+returns ``None`` hides everything rather than leaking it. "See everything" must
+be requested explicitly by returning :data:`UNRESTRICTED`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Final, Union
+
+if TYPE_CHECKING:
+    from specstar.query import ConditionBuilder
+
+
+class _Unrestricted:
+    """Singleton sentinel returned by an ``access_scope`` to skip scoping."""
+
+    __slots__ = ()
+    _instance: "_Unrestricted | None" = None
+
+    def __new__(cls) -> "_Unrestricted":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "UNRESTRICTED"
+
+
+UNRESTRICTED: Final[_Unrestricted] = _Unrestricted()
+"""Return this from an ``access_scope`` to grant unrestricted read access."""
+
+
+# A per-model read access-scope predicate: user -> visibility.
+AccessScope = Callable[[str], Union["ConditionBuilder", None, _Unrestricted]]
+
+
+__all__ = ["UNRESTRICTED", "AccessScope", "_Unrestricted"]

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -149,11 +149,13 @@ from specstar.types import (
 )
 
 if TYPE_CHECKING:
+    from specstar.permission.access_scope import AccessScope
     from specstar.permission.checker import IPermissionChecker
     from specstar.schema import Schema
 
+from specstar.permission.access_scope import UNRESTRICTED, _Unrestricted
 from specstar.permission.checker import PermissionResult
-from specstar.query import Query
+from specstar.query import QB, ConditionBuilder, Query
 from specstar.resource_manager.basic import (
     Ctx,
     Encoding,
@@ -722,7 +724,14 @@ class ResourceOps(Generic[T]):
         forbidden and raises :class:`RuntimeError`.
     """
 
-    __slots__ = ("_mgr", "_user", "_now", "_resource_id", "_active")
+    __slots__ = (
+        "_mgr",
+        "_user",
+        "_now",
+        "_resource_id",
+        "_apply_access_scope",
+        "_active",
+    )
 
     def __init__(
         self,
@@ -730,11 +739,13 @@ class ResourceOps(Generic[T]):
         user: "str | UnsetType",
         now: "dt.datetime | UnsetType",
         resource_id: "str | UnsetType",
+        apply_access_scope: bool = False,
     ) -> None:
         object.__setattr__(self, "_mgr", mgr)
         object.__setattr__(self, "_user", user)
         object.__setattr__(self, "_now", now)
         object.__setattr__(self, "_resource_id", resource_id)
+        object.__setattr__(self, "_apply_access_scope", apply_access_scope)
         object.__setattr__(self, "_active", True)
 
     def _deactivate(self) -> None:
@@ -754,7 +765,10 @@ class ResourceOps(Generic[T]):
                 if not self._active:
                     raise RuntimeError("ResourceOps is no longer active")
                 with self._mgr._apply_context(
-                    self._user, self._now, resource_id=self._resource_id
+                    self._user,
+                    self._now,
+                    resource_id=self._resource_id,
+                    apply_access_scope=self._apply_access_scope,
                 ):
                     return attr(*args, **kwargs)
 
@@ -899,6 +913,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         migration: "IMigration[T] | Schema[T] | None" = None,
         indexed_fields: list[IndexableField] | None = None,
         permission_checker: "IPermissionChecker | None" = None,
+        access_scope: "AccessScope | None" = None,
         name: str | NamingFormat = NamingFormat.SNAKE,
         event_handlers: Sequence[IEventHandler] | None = None,
         encoding: Encoding = Encoding.json,
@@ -1003,6 +1018,12 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 default_factory=lambda: dt.datetime.now(dt.timezone.utc),
             )
         self.id_ctx = Ctx[str | UnsetType]("id_ctx", default=UNSET)
+        # Per-model read access-scope predicate (issue #398). Only consulted
+        # when ``apply_scope_ctx`` is True — i.e. for request-originated reads
+        # entered via ``using(..., apply_access_scope=True)`` from the generated
+        # read-route templates. Internal reads default to unscoped.
+        self._access_scope = access_scope
+        self.apply_scope_ctx = Ctx[bool]("apply_scope_ctx", default=False)
         self._resource_type = resource_type
         self.storage = storage
         self.blob_store = blob_store
@@ -1447,6 +1468,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         now: dt.datetime | UnsetType = UNSET,
         *,
         resource_id: str | UnsetType = UNSET,
+        apply_access_scope: bool = False,
     ) -> Generator[ResourceOps[T], None, None]:
         """Context manager to provide operation context for write operations.
 
@@ -1485,8 +1507,13 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 op1.create(data1)  # created_by = "u1"
                 op2.create(data2)  # created_by = "u2"
         """
-        ops = ResourceOps(self, user, now, resource_id)
-        with self._apply_context(user=user, now=now, resource_id=resource_id):
+        ops = ResourceOps(self, user, now, resource_id, apply_access_scope)
+        with self._apply_context(
+            user=user,
+            now=now,
+            resource_id=resource_id,
+            apply_access_scope=apply_access_scope,
+        ):
             try:
                 yield ops
             finally:
@@ -1526,12 +1553,14 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         now: dt.datetime | UnsetType = UNSET,
         *,
         resource_id: str | UnsetType = UNSET,
+        apply_access_scope: bool = False,
     ):
         """Internal context manager — same as using() but without yielding self."""
         with (
             self.user_ctx.ctx(user) if user is not UNSET else suppress(),
             self.now_ctx.ctx(now) if now is not UNSET else suppress(),
             self.id_ctx.ctx(resource_id) if resource_id is not UNSET else suppress(),
+            self.apply_scope_ctx.ctx(True) if apply_access_scope else suppress(),
         ):
             yield
 
@@ -1695,6 +1724,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 eh.handle_event(context)
 
     def _get_meta_no_check_is_deleted(self, resource_id: str) -> ResourceMeta:
+        # Read access-scope gate: a request-scoped read of a resource outside
+        # the caller's scope is hidden as a 404. No-op for internal reads.
+        # This is the single choke point every single-resource read route leads
+        # with (get_meta, or get()->get_meta), so all GET variants inherit it.
+        self._assert_in_scope(resource_id)
         # Read straight from the store and treat a missing key as not-found.
         # Going through get_meta (rather than an exists()-then-read pair) closes
         # the TOCTOU window where a concurrent purge / interrupted create can
@@ -1990,6 +2024,88 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return msgspec.structs.replace(query, is_deleted=self._default_is_deleted)
         return query
 
+    # ── Read access-scope (issue #398, part A) ───────────────────────────
+    def _resolve_active_scope(
+        self,
+    ) -> "ConditionBuilder | None | _Unrestricted | UnsetType":
+        """Resolve the read access-scope decision for the *current* read.
+
+        Returns ``UNSET`` when scoping is inactive — either no ``access_scope``
+        is registered, or this read did not opt in. Only the generated
+        read-route templates enter ``using(..., apply_access_scope=True)``;
+        every internal ``ResourceManager`` read stays unscoped. Otherwise
+        returns the predicate's result: a :class:`ConditionBuilder` (restrict),
+        ``None`` (deny all, fail-closed), or :data:`UNRESTRICTED` (no limit)."""
+        if self._access_scope is None or not self.apply_scope_ctx.get():
+            return UNSET
+        return self._access_scope(self.user)
+
+    def _validate_scope_fields(self, scope_query: ResourceMetaSearchQuery) -> None:
+        """Strictly reject an access-scope predicate that filters on a field
+        which is neither a ``ResourceMeta`` attribute nor a configured indexed
+        field. Unlike ``_validate_query_fields`` (whose leniency is governed by
+        ``on_unindexed_query``), a scope predicate must **never** silently
+        degrade — a dropped/unmatched condition would widen visibility, a
+        security hole. Always raises on an unknown field."""
+        refs = self._collect_condition_fields(scope_query)
+        if not refs:
+            return
+        valid = self._queryable_field_names()
+        missing = [f for f in dict.fromkeys(refs) if f not in valid]
+        if missing:
+            indexed = sorted(f.index_key or f.field_path for f in self._indexed_fields)
+            raise UnindexedQueryError(missing, indexed)
+
+    def _and_scope_into(
+        self, query: ResourceMetaSearchQuery, scope: "ConditionBuilder"
+    ) -> ResourceMetaSearchQuery:
+        """AND a scope predicate into ``query.conditions`` (list entries are
+        ANDed), after strictly validating the scope's fields."""
+        scope_query = scope.build()
+        if scope_query.conditions is UNSET or not scope_query.conditions:
+            return query  # an empty predicate carries no restriction
+        self._validate_scope_fields(scope_query)
+        existing = list(query.conditions) if query.conditions is not UNSET else []
+        return msgspec.structs.replace(
+            query, conditions=existing + list(scope_query.conditions)
+        )
+
+    @contextmanager
+    def _scoped_read(self, query: ResourceMetaSearchQuery):
+        """For a request-scoped list/count, yield ``(query, deny)`` and clear
+        the scope flag for the duration so nested/downstream reads (events,
+        per-row fetches) run unscoped — scope is applied exactly once, at the
+        outermost read. ``deny`` True → caller returns the empty result without
+        touching storage (the ``None`` deny-all, fail-closed case)."""
+        scope = self._resolve_active_scope()
+        if scope is UNSET or scope is UNRESTRICTED:
+            yield query, False
+            return
+        with self.apply_scope_ctx.ctx(False):
+            if scope is None:
+                yield query, True
+            else:
+                yield self._and_scope_into(query, scope), False
+
+    def _assert_in_scope(self, resource_id: str) -> None:
+        """Enforce the read access-scope for a single-resource read: a resource
+        outside the caller's scope is treated as non-existent
+        (``ResourceIDNotFoundError`` → HTTP 404), hiding its existence
+        uniformly with list/search. No-op for unscoped (internal) reads."""
+        scope = self._resolve_active_scope()
+        if scope is UNSET or scope is UNRESTRICTED:
+            return
+        with self.apply_scope_ctx.ctx(False):
+            if scope is None:
+                raise ResourceIDNotFoundError(resource_id)
+            probe = self._and_scope_into(
+                ResourceMetaSearchQuery(),
+                scope & QB["resource_id"].eq(resource_id),
+            )
+            probe = msgspec.structs.replace(probe, limit=1)
+            if self.storage.count(probe) == 0:
+                raise ResourceIDNotFoundError(resource_id)
+
     def count_resources(
         self, query: "ResourceMetaSearchQuery | Query | None" = None
     ) -> int:
@@ -2008,10 +2124,13 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             query = ResourceMetaSearchQuery()
         elif isinstance(query, Query):
             query = query.build()
-        query = self._apply_default_is_deleted(query)
-        self._validate_query_fields(query)
-        query = self._resolve_str_query_vectors(query)
-        return self.storage.count(query)
+        with self._scoped_read(query) as (query, deny):
+            if deny:
+                return 0
+            query = self._apply_default_is_deleted(query)
+            self._validate_query_fields(query)
+            query = self._resolve_str_query_vectors(query)
+            return self.storage.count(query)
 
     def _resolve_str_query_vectors(
         self, query: ResourceMetaSearchQuery
@@ -2125,7 +2244,12 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         # (matching how list_resources / iter_all already work).
         if query is None:
             query = ResourceMetaSearchQuery()
-        return self._search_resources(query)
+        elif isinstance(query, Query):
+            query = query.build()
+        with self._scoped_read(query) as (query, deny):
+            if deny:
+                return []
+            return self._search_resources(query)
 
     @execute_with_events(
         (
@@ -2335,24 +2459,33 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         results: list[SearchedResource[T]] = []
         skipped_ids: list[str] = []
 
-        if worker_num <= 1:
-            for meta in metas:
-                item = _fetch_one(meta)
-                if item is not None:
-                    results.append(item)
-                else:
-                    skipped_ids.append(meta.resource_id)
-        else:
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=worker_num,
-            ) as executor:
-                futures = {executor.submit(_fetch_one, meta): meta for meta in metas}
-                for future in futures:
-                    item = future.result()
+        # The page rows were already scoped by ``search_resources`` above, so
+        # the per-row data/info fetches must NOT re-apply the access scope —
+        # clear the flag for the fetch phase to keep it from re-probing each row
+        # (a single-resource re-check per row = N+1). The parallel branch runs
+        # in worker threads where ContextVars don't propagate anyway; this makes
+        # the single-threaded branch consistent with it.
+        with self.apply_scope_ctx.ctx(False):
+            if worker_num <= 1:
+                for meta in metas:
+                    item = _fetch_one(meta)
                     if item is not None:
                         results.append(item)
                     else:
-                        skipped_ids.append(futures[future].resource_id)
+                        skipped_ids.append(meta.resource_id)
+            else:
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=worker_num,
+                ) as executor:
+                    futures = {
+                        executor.submit(_fetch_one, meta): meta for meta in metas
+                    }
+                    for future in futures:
+                        item = future.result()
+                        if item is not None:
+                            results.append(item)
+                        else:
+                            skipped_ids.append(futures[future].resource_id)
 
         # A matched resource whose data can't be fetched/decoded is skipped here
         # (defensive — one bad row shouldn't 500 the whole page), but ``count``
@@ -2828,15 +2961,22 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         Returns:
             info (RevisionInfo): The metadata of the revision.
         """
-        if revision_id is UNSET:
-            meta = self.get_meta(resource_id)
-            revision_id = meta.current_revision_id
-            if schema_version is UNSET:
-                schema_version = meta.schema_version
+        # Access-scope gate: this is the one single-resource read route that can
+        # reach storage with an explicit ``revision_id`` *without* leading with
+        # get_meta (``GET /{id}/revision-info?revision_id=...``), so enforce
+        # scope here too. Clear the flag for the rest so the UNSET-branch
+        # get_meta below doesn't re-probe (the resource is already authorized).
+        self._assert_in_scope(resource_id)
+        with self.apply_scope_ctx.ctx(False):
+            if revision_id is UNSET:
+                meta = self.get_meta(resource_id)
+                revision_id = meta.current_revision_id
+                if schema_version is UNSET:
+                    schema_version = meta.schema_version
 
-        return self.storage.get_resource_revision_info(
-            resource_id, revision_id, schema_version=schema_version
-        )
+            return self.storage.get_resource_revision_info(
+                resource_id, revision_id, schema_version=schema_version
+            )
 
     @execute_with_events(
         (

--- a/specstar/resource_manager/meta_store/sqlalchemy.py
+++ b/specstar/resource_manager/meta_store/sqlalchemy.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     cast,
     create_engine,
     delete,
+    false,
     func,
     literal,
     literal_column,
@@ -1110,6 +1111,18 @@ class SQLAlchemyMetaStore(ISlowMetaStore):
                     f"%{value}%"
                 )
             return jsonb_text.contains(str(value))
+        if operator == DataSearchOperator.contains_any:
+            # List set-overlap: the field shares at least one element with the
+            # candidate set. Reuse the per-dialect element-membership predicate
+            # (the same one ``contains`` uses) OR'd across candidates so it
+            # agrees with the in-process backends' ``set(field) & set(value)``
+            # (basic.py) and the raw sqlite3/psycopg meta stores. Previously
+            # unhandled — the condition was silently dropped, a correctness and
+            # access-scope security hole. See #378, #398.
+            vals = list(value) if isinstance(value, (list, tuple, set)) else [value]
+            if not vals:
+                return false()  # empty candidate set matches nothing
+            return or_(*[self._list_contains(field_path, v) for v in vals])
         if operator == DataSearchOperator.starts_with:
             return jsonb_text.startswith(str(value))
         if operator == DataSearchOperator.ends_with:

--- a/tests/test_access_scope.py
+++ b/tests/test_access_scope.py
@@ -1,0 +1,369 @@
+"""Per-model read/list access-scope predicate — issue #398, part A.
+
+``access_scope`` is a per-model callable ``user -> ConditionBuilder | None |
+UNRESTRICTED`` that specstar ANDs into every *request-originated* read
+(list/search/count + every single-resource GET variant) at the
+ResourceManager read layer. Out-of-scope resources become 404 (existence
+hidden, uniformly with list filtering); ``None`` denies all (fail-closed) and
+``UNRESTRICTED`` skips scoping. Internal ResourceManager reads stay unscoped.
+
+These tests pin the behaviour at three levels:
+
+* ResourceManager (in-memory) — the enforcement logic itself;
+* the SQLAlchemy meta store (real sqlite) — cross-backend consistency, and the
+  ``contains_any`` operator the canonical ACL predicate needs (previously
+  silently dropped on SQLAlchemy — a security hole this feature exposed);
+* the generated HTTP routes (TestClient) — that every read route opts in.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from fastapi import APIRouter, FastAPI, Header
+from fastapi.testclient import TestClient
+from msgspec import Struct
+
+from specstar import QB, UNRESTRICTED, SpecStar
+from specstar.crud.route_templates.dependency_provider import DependencyProvider
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import (
+    IndexableField,
+    OnUnindexedQuery,
+    ResourceIDNotFoundError,
+    UnindexedQueryError,
+)
+
+NOW = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+
+class Doc(Struct):
+    owner: str = ""
+    visibility: str = "private"
+    readers: list[str] = []  # noqa: RUF012
+
+
+def scope_for(user: str):
+    """Canonical row-level ACL: public, or you own it, or you're a reader.
+
+    Admins see everything; a banned user sees nothing (fail-closed).
+    """
+    if user == "admin":
+        return UNRESTRICTED
+    if user == "banned":
+        return None
+    return (
+        (QB["visibility"] == "public")
+        | (QB["owner"] == user)
+        | QB["readers"].contains_any([user])
+    )
+
+
+def _indexed_fields() -> list[IndexableField]:
+    return [
+        IndexableField(field_path="visibility", field_type=str),
+        IndexableField(field_path="owner", field_type=str),
+        IndexableField(field_path="readers", field_type=list),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# ResourceManager-level (in-memory)
+# --------------------------------------------------------------------------- #
+def _mk_rm(access_scope=scope_for, on_unindexed_query=OnUnindexedQuery.warn):
+    storage = SimpleStorage(
+        meta_store=MemoryMetaStore(),
+        resource_store=MemoryResourceStore(Doc),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(
+        Doc,
+        storage=storage,
+        indexed_fields=_indexed_fields(),
+        access_scope=access_scope,
+        on_unindexed_query=on_unindexed_query,
+    )
+
+
+def _seed(rm) -> dict[str, str]:
+    """Create four docs; return name -> resource_id."""
+    docs = {
+        "pub": Doc(owner="alice", visibility="public", readers=[]),
+        "alice_priv": Doc(owner="alice", visibility="private", readers=["bob"]),
+        "bob_priv": Doc(owner="bob", visibility="private", readers=[]),
+        "carol_priv": Doc(owner="carol", visibility="private", readers=["alice"]),
+    }
+    ids = {}
+    for name, doc in docs.items():
+        with rm.using(doc.owner, NOW) as op:
+            ids[name] = op.create(doc).resource_id
+    return ids
+
+
+def test_list_filters_rows_by_scope():
+    rm = _mk_rm()
+    ids = _seed(rm)
+
+    # bob: public + his own + docs he can read
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        got = {r.meta.resource_id for r in op.list_resources()}
+    assert got == {ids["pub"], ids["alice_priv"], ids["bob_priv"]}
+    assert ids["carol_priv"] not in got
+
+    # alice: public + her own + carol's doc shared with her
+    with rm.using("alice", NOW, apply_access_scope=True) as op:
+        got = {r.meta.resource_id for r in op.list_resources()}
+    assert got == {ids["pub"], ids["alice_priv"], ids["carol_priv"]}
+
+    # dave: only the public one
+    with rm.using("dave", NOW, apply_access_scope=True) as op:
+        got = {r.meta.resource_id for r in op.list_resources()}
+    assert got == {ids["pub"]}
+
+
+def test_count_is_scoped_like_list():
+    rm = _mk_rm()
+    _seed(rm)
+    for user, expected in [("bob", 3), ("alice", 3), ("dave", 1), ("admin", 4)]:
+        with rm.using(user, NOW, apply_access_scope=True) as op:
+            assert op.count_resources() == expected, user
+
+
+def test_single_get_hides_out_of_scope_as_404():
+    rm = _mk_rm()
+    ids = _seed(rm)
+    # bob may read his own private doc
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        assert op.get(ids["bob_priv"]).data.owner == "bob"
+    # ...but carol's private doc is hidden as not-found, not 403
+    with rm.using("bob", NOW, apply_access_scope=True) as op:  # noqa: SIM117
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get(ids["carol_priv"])
+
+
+def test_single_get_meta_and_revision_info_also_404():
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get_meta(ids["carol_priv"])
+    # revision-info with an *explicit* revision id is the one single-resource
+    # path that does not lead with get_meta — it must still be gated.
+    rev = rm.get_revision_info(ids["carol_priv"]).revision_id  # internal, unscoped
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get_revision_info(ids["carol_priv"], rev)
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get_revision_info(ids["carol_priv"])  # UNSET branch too
+
+
+def test_none_denies_all_fail_closed():
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("banned", NOW, apply_access_scope=True) as op:
+        assert op.list_resources() == []
+        assert op.count_resources() == 0
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get(ids["pub"])  # even the public doc is hidden
+
+
+def test_unrestricted_sees_everything():
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("admin", NOW, apply_access_scope=True) as op:
+        assert {r.meta.resource_id for r in op.list_resources()} == set(ids.values())
+        assert op.get(ids["carol_priv"]).data.owner == "carol"
+
+
+def test_internal_reads_are_never_scoped():
+    """Without ``apply_access_scope=True`` (every internal call), reads see
+    everything — even for a user the predicate would otherwise restrict."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("dave", NOW) as op:  # no apply_access_scope
+        assert {r.meta.resource_id for r in op.list_resources()} == set(ids.values())
+        assert op.count_resources() == len(ids)
+        assert op.get(ids["carol_priv"]).data.owner == "carol"
+
+
+def test_scope_anded_with_user_query():
+    """A caller's own filter ANDs with the scope, never widens it."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        # Narrowing to owner==alice keeps only the in-scope alice docs.
+        got = {r.meta.resource_id for r in op.list_resources(QB["owner"] == "alice")}
+        assert got == {ids["pub"], ids["alice_priv"]}
+        # Querying for carol's docs returns nothing — the scope still hides them
+        # even though the user's filter explicitly asks for owner==carol.
+        widen = list(op.list_resources(QB["owner"] == "carol"))
+    assert widen == []
+
+
+def test_scope_on_unindexed_field_always_raises():
+    """A scope predicate over a non-indexed field must fail loudly (never
+    silently degrade), regardless of the lenient ``on_unindexed_query``."""
+
+    def bad_scope(user: str):
+        return QB["secret"] == "x"  # 'secret' is not indexed
+
+    rm = _mk_rm(access_scope=bad_scope, on_unindexed_query=OnUnindexedQuery.warn)
+    ids = _seed(rm)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        with pytest.raises(UnindexedQueryError):
+            op.list_resources()
+        with pytest.raises(UnindexedQueryError):
+            op.get(ids["pub"])
+
+
+def test_contains_any_membership_in_memory():
+    """The ACL list-membership term resolves to true element overlap."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    # bob is a reader of alice_priv only
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        got = {r.meta.resource_id for r in op.list_resources()}
+    assert ids["alice_priv"] in got
+
+
+# --------------------------------------------------------------------------- #
+# SQLAlchemy meta store (real sqlite) — cross-backend consistency + the
+# previously-missing contains_any operator (#398 / #378).
+# --------------------------------------------------------------------------- #
+def _mk_sqlalchemy_rm():
+    from sqlalchemy import create_engine
+
+    from specstar.resource_manager.meta_store.sqlalchemy import SQLAlchemyMetaStore
+
+    engine = create_engine("sqlite://")  # in-process; pooled kwargs rejected by sqlite
+    meta_store = SQLAlchemyMetaStore("sqlite://", engine=engine)
+    meta_store.register_list_field("readers")
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(Doc),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(
+        Doc,
+        storage=storage,
+        indexed_fields=_indexed_fields(),
+        access_scope=scope_for,
+    )
+
+
+def test_sqlalchemy_contains_any_builds_membership_predicate():
+    """Regression: ``contains_any`` was unhandled in the SQLAlchemy builder and
+    silently dropped — for an access scope that is over-matching (a security
+    hole). It must now compile to JSON element membership, not vanish."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.dialects import sqlite
+
+    from specstar.query_types import DataSearchCondition, DataSearchOperator
+    from specstar.resource_manager.meta_store.sqlalchemy import SQLAlchemyMetaStore
+
+    store = SQLAlchemyMetaStore("sqlite://", engine=create_engine("sqlite://"))
+    store.register_list_field("readers")
+    cond = DataSearchCondition(
+        field_path="readers",
+        operator=DataSearchOperator.contains_any,
+        value=["alice", "bob"],
+    )
+    expr = store._build_condition(cond)
+    assert expr is not None, "contains_any must not be dropped"
+    sql = str(
+        expr.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True})
+    )
+    assert "json_each" in sql  # element membership, not a substring LIKE
+    # empty candidate set matches nothing (not everything)
+    empty = store._build_condition(
+        DataSearchCondition(
+            field_path="readers",
+            operator=DataSearchOperator.contains_any,
+            value=[],
+        )
+    )
+    assert empty is not None
+
+
+def test_sqlalchemy_backend_scope_consistent_with_memory():
+    rm = _mk_sqlalchemy_rm()
+    ids = _seed(rm)
+    # Same expectations as the in-memory backend → cross-backend consistency.
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        listed = {r.meta.resource_id for r in op.list_resources()}
+        count = op.count_resources()
+    assert listed == {ids["pub"], ids["alice_priv"], ids["bob_priv"]}
+    assert count == 3
+    with rm.using("bob", NOW, apply_access_scope=True) as op:  # noqa: SIM117
+        with pytest.raises(ResourceIDNotFoundError):
+            op.get(ids["carol_priv"])
+
+
+# --------------------------------------------------------------------------- #
+# HTTP routes (TestClient) — every read route opts into scoping.
+# --------------------------------------------------------------------------- #
+def _get_user(x_user: str = Header(default="anonymous")) -> str:
+    return x_user
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    router = APIRouter()
+    spec = SpecStar(dependency_provider=DependencyProvider(get_user=_get_user))
+    spec.add_model(
+        Doc,
+        indexed_fields=[("visibility", str), ("owner", str), ("readers", list)],
+        access_scope=scope_for,
+    )
+    spec.apply(router)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _create(client: TestClient, owner: str, **kw) -> str:
+    body = {
+        "owner": owner,
+        "visibility": kw.get("visibility", "private"),
+        "readers": kw.get("readers", []),
+    }
+    r = client.post("/doc", json=body, headers={"X-User": owner})
+    assert r.status_code == 200, r.text
+    return r.json()["resource_id"]
+
+
+def test_http_list_and_single_get_are_scoped(client: TestClient):
+    pub = _create(client, "alice", visibility="public")
+    alice_priv = _create(client, "alice", visibility="private", readers=["bob"])
+    bob_priv = _create(client, "bob", visibility="private")
+    carol_priv = _create(client, "carol", visibility="private", readers=["alice"])
+
+    # bob's list: public + own + reader-of
+    r = client.get("/doc", headers={"X-User": "bob"})
+    assert r.status_code == 200
+    got = {item["meta"]["resource_id"] for item in r.json()}
+    assert got == {pub, alice_priv, bob_priv}
+
+    # count agrees
+    r = client.get("/doc/count", headers={"X-User": "bob"})
+    assert r.status_code == 200 and r.json() == 3
+
+    # carol's private doc is a 404 for bob (existence hidden), 200 for carol
+    assert (
+        client.get(f"/doc/{carol_priv}", headers={"X-User": "bob"}).status_code == 404
+    )
+    assert (
+        client.get(f"/doc/{carol_priv}", headers={"X-User": "carol"}).status_code == 200
+    )
+
+    # admin (UNRESTRICTED) sees all four
+    r = client.get("/doc/count", headers={"X-User": "admin"})
+    assert r.json() == 4
+
+
+def test_http_banned_user_sees_nothing(client: TestClient):
+    pub = _create(client, "alice", visibility="public")
+    r = client.get("/doc", headers={"X-User": "banned"})
+    assert r.status_code == 200 and r.json() == []
+    assert client.get(f"/doc/{pub}", headers={"X-User": "banned"}).status_code == 404


### PR DESCRIPTION
## What

Implements **part A of #398** — a per-model **read access-scope** predicate for first-class row-level security on the auto-CRUD read routes.

```python
spec.add_model(
    Doc,
    indexed_fields=[("visibility", str), ("owner", str), ("readers", list)],
    access_scope=lambda user: (
        (QB["visibility"] == "public")
        | (QB["owner"] == user)
        | QB["readers"].contains_any([user])
    ),
)
```

`access_scope` is a callable `user -> ConditionBuilder | None | UNRESTRICTED` that specstar **ANDs into every request-originated read** — `list`/`search`/`count` **and** every single-resource GET variant (`/{id}`, `/data`, `/full`, `/meta`, `/revision-info`, `/revision-list`, `/blobs/*`).

- **Out-of-scope → 404** (existence hidden), uniformly with list filtering. No per-route wiring.
- **`None` → deny all (fail-closed)** — list/count return empty without touching storage; single GET → 404. A misconfigured predicate hides rather than leaks.
- **`UNRESTRICTED` → no restriction** (admins/privileged). The single, greppable "see everything" path; no implicit global admin bypass.

## Design (decided via a design review on #398)

- **Enforcement layer = ResourceManager read methods**, not per-route. One choke point; new read routes inherit it.
- **Opt-in**: only the generated read-route templates enter `using(..., apply_access_scope=True)`. Every internal `ResourceManager` read stays **unscoped** (zero behaviour change for async jobs, constraints, restore, migration, …).
- **Applied once, at the outermost read**: list/count AND the predicate into the storage query; single GETs run a scoped existence probe (`count(scope & resource_id == id)`). Nested/per-row reads clear the flag → **no N+1**.
- **404, never 403**: access_scope is a visibility filter; `403` stays the `permission_checker`'s job. Single-resource: scope is evaluated first, so an out-of-scope resource 404s without consulting the checker (no existence leak).
- **Storage is the single evaluator** for both list and single GET → no "visible in list but 404 on direct GET" divergence.
- **Strict field validation**: a scope predicate over a non-indexed field raises (never silently degrades to substring `LIKE`), independent of the model's `on_unindexed_query` — a dropped condition would widen visibility.

## Bug fix bundled (A depends on it)

`contains_any` (the canonical ACL list-membership term, e.g. `readers.contains_any([user])`) was **unhandled in the SQLAlchemy meta store** and silently dropped from the WHERE clause — over-matching, i.e. a security hole that this feature exposes. It now compiles to per-dialect JSON element membership, consistent with the in-process and raw sqlite3/psycopg backends (#378/#398).

## Tests

`tests/test_access_scope.py` (14 tests, all green) covers three levels:
- **ResourceManager (in-memory)**: list filtering, count, single-GET 404, `get_meta`/`get_revision_info` (incl. the explicit-`revision_id` path that doesn't lead with `get_meta`), `None` deny-all, `UNRESTRICTED`, internal-reads-unscoped, scope-ANDs-with-user-query, strict unindexed-field rejection, `contains_any` membership.
- **SQLAlchemy meta store (real sqlite)**: cross-backend consistency + a regression test pinning the `contains_any` fix.
- **HTTP routes (TestClient)**: per-user list filtering, single-GET 404 vs 200, count, banned-user-sees-nothing.

No regressions in the in-process suites (routes / permission / meta_store-in-process / core read paths). Two pre-existing local failures (`test_blob_lifecycle` content-type, `test_list_resources_error_skip`) fail identically on the base branch and are unrelated (missing optional deps in this env).

## Seams left for B (#399)

- `permission_checker` keyed on `get` does not fire on `GET /{id}` today (single GET doesn't call `rm.get()`); A's 404 now provides read enforcement there.
- Writes are **not** scoped by access_scope; whether an out-of-scope write should 404 (to avoid existence-probing via writes) vs 403 is B's call.

Closes part A of #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
