### PR TITLE
feat(permission): gate writes by access_scope + lifecycle resource-aware checks (#398 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 
+### Added
+
+- **Resource-level access control (#398).** A per-model `access_scope`
+  predicate (`user -> ConditionBuilder | None | UNRESTRICTED`) for row-level
+  security. It is ANDed into every request-originated read (`list`/`search`/
+  `count` and all single-resource GET variants) **and** enforced as a
+  precondition for every request-originated write (`update`/`modify`/`patch`/
+  `delete`/`permanently_delete`/`switch`/`restore`, plus the batch
+  delete/restore endpoints). A resource outside the caller's scope is hidden as
+  **404** on both reads and writes — evaluated *before* the permission checker,
+  so existence never leaks via a 403. `None` denies all (fail-closed),
+  `UNRESTRICTED` bypasses, and a predicate over an unindexed field raises rather
+  than silently widening visibility. Internal `ResourceManager` calls stay
+  unscoped; only routes entered with `apply_access_scope=True` are gated. See the
+  [access-scope how-to](docs/en/howto/access-scope.md). (#399, #400)
+- Write-phase permission checks can read the current stored resource via
+  `PermissionContext.current_resource`, gated per action by
+  `IPermissionChecker.required_resource_parts` / `@requires_resource_parts` so a
+  checker pays only for the slices it declares. Available across the full write
+  lifecycle — `update`/`modify`/`patch`/`delete` **and** `switch`/
+  `permanently_delete`/`restore` — so `owner_self` and embedded-field write ACLs
+  work end-to-end. (#398)
+
+
 ### Fixed
+
+- `owner_self` no longer always-denies write actions: it read a `context.meta`
+  that never existed on before-contexts (deny-all). It now reads
+  `current_resource.meta.created_by` and works on the whole write lifecycle.
+  ⚠️ behavior change: a setup that mapped `owner_self` to a write/lifecycle
+  action was effectively deny-all and will now correctly allow the owner. (#398)
 
 - `partition_key` / `idempotency_key` are now honored by **every** message
   queue backend, not just `SimpleMessageQueue` (#384). RabbitMQ and Celery

--- a/docs/en/howto/access-scope.md
+++ b/docs/en/howto/access-scope.md
@@ -1,0 +1,133 @@
+# Read/write access scope (row-level security)
+
+`access_scope` is a per-model predicate that SpecStar **ANDs into every
+request-originated read**, and enforces as a **precondition for every
+request-originated write**. It gives you row-level security — "which resources
+exist *for this user*" — at a single choke point, without per-route wiring.
+
+```python
+spec.add_model(
+    Doc,
+    indexed_fields=[("visibility", str), ("owner", str), ("readers", list)],
+    access_scope=lambda user: (
+        (QB["visibility"] == "public")
+        | (QB["owner"] == user)
+        | QB["readers"].contains_any([user])
+    ),
+)
+```
+
+The callable is `user -> ConditionBuilder | None | UNRESTRICTED`:
+
+| Return value          | Meaning                                                        |
+| --------------------- | ------------------------------------------------------------- |
+| a `ConditionBuilder`  | restrict to rows matching the predicate                       |
+| `None`                | **deny all** (fail-closed) — list/count empty, every GET 404  |
+| `UNRESTRICTED`        | no restriction (admins / privileged callers)                  |
+
+```python
+from specstar import UNRESTRICTED
+
+def scope_for(user: str):
+    if user == "admin":
+        return UNRESTRICTED          # sees everything
+    if user == "banned":
+        return None                  # sees nothing
+    return (QB["visibility"] == "public") | (QB["owner"] == user)
+```
+
+`UNRESTRICTED` is the single, greppable "see everything" path — there is no
+implicit global-admin bypass.
+
+## What it gates
+
+**Reads** — `access_scope` ANDs into `list` / `search` / `count` **and** every
+single-resource GET variant (`/{id}`, `/data`, `/full`, `/meta`,
+`/revision-info`, `/revision-list`, and the resource-scoped
+`/{id}/blobs/{file_id}`):
+
+- list/search/count return only in-scope rows, filtered **at the storage layer**.
+- a single GET of an out-of-scope resource returns **404** — its existence is
+  hidden, uniformly with list filtering, never a 403.
+
+**Writes** — `access_scope` is a **necessary precondition** for every
+request-originated write that targets an existing resource by id: `update`,
+`modify`, `patch`, `delete`, `permanently_delete`, `switch`, and `restore`
+(plus the batch delete/restore endpoints, which only touch in-scope rows). A
+write to an out-of-scope resource raises not-found (**404**) *before* the
+permission checker runs, so writes never leak existence either.
+
+`create` is **not** gated — there is no existing resource to be out of scope of.
+
+## access_scope is visibility, not authorization
+
+`access_scope` answers *"does this row exist for this caller?"* (→ 404). It is
+**not** a replacement for a [permission checker](permissions.md), which answers
+*"is this caller allowed to perform this action?"* (→ 403). They compose:
+
+1. `access_scope` is evaluated **first**. Out of scope → 404, and the checker
+   never runs (no existence leak via a 403).
+2. For an in-scope resource, the `permission_checker` still runs and may deny
+   the write with a 403.
+
+So a typical resource is locked down with **both**: a broad read predicate
+(public *or* owner *or* shared) plus a narrower write checker (e.g.
+`owner_self`, which only the owner passes). Setting only `access_scope` makes a
+resource invisible *and* unwritable to outsiders, but in-scope callers can still
+write it unless a checker says otherwise.
+
+## Opt-in and internal calls
+
+Scoping is applied only when a read/write is entered with
+`apply_access_scope=True`:
+
+- **Generated routes opt in for you.** Every built-in read route and every
+  built-in write route enters `using(..., apply_access_scope=True)`.
+- **Custom routes must opt in explicitly.** If you write your own route that
+  reads or mutates resources on behalf of the request user, wrap the call:
+
+  ```python
+  with resource_manager.using(user=current_user, apply_access_scope=True):
+      resource_manager.update(resource_id, data)
+  ```
+
+  A custom route that forgets this is **not** scoped — treat it like any other
+  place you must apply authorization by hand.
+- **Internal `ResourceManager` calls stay unscoped.** Async jobs, constraints,
+  restore/migration machinery, and any other trusted internal read or write see
+  everything — exactly as before. A model with no `access_scope` configured pays
+  nothing.
+
+## Fields must be indexed
+
+A scope predicate may only reference `ResourceMeta` attributes or configured
+indexed fields. A predicate over an unindexed field **always raises**
+(`UnindexedQueryError`), regardless of the model's `on_unindexed_query` setting —
+a silently-dropped condition would *widen* visibility, a security hole. Register
+every field your predicate touches:
+
+```python
+spec.add_model(
+    Doc,
+    indexed_fields=[("visibility", str), ("owner", str), ("readers", list)],
+    access_scope=scope_for,
+)
+```
+
+For list-membership ACLs (`readers.contains_any([user])`), the list field must be
+registered as a list-typed indexed field so it compiles to true element
+membership rather than a substring match.
+
+## Caveat: the bare blob endpoint
+
+The bare `GET /blobs/{file_id}` endpoint is a global, content-addressed blob
+download with **no resource context**, so `access_scope` (a per-resource
+predicate) cannot apply to it. The resource-scoped
+`GET /{model}/{id}/blobs/{file_id}` route *is* scoped. If you need row-level
+security on blob content, do not expose the bare endpoint, or gate it yourself.
+
+## Related pages
+
+- [Permissions](permissions.md) — action-based authorization (the 403 side).
+- [Query Builder](query-builder.md) — building the predicate.
+- [Routes generation](routes.md)

--- a/docs/en/howto/permissions.md
+++ b/docs/en/howto/permissions.md
@@ -149,7 +149,8 @@ Use this when you want a convenient starting point and plan to build out the rul
 
 ## Resource-aware write authorization
 
-For write actions (`update`, `modify`, `patch`, `delete`) a checker can read the
+For write actions (`update`, `modify`, `patch`, `delete`, and the lifecycle
+verbs `switch`, `permanently_delete`, `restore`) a checker can read the
 **current, already-stored** resource — its `meta`, `data`, and revision `info` —
 to make data- or owner-based decisions. SpecStar loads that snapshot into
 `context.current_resource` *before* running the before-phase check.
@@ -200,8 +201,11 @@ Notes:
   "this field is immutable" rules.
 - If the resource doesn't exist, the write fails with the usual not-found
   (404) **before** the permission verdict is reached.
-- Reads/lists are out of scope here — filter those with a read access-scope
-  predicate instead.
+- Reads/lists are filtered by an [access-scope predicate](access-scope.md), not
+  this checker. That same predicate is also a **precondition for writes**: a
+  request targeting a resource outside the caller's scope 404s (existence
+  hidden) *before* this checker runs, so `access_scope` (visibility / 404) and
+  the permission checker (authorization / 403) compose.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ plugins:
                 - howto/api-conventions.md
                 - howto/routes.md
                 - howto/permissions.md
+                - howto/access-scope.md
                 - howto/audit-user.md
                 - howto/event-handlers.md
                 - howto/query-builder.md

--- a/specstar/crud/route_templates/delete.py
+++ b/specstar/crud/route_templates/delete.py
@@ -72,7 +72,9 @@ class DeleteRouteTemplate(BaseRouteTemplate):
             current_time: dt.datetime = Depends(self.deps.get_now),
         ):
             try:
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.delete(resource_id)
                 return MsgspecResponse(meta)
             except Exception as e:
@@ -121,7 +123,9 @@ class PermanentlyDeleteRouteTemplate(BaseRouteTemplate):
             current_time: dt.datetime = Depends(self.deps.get_now),
         ):
             try:
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.permanently_delete(resource_id)
                 return MsgspecResponse(meta)
             except Exception as e:
@@ -184,7 +188,9 @@ class BatchDeleteRouteTemplate(BaseRouteTemplate):
                 # 強制覆蓋 is_deleted = False，只搜尋未刪除的資源
                 query_params.is_deleted = False
                 query = build_query(query_params, request, {"is_deleted"})
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     metas = resource_manager.search_resources(query)
                     results: list[ResourceMeta] = []
                     for meta in metas:
@@ -251,7 +257,9 @@ class RestoreRouteTemplate(BaseRouteTemplate):
             current_time: dt.datetime = Depends(self.deps.get_now),
         ):
             try:
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.restore(resource_id)
                 return MsgspecResponse(meta)
             except Exception as e:
@@ -314,7 +322,9 @@ class BatchRestoreRouteTemplate(BaseRouteTemplate):
                 # 強制覆蓋 is_deleted = True，只搜尋已刪除的資源
                 query_params.is_deleted = True
                 query = build_query(query_params, request, {"is_deleted"})
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     metas = resource_manager.search_resources(query)
                     results: list[ResourceMeta] = []
                     for meta in metas:

--- a/specstar/crud/route_templates/patch.py
+++ b/specstar/crud/route_templates/patch.py
@@ -216,16 +216,16 @@ class PatchRouteTemplate(BaseRouteTemplate):
                     "expected_revision_id": expected_rev_id,
                     "expected_etag": expected_etag,
                 }
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     if flavor == "merge":
                         _guard_merge_patch_body(
                             body, content_type, _struct_owns_resource_id
                         )
                         merge = MergePatch(body)
                         if mode == "update":
-                            info = resource_manager.patch(
-                                resource_id, merge, **cas_kw
-                            )
+                            info = resource_manager.patch(resource_id, merge, **cas_kw)
                         else:  # mode == "modify"
                             info = resource_manager.modify(
                                 resource_id,
@@ -242,9 +242,7 @@ class PatchRouteTemplate(BaseRouteTemplate):
                             reject_resource_id_in_patch(body)
                         patch = JsonPatch(body)
                         if mode == "update":
-                            info = resource_manager.patch(
-                                resource_id, patch, **cas_kw
-                            )
+                            info = resource_manager.patch(resource_id, patch, **cas_kw)
                         else:  # mode == "modify"
                             info = resource_manager.modify(
                                 resource_id,

--- a/specstar/crud/route_templates/switch.py
+++ b/specstar/crud/route_templates/switch.py
@@ -76,7 +76,9 @@ class SwitchRevisionRouteTemplate(BaseRouteTemplate):
         ):
             try:
                 normalized = _normalize_revision_id(resource_id, revision_id)
-                with resource_manager.using(current_user, current_time):
+                with resource_manager.using(
+                    current_user, current_time, apply_access_scope=True
+                ):
                     meta = resource_manager.switch(resource_id, normalized)
                 return MsgspecResponse(meta)
             except Exception as e:

--- a/specstar/crud/route_templates/update.py
+++ b/specstar/crud/route_templates/update.py
@@ -139,9 +139,7 @@ class UpdateRouteTemplate(BaseRouteTemplate):
                                 actual_revision_id="exists",
                             ) from exc
                         raise
-                    return MsgspecResponse(
-                        info, headers={"ETag": f'"{info.etag}"'}
-                    )
+                    return MsgspecResponse(info, headers={"ETag": f'"{info.etag}"'})
                 expected_etag, expected_rev_id = _resolve_precondition(
                     expected_revision_id, if_match
                 )
@@ -150,7 +148,9 @@ class UpdateRouteTemplate(BaseRouteTemplate):
                 # ``msgspec.convert`` drops unknown keys.
                 data = msgspec.UNSET if body is None else body
                 if mode == "update":
-                    with resource_manager.using(current_user, current_time):
+                    with resource_manager.using(
+                        current_user, current_time, apply_access_scope=True
+                    ):
                         info = resource_manager.update(  # ty:ignore[invalid-argument-type]
                             resource_id,
                             data,
@@ -158,7 +158,9 @@ class UpdateRouteTemplate(BaseRouteTemplate):
                             expected_etag=expected_etag,
                         )
                 else:  # mode == "modify"
-                    with resource_manager.using(current_user, current_time):
+                    with resource_manager.using(
+                        current_user, current_time, apply_access_scope=True
+                    ):
                         info = resource_manager.modify(
                             resource_id,
                             data,

--- a/specstar/events.py
+++ b/specstar/events.py
@@ -690,6 +690,7 @@ BeforeSwitch = defstruct(
     [
         *_before_context,
         *_switch_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,
@@ -805,6 +806,7 @@ BeforePermanentlyDelete = defstruct(
     [
         *_before_context,
         *_permanently_delete_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,
@@ -917,6 +919,7 @@ BeforeRestore = defstruct(
     [
         *_before_context,
         *_restore_context,
+        _current_resource_field,
     ],
     kw_only=True,
     tag=True,

--- a/specstar/events.pyi
+++ b/specstar/events.pyi
@@ -536,6 +536,7 @@ class BeforePermanentlyDelete(Struct, kw_only=True, tag=True, tag_field="context
         ResourceAction.permanently_delete
     )
     resource_id: str
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterPermanentlyDelete(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -624,6 +625,7 @@ class BeforeRestore(Struct, kw_only=True, tag=True, tag_field="context_type"):
     resource_name: str
     action: Literal[ResourceAction.restore] = ResourceAction.restore
     resource_id: str
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterRestore(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"
@@ -699,6 +701,7 @@ class BeforeSwitch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     action: Literal[ResourceAction.switch] = ResourceAction.switch
     resource_id: str
     revision_id: str
+    current_resource: SearchedResource[T] | UnsetType = UNSET
 
 class AfterSwitch(Struct, kw_only=True, tag=True, tag_field="context_type"):
     phase: Literal["after"] = "after"

--- a/specstar/permission/builtins.py
+++ b/specstar/permission/builtins.py
@@ -51,7 +51,8 @@ def owner_self(context: PermissionContext) -> PermissionResult:
     ``meta.created_by``.
 
     Reads the pre-write ``current_resource`` snapshot the ResourceManager
-    loads for write checks (update/modify/patch/delete) — the
+    loads for write checks (update/modify/patch/delete and the lifecycle verbs
+    switch/permanently_delete/restore) — the
     ``@requires_resource_parts(ResourcePart.META)`` marker is what makes that
     ``meta`` slice available. For actions with no current resource (e.g.
     create, or read contexts that don't carry the snapshot) no owner exists

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -587,6 +587,25 @@ def coerce_data_to_resource_type(func):
     return wrapper
 
 
+# Write verbs that target an existing resource by id and are subject to the
+# read access-scope as a *precondition*: a request-originated write of a
+# resource outside the caller's scope is hidden as 404 before the permission
+# checker runs (#398 follow-up). ``create`` is excluded (no existing resource);
+# maintenance verbs (migrate/prune/dump/load) run under a privileged/unscoped
+# context and are intentionally not gated here.
+_SCOPED_WRITE_ACTIONS = frozenset(
+    {
+        ResourceAction.update,
+        ResourceAction.modify,
+        ResourceAction.patch,
+        ResourceAction.delete,
+        ResourceAction.permanently_delete,
+        ResourceAction.switch,
+        ResourceAction.restore,
+    }
+)
+
+
 def execute_with_events(
     contexts: "_Contexts | tuple[Any, Any, Any, Any]",
     result: str | Callable[[Any], dict[str, Any]],
@@ -675,6 +694,15 @@ def execute_with_events(
                         else:
                             inputs_[k] = get_from_path(func_inputs, v)
                 before_ctx = contexts.before(**inputs_)
+                # Read access-scope is a precondition for request-originated
+                # writes: a resource outside the caller's scope is hidden as
+                # not-found (→ 404) *before* the permission checker (→ 403) and
+                # before any current_resource load, so writes never leak
+                # existence. The remainder then runs unscoped — the resource is
+                # confirmed in-scope, and the operation's own (and nested
+                # get/get_meta) reads must not re-probe.
+                if self._maybe_assert_write_scope(before_ctx) and stack is not None:
+                    stack.enter_context(self.apply_scope_ctx.ctx(False))
                 self._maybe_load_current_resource(before_ctx)
                 self._handle_event(before_ctx)
                 try:
@@ -1799,6 +1827,30 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         before_ctx.current_resource = self._load_current_resource(
             before_ctx.resource_id, parts
         )
+
+    def _maybe_assert_write_scope(self, before_ctx: Any) -> bool:
+        """Enforce the read access-scope as a precondition for a
+        request-originated write: a resource outside the caller's scope raises
+        not-found (→ 404) *before* the permission checker runs, so writes never
+        leak existence (uniformly with reads).
+
+        Returns ``True`` when this is a scoped write that was probed — the
+        caller then runs the remainder of the operation unscoped (the resource
+        is confirmed in-scope; its own and nested reads must not re-probe).
+        Returns ``False`` (a no-op) for internal/unscoped writes — every
+        ``ResourceManager`` write that isn't entered via
+        ``using(..., apply_access_scope=True)`` keeps its full pre-#398
+        behaviour, paying nothing.
+        """
+        if not self.apply_scope_ctx.get():
+            return False
+        if getattr(before_ctx, "action", None) not in _SCOPED_WRITE_ACTIONS:
+            return False
+        rid = getattr(before_ctx, "resource_id", UNSET)
+        if rid is UNSET or rid is None:
+            return False
+        self._assert_in_scope(rid)
+        return True
 
     def exists(self, resource_id: str) -> bool:
         """

--- a/tests/permission/test_current_resource.py
+++ b/tests/permission/test_current_resource.py
@@ -293,3 +293,55 @@ def test_action_based_aggregates_markers_per_action() -> None:
         {ResourcePart.META}
     )
     assert chk.required_resource_parts(ResourceAction.delete) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# current_resource reaches the whole lifecycle, not just soft delete. The
+# ``owner`` grouped action (= read | patch | update | modify | lifecycle)
+# advertises switch / permanently_delete / restore as owner-protectable, so a
+# resource-aware checker (owner_self) must get the snapshot there too —
+# otherwise it silently denies even the owner (#398 follow-up).
+# ---------------------------------------------------------------------------
+
+
+def _owner_lifecycle_checker() -> ActionBasedPermissionChecker:
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.read: any_user,  # internal/nested reads (switch's get_meta)
+            ResourceAction.switch: owner_self,
+            ResourceAction.permanently_delete: owner_self,
+            ResourceAction.restore: owner_self,
+        }
+    )
+
+
+def test_owner_self_covers_permanently_delete() -> None:
+    rm = make_rm(_owner_lifecycle_checker())
+    rid = _seed(rm, "alice")
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.permanently_delete(rid)
+    with rm.using("alice", NOW):  # owner is allowed (current_resource.meta available)
+        rm.permanently_delete(rid)
+
+
+def test_owner_self_covers_restore() -> None:
+    rm = make_rm(_owner_lifecycle_checker())
+    rid = _seed(rm, "alice")
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.restore(rid)
+    with rm.using("alice", NOW):  # owner is allowed
+        rm.restore(rid)
+
+
+def test_owner_self_covers_switch() -> None:
+    rm = make_rm(_owner_lifecycle_checker())
+    rid = _seed(rm, "alice")
+    current = rm.get_meta(rid).current_revision_id  # internal read, unscoped
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.switch(rid, current)
+    with rm.using("alice", NOW):  # owner is allowed
+        rm.switch(rid, current)

--- a/tests/test_access_scope.py
+++ b/tests/test_access_scope.py
@@ -27,12 +27,17 @@ from msgspec import Struct
 
 from specstar import QB, UNRESTRICTED, SpecStar
 from specstar.crud.route_templates.dependency_provider import DependencyProvider
+from specstar.permission.action import ActionBasedPermissionChecker
+from specstar.permission.builtins import any_user
+from specstar.permission.checker import PermissionContext, PermissionResult
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.simple import MemoryMetaStore
 from specstar.resource_manager.resource_store.simple import MemoryResourceStore
 from specstar.types import (
     IndexableField,
     OnUnindexedQuery,
+    PermissionDeniedError,
+    ResourceAction,
     ResourceIDNotFoundError,
     UnindexedQueryError,
 )
@@ -73,7 +78,11 @@ def _indexed_fields() -> list[IndexableField]:
 # --------------------------------------------------------------------------- #
 # ResourceManager-level (in-memory)
 # --------------------------------------------------------------------------- #
-def _mk_rm(access_scope=scope_for, on_unindexed_query=OnUnindexedQuery.warn):
+def _mk_rm(
+    access_scope=scope_for,
+    on_unindexed_query=OnUnindexedQuery.warn,
+    permission_checker=None,
+):
     storage = SimpleStorage(
         meta_store=MemoryMetaStore(),
         resource_store=MemoryResourceStore(Doc),  # ty:ignore[invalid-argument-type]
@@ -84,6 +93,7 @@ def _mk_rm(access_scope=scope_for, on_unindexed_query=OnUnindexedQuery.warn):
         indexed_fields=_indexed_fields(),
         access_scope=access_scope,
         on_unindexed_query=on_unindexed_query,
+        permission_checker=permission_checker,
     )
 
 
@@ -229,6 +239,114 @@ def test_contains_any_membership_in_memory():
 
 
 # --------------------------------------------------------------------------- #
+# Write access-scope gate (#398 follow-up) — a resource outside the caller's
+# scope is hidden as 404 on writes too, *before* the permission checker runs.
+# access_scope is a necessary precondition for request-originated writes; the
+# permission checker still authorizes the in-scope ones.
+# --------------------------------------------------------------------------- #
+def test_out_of_scope_update_is_404():
+    rm = _mk_rm()
+    ids = _seed(rm)
+    # bob may update his own in-scope doc
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        op.update(ids["bob_priv"], Doc(owner="bob", visibility="private"))
+    # ...but carol's private doc is hidden as not-found on write too (not 403/200)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:  # noqa: SIM117
+        with pytest.raises(ResourceIDNotFoundError):
+            op.update(ids["carol_priv"], Doc(owner="carol", visibility="private"))
+
+
+def _deny_update(context: PermissionContext) -> PermissionResult:
+    # No @requires_resource_parts marker → declares no slices, so the
+    # current_resource load does *not* incidentally trigger the scope probe.
+    return PermissionResult.deny
+
+
+def _deny_update_checker() -> ActionBasedPermissionChecker:
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.read: any_user,
+            ResourceAction.update: _deny_update,
+        }
+    )
+
+
+def test_out_of_scope_write_404s_before_permission_403():
+    """Scope is evaluated first: an out-of-scope write 404s (existence hidden)
+    before the permission checker can 403 — even when the checker declares no
+    resource parts, so the current_resource load wouldn't incidentally probe."""
+    rm = _mk_rm(permission_checker=_deny_update_checker())
+    ids = _seed(rm)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:  # noqa: SIM117
+        # carol's doc is out of bob's scope → not-found, never the deny verdict
+        with pytest.raises(ResourceIDNotFoundError):
+            op.update(ids["carol_priv"], Doc(owner="carol", visibility="private"))
+
+
+def test_in_scope_write_still_runs_the_checker():
+    """Scope is a precondition, not authorization: an in-scope write still goes
+    through the permission checker (here: deny → 403, not a silent allow)."""
+    rm = _mk_rm(permission_checker=_deny_update_checker())
+    ids = _seed(rm)
+    with rm.using("bob", NOW, apply_access_scope=True) as op:  # noqa: SIM117
+        # bob_priv IS in bob's scope, so the checker runs and denies it
+        with pytest.raises(PermissionDeniedError):
+            op.update(ids["bob_priv"], Doc(owner="bob", visibility="private"))
+
+
+def test_internal_writes_are_never_scoped():
+    """Without ``apply_access_scope=True`` (every internal call), a write of a
+    resource the predicate would hide still succeeds — internal machinery is
+    trusted, exactly like internal reads."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    with rm.using("bob", NOW) as op:  # no apply_access_scope
+        op.update(ids["carol_priv"], Doc(owner="carol", visibility="private"))
+        op.delete(ids["carol_priv"])  # carol's doc, out of bob's read scope
+
+
+def test_write_unaffected_when_no_access_scope_configured():
+    """A model with no ``access_scope`` pays nothing and behaves exactly as
+    before, even under ``apply_access_scope=True``."""
+    rm = _mk_rm(access_scope=None)
+    ids = _seed(rm)
+    with rm.using("dave", NOW, apply_access_scope=True) as op:
+        op.update(ids["carol_priv"], Doc(owner="carol", visibility="private"))
+
+
+def test_out_of_scope_lifecycle_writes_are_404():
+    """Every request-originated write that targets an existing resource by id
+    is gated, so an out-of-scope caller cannot soft-delete / hard-delete /
+    switch / restore a resource they can't even see."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    carol = ids["carol_priv"]  # out of bob's scope
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        with pytest.raises(ResourceIDNotFoundError):
+            op.delete(carol)
+        with pytest.raises(ResourceIDNotFoundError):
+            op.permanently_delete(carol)
+        with pytest.raises(ResourceIDNotFoundError):
+            op.switch(carol, "any-revision")
+        with pytest.raises(ResourceIDNotFoundError):
+            op.restore(carol)
+
+
+def test_in_scope_restore_after_soft_delete_passes_the_gate():
+    """A soft-deleted but in-scope resource can still be restored under the
+    write gate — the scope probe must not filter out deleted rows, or restore
+    would 404 itself."""
+    rm = _mk_rm()
+    ids = _seed(rm)
+    bob_doc = ids["bob_priv"]
+    with rm.using("bob", NOW, apply_access_scope=True) as op:
+        op.delete(bob_doc)  # soft-delete own (in scope)
+        meta = op.restore(bob_doc)  # restore own — the gate must still allow it
+    assert meta.is_deleted is False
+
+
+# --------------------------------------------------------------------------- #
 # SQLAlchemy meta store (real sqlite) — cross-backend consistency + the
 # previously-missing contains_any operator (#398 / #378).
 # --------------------------------------------------------------------------- #
@@ -367,3 +485,41 @@ def test_http_banned_user_sees_nothing(client: TestClient):
     r = client.get("/doc", headers={"X-User": "banned"})
     assert r.status_code == 200 and r.json() == []
     assert client.get(f"/doc/{pub}", headers={"X-User": "banned"}).status_code == 404
+
+
+def test_http_writes_are_scoped(client: TestClient):
+    """Every request-originated write route opts into access-scope: a caller
+    who can't see a resource gets 404 (existence hidden) on writes too, while
+    the owner can still write their own."""
+    carol_priv = _create(client, "carol", visibility="private")
+    body = {"owner": "carol", "visibility": "private", "readers": []}
+    bob = {"X-User": "bob"}
+    assert client.put(f"/doc/{carol_priv}", json=body, headers=bob).status_code == 404
+    assert client.delete(f"/doc/{carol_priv}", headers=bob).status_code == 404
+    assert (
+        client.delete(f"/doc/{carol_priv}/permanently", headers=bob).status_code == 404
+    )
+    assert client.post(f"/doc/{carol_priv}/restore", headers=bob).status_code == 404
+    # carol (owner, in scope) can update her own doc
+    assert (
+        client.put(
+            f"/doc/{carol_priv}", json=body, headers={"X-User": "carol"}
+        ).status_code
+        == 200
+    )
+
+
+def test_http_batch_delete_only_touches_in_scope_rows(client: TestClient):
+    """A batch delete is bounded by the caller's scope — it cannot reach rows
+    the caller can't even see."""
+    pub = _create(client, "alice", visibility="public")
+    carol_priv = _create(client, "carol", visibility="private")
+    # bob batch-deletes everything he can: only the public row is in scope
+    r = client.request("DELETE", "/doc", headers={"X-User": "bob"})
+    assert r.status_code == 200, r.text
+    deleted = {m["resource_id"] for m in r.json()}
+    assert deleted == {pub}
+    # carol's private row was never touched (still visible & active to carol)
+    assert (
+        client.get(f"/doc/{carol_priv}", headers={"X-User": "carol"}).status_code == 200
+    )


### PR DESCRIPTION
## What & why

Follow-up to **#399** (write `current_resource`) and **#400** (read
`access_scope`), closing the two gaps that kept the #398 halves from fully
interlocking. Verified that #399 + #400 merged cleanly and jointly cover #398's
read/list/write requirements; this PR finishes the seam they explicitly left as
"B's call".

### 1. `access_scope` now gates writes (was: reads only)

Before this PR, `access_scope` filtered reads but **not** writes — an
out-of-scope caller could `PUT`/`DELETE`/`.../permanently` a resource they
couldn't even see (404 on read, but 200/403 on write). Now `access_scope` is a
**necessary precondition** for every request-originated write that targets an
existing resource by id:

- `update` / `modify` / `patch` / `delete` / `permanently_delete` / `switch` /
  `restore`, plus the batch delete/restore endpoints (their search is scoped, so
  a batch only ever touches in-scope rows).
- Out-of-scope → **404** (existence hidden), evaluated **before** the permission
  checker, so writes never leak existence via a 403 — uniform with reads.
- Enforced at a single choke point in the event before-phase, gated by
  `apply_access_scope`. The probe is an indexed `count` (no resource decode);
  **internal writes and models without `access_scope` pay nothing**. Generated
  write routes opt in; custom routes opt in the same way reads do.

### 2. `current_resource` extended to the full write lifecycle

`ResourceAction.owner` (= `read | patch | update | modify | lifecycle`) and
`lifecycle` (= `switch | delete | permanently_delete | restore`) already
advertise these verbs as owner-protectable, but `BeforeSwitch` /
`BeforePermanentlyDelete` / `BeforeRestore` carried no `current_resource`, so
`owner_self` (and any resource-aware checker) **silently always-denied** them —
the same always-deny class #399 fixed for soft `delete`. They now carry
`current_resource`, so owner/embedded-field write ACLs work across the whole
lifecycle. `events.pyi` regenerated via `make stubs`.

### 3. Docs

- New `docs/en/howto/access-scope.md`: reads + the new write precondition,
  opt-in model, `None`/`UNRESTRICTED`, strict field validation, the
  `access_scope` (404) vs permission-checker (403) split, and the bare-blob
  caveat.
- `permissions.md` now cross-links it and documents the write precondition.
- CHANGELOG entries for the full #398 feature (A + B + this).

## Tests

- `tests/test_access_scope.py`: out-of-scope write → 404 **before** a deny
  checker (ordering / no existence leak); lifecycle verbs gated;
  in-scope-still-checked; internal writes unscoped; no-`access_scope` unaffected;
  HTTP write routes scoped; batch delete bounded to in-scope; restore-after-
  soft-delete passes the gate.
- `tests/permission/test_current_resource.py`: `owner_self` allows owner /
  denies non-owner on `permanently_delete` / `switch` / `restore`.

All new + existing permission/route/access-scope suites green. The one local
failure (`test_blob_lifecycle`, content-type sniffing) is pre-existing and
environment-only — it fails identically on the base commit and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)