### PR TITLE
fix(permission): authorize once at request boundary (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [Unreleased]
+
+
+### Changed
+
+- **Behavior change:** permission is now authorized once per request, at the
+  outermost operation (request-boundary model, matching access-scope). A single
+  PATCH no longer re-runs the permission checker for the internal `get`/`update`
+  it performs, and a single GET no longer re-checks the nested
+  `get_meta`/`get_resource_revision`. Consequence: granting only `patch` is now
+  sufficient — a policy that *denied* `read`/`update` but *allowed* `patch`
+  previously blocked the patch and now lets it through. Express "can't see →
+  can't write" via `access_scope` instead of a deny-read rule. (#402)
+
+
+### Fixed
+
+- Permission checker ran 3× per HTTP PATCH (patch→get→update cascade) (#402)
+
 ## [0.11.11] — 2026-06-27
 
 

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -636,9 +636,12 @@ def execute_with_events(
             func_inputs = dict(bound_args.arguments)
             del func_inputs["self"]
 
+            # ``stack`` always exists so the permission re-entrancy guard (#402)
+            # can be armed even for non-context_aware ops (e.g. ``get``, whose
+            # nested ``get_meta``/``get_resource_revision`` must skip re-checking).
+            stack = ExitStack()
             # ── context_aware: push explicit kwargs into ContextVar ──
             if context_aware:
-                stack = ExitStack()
                 ctx_user = func_inputs.get("user", UNSET)
                 ctx_now = func_inputs.get("now", UNSET)
                 ctx_rid = func_inputs.get("resource_id", UNSET)
@@ -648,8 +651,6 @@ def execute_with_events(
                     stack.enter_context(self.now_ctx.ctx(ctx_now))
                 if ctx_rid is not UNSET:
                     stack.enter_context(self.id_ctx.ctx(ctx_rid))
-            else:
-                stack = None
 
             # Strip context-only kwargs from func_inputs so they don't
             # leak into event contexts as raw UNSET values.  A kwarg is
@@ -664,8 +665,7 @@ def execute_with_events(
                         func_inputs.pop(name, None)
 
             try:
-                if stack is not None:
-                    stack.__enter__()
+                stack.__enter__()
 
                 # Strict mode validation (after ContextVar push)
                 if context_aware and self._strict_operation_context:
@@ -694,6 +694,16 @@ def execute_with_events(
                         else:
                             inputs_[k] = get_from_path(func_inputs, v)
                 before_ctx = contexts.before(**inputs_)
+                # Permission re-entrancy guard (#402): authorize once, at the
+                # outermost operation. The first event-emitting op in this call
+                # stack arms the flag for its whole extent; any nested op (a
+                # patch's internal get/update, a get's internal get_meta, …)
+                # observes it and skips ONLY its permission check — every other
+                # event handler still fires. ``check_permission`` is False for
+                # such nested ops.
+                check_permission = not self._perm_checked_ctx.get()
+                if check_permission:
+                    stack.enter_context(self._perm_checked_ctx.ctx(True))
                 # Read access-scope is a precondition for request-originated
                 # writes: a resource outside the caller's scope is hidden as
                 # not-found (→ 404) *before* the permission checker (→ 403) and
@@ -701,10 +711,13 @@ def execute_with_events(
                 # existence. The remainder then runs unscoped — the resource is
                 # confirmed in-scope, and the operation's own (and nested
                 # get/get_meta) reads must not re-probe.
-                if self._maybe_assert_write_scope(before_ctx) and stack is not None:
+                if self._maybe_assert_write_scope(before_ctx):
                     stack.enter_context(self.apply_scope_ctx.ctx(False))
-                self._maybe_load_current_resource(before_ctx)
-                self._handle_event(before_ctx)
+                # current_resource is loaded solely for the permission check, so
+                # skip the extra storage read when this nested op won't check.
+                if check_permission:
+                    self._maybe_load_current_resource(before_ctx)
+                self._handle_event(before_ctx, check_permission=check_permission)
                 try:
                     result = func(self, *args, **kwargs)
                     built_result = _build_result(result)
@@ -722,8 +735,7 @@ def execute_with_events(
                 finally:
                     self._handle_event(contexts.after(**inputs_))
             finally:
-                if stack is not None:
-                    stack.__exit__(None, None, None)
+                stack.__exit__(None, None, None)
 
         return wrapped
 
@@ -1054,6 +1066,15 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         # read-route templates. Internal reads default to unscoped.
         self._access_scope = access_scope
         self.apply_scope_ctx = Ctx[bool]("apply_scope_ctx", default=False)
+        # Re-entrancy guard for permission checking (issue #402). A single
+        # request-level operation (e.g. ``patch`` → internal ``get`` + ``update``;
+        # ``get`` → internal ``get_meta`` + ``get_resource_revision``) used to run
+        # the permission checker once per nested op. Authorization is now applied
+        # once, at the outermost operation: the first event-emitting op in a call
+        # stack arms this flag for its whole extent, and any nested op observing it
+        # skips ONLY the permission check (every other event handler still fires).
+        # Mirrors ``apply_scope_ctx``'s request-boundary model.
+        self._perm_checked_ctx = Ctx[bool]("perm_checked_ctx", default=False)
         self._resource_type = resource_type
         self.storage = storage
         self.blob_store = blob_store
@@ -1748,8 +1769,18 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         )
         return info
 
-    def _handle_event(self, context: EventContext) -> None:
+    def _handle_event(
+        self, context: EventContext, *, check_permission: bool = True
+    ) -> None:
+        # ``check_permission=False`` for a nested op's before-context (#402):
+        # the outermost op already authorized this request, so suppress the
+        # permission checker while keeping every other handler (audit,
+        # constraints, on_success, …) running. Non-before contexts never trigger
+        # the permission checker (it is before-phase only), so the flag is a
+        # no-op for them and defaults to True for all other callers.
         for eh in self.event_handlers:
+            if not check_permission and isinstance(eh, PermissionEventHandler):
+                continue
             if eh.is_supported(context):
                 eh.handle_event(context)
 

--- a/tests/permission/test_current_resource.py
+++ b/tests/permission/test_current_resource.py
@@ -65,12 +65,12 @@ def _seed(rm: ResourceManager, user: str = "alice", level: str = "public") -> st
 
 
 def _owner_checker() -> ActionBasedPermissionChecker:
-    # ``read`` (= get/get_meta/...) must be allowed so the internal reads each
-    # write performs aren't denied by the cascade.
+    # No ``read`` mapping needed: since #402 a write authorizes once at its
+    # outermost op, so the nested reads it performs internally are not
+    # re-checked against ``read`` (which would otherwise be denied here).
     return ActionBasedPermissionChecker.from_dict(
         {
             ResourceAction.create: any_user,
-            ResourceAction.read: any_user,
             ResourceAction.update: owner_self,
             ResourceAction.delete: owner_self,
         }
@@ -223,7 +223,6 @@ def _embedded_checker() -> ActionBasedPermissionChecker:
     return ActionBasedPermissionChecker.from_dict(
         {
             ResourceAction.create: any_user,
-            ResourceAction.read: any_user,
             ResourceAction.update: _allow_only_public,
         }
     )
@@ -262,7 +261,6 @@ def test_incoming_vs_stored_data_compare() -> None:
         ActionBasedPermissionChecker.from_dict(
             {
                 ResourceAction.create: any_user,
-                ResourceAction.read: any_user,
                 ResourceAction.update: _level_is_immutable,
             }
         )
@@ -308,7 +306,10 @@ def _owner_lifecycle_checker() -> ActionBasedPermissionChecker:
     return ActionBasedPermissionChecker.from_dict(
         {
             ResourceAction.create: any_user,
-            ResourceAction.read: any_user,  # internal/nested reads (switch's get_meta)
+            # Needed for the *top-level* ``rm.get_meta`` in
+            # test_owner_self_covers_switch (not the nested reads — those are no
+            # longer re-checked since #402).
+            ResourceAction.read: any_user,
             ResourceAction.switch: owner_self,
             ResourceAction.permanently_delete: owner_self,
             ResourceAction.restore: owner_self,

--- a/tests/permission/test_request_boundary_auth.py
+++ b/tests/permission/test_request_boundary_auth.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Request-boundary authorization (#402).
+
+A single request-level operation used to run the permission checker once per
+*nested* operation it performs internally:
+
+* ``patch`` → internal ``get`` (read current data) + ``update`` (write it back)
+* ``get``   → internal ``get_meta`` + ``get_resource_revision``
+
+That meant a checker scoped to ``patch`` was not enough — the caller also had to
+be granted ``read`` and ``update``, and every PATCH paid 3 checker invocations.
+
+Authorization is now applied **once, at the outermost operation**: the first
+event-emitting op in a call stack runs the permission gate; any nested op skips
+*only* its permission check (every other event handler still fires). These tests
+pin that contract and its (documented) behavior change.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+import pytest
+
+from specstar.events import EventContext, IEventHandler
+from specstar.permission.action import ActionBasedPermissionChecker
+from specstar.permission.builtins import any_user, owner_self
+from specstar.permission.checker import (
+    IPermissionChecker,
+    PermissionContext,
+    PermissionResult,
+    ResourcePart,
+)
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import (
+    MergePatch,
+    PermissionDeniedError,
+    ResourceAction,
+)
+
+NOW = dt.datetime(2026, 1, 1, 12, 0, 0)
+
+
+@dataclass
+class Doc:
+    title: str
+    level: str = "public"
+
+
+def make_rm(
+    permission_checker: IPermissionChecker,
+    event_handlers: list[IEventHandler] | None = None,
+) -> ResourceManager:
+    storage = SimpleStorage(
+        meta_store=MemoryMetaStore(),
+        resource_store=MemoryResourceStore(Doc),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(
+        Doc,
+        storage=storage,
+        permission_checker=permission_checker,
+        event_handlers=event_handlers,
+    )
+
+
+def _seed(rm: ResourceManager, user: str = "alice") -> str:
+    with rm.using(user, NOW):
+        return rm.create(Doc(title="orig")).resource_id
+
+
+class _CountingChecker(IPermissionChecker):
+    """Allows everything; records the action of every permission check it runs."""
+
+    def __init__(self) -> None:
+        self.seen: list[ResourceAction] = []
+
+    def required_resource_parts(
+        self, action: ResourceAction
+    ) -> frozenset[ResourcePart]:
+        return frozenset()
+
+    def check_permission(self, context: PermissionContext) -> PermissionResult:
+        self.seen.append(context.action)
+        return PermissionResult.allow
+
+
+class _BeforeActionRecorder(IEventHandler):
+    """A plain (non-permission) event handler that records the action of every
+    before-phase context it observes."""
+
+    def __init__(self) -> None:
+        self.seen: list[ResourceAction] = []
+
+    def is_supported(self, context: EventContext) -> bool:
+        return getattr(context, "phase", None) == "before" and hasattr(
+            context, "action"
+        )
+
+    def handle_event(self, context: EventContext) -> None:
+        self.seen.append(context.action)
+
+
+# ---------------------------------------------------------------------------
+# Authorization happens once, at the outermost op — nested ops are not rechecked.
+# ---------------------------------------------------------------------------
+
+
+def test_patch_checks_permission_once() -> None:
+    chk = _CountingChecker()
+    rm = make_rm(chk)
+    rid = _seed(rm)
+    chk.seen.clear()
+    with rm.using("alice", NOW):
+        rm.patch(rid, MergePatch({"title": "new"}))
+    # Only the outermost ``patch`` is checked — not the internal get/update.
+    assert chk.seen == [ResourceAction.patch]
+
+
+def test_get_checks_permission_once() -> None:
+    chk = _CountingChecker()
+    rm = make_rm(chk)
+    rid = _seed(rm)
+    chk.seen.clear()
+    with rm.using("alice", NOW):
+        rm.get(rid)
+    # Only the outermost ``get`` is checked — not the nested get_meta /
+    # get_resource_revision a single read fans out into.
+    assert chk.seen == [ResourceAction.get]
+
+
+# ---------------------------------------------------------------------------
+# Nested ops still fire their *other* event handlers — only the permission
+# check is suppressed (this is what separates approach A from "patch uses
+# internal non-event read/write").
+# ---------------------------------------------------------------------------
+
+
+def test_nested_events_fire_but_permission_checked_once() -> None:
+    perm = _CountingChecker()
+    rec = _BeforeActionRecorder()
+    rm = make_rm(perm, event_handlers=[rec])
+    rid = _seed(rm)
+    perm.seen.clear()
+    rec.seen.clear()
+    with rm.using("alice", NOW):
+        rm.patch(rid, MergePatch({"title": "new"}))
+    # Permission gate ran once (outermost patch only)...
+    assert perm.seen == [ResourceAction.patch]
+    # ...but the nested get + update before-events still reached other handlers.
+    assert ResourceAction.patch in rec.seen
+    assert ResourceAction.get in rec.seen
+    assert ResourceAction.update in rec.seen
+
+
+# ---------------------------------------------------------------------------
+# Behavior change (#402): granting only ``patch`` is now sufficient — the
+# nested get/update it performs are no longer separately authorized.
+# ---------------------------------------------------------------------------
+
+
+def _only_patch_checker() -> ActionBasedPermissionChecker:
+    # No read/update mapping: if the nested ops were still checked, they would be
+    # denied (unmapped action -> not_applicable -> deny).
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.patch: any_user,
+        }
+    )
+
+
+def test_patch_succeeds_with_only_patch_granted() -> None:
+    rm = make_rm(_only_patch_checker())
+    rid = _seed(rm)
+    with rm.using("alice", NOW):
+        info = rm.patch(rid, MergePatch({"title": "patched"}))
+    assert info.resource_id == rid
+
+
+# ---------------------------------------------------------------------------
+# No security regression: the outermost op is *always* authorized.
+# ---------------------------------------------------------------------------
+
+
+def _owner_patch_checker() -> ActionBasedPermissionChecker:
+    return ActionBasedPermissionChecker.from_dict(
+        {
+            ResourceAction.create: any_user,
+            ResourceAction.read: any_user,
+            ResourceAction.patch: owner_self,
+        }
+    )
+
+
+def test_outermost_patch_still_enforced_for_non_owner() -> None:
+    rm = make_rm(_owner_patch_checker())
+    rid = _seed(rm, "alice")
+    with pytest.raises(PermissionDeniedError):
+        with rm.using("bob", NOW):
+            rm.patch(rid, MergePatch({"title": "hijack"}))
+
+
+def test_outermost_patch_allowed_for_owner() -> None:
+    rm = make_rm(_owner_patch_checker())
+    rid = _seed(rm, "alice")
+    with rm.using("alice", NOW):
+        info = rm.patch(rid, MergePatch({"title": "ok"}))
+    assert info.resource_id == rid


### PR DESCRIPTION
Fixes #402.

## Problem
A single HTTP `PATCH` ran the permission checker **3×** (`patch`→`get`→`update`), and a single `GET` 2–3× (`get`→`get_meta`→`get_resource_revision`): every nested, event-emitting sub-op fired its own before-phase permission check. So a checker scoped to `patch` was not enough — the caller also had to be granted `read` and `update` — and each request paid redundant checks plus extra `current_resource` loads.

## Fix (approach A — request-boundary authorization)
Add a re-entrancy guard `_perm_checked_ctx` (mirrors the existing `apply_scope_ctx` request-boundary model):

- The **outermost** operation in a call stack arms the flag for its whole extent.
- Any **nested** op observes it and skips **only** its permission check — every other event handler (audit, constraints, `on_success`, …) still fires.
- Nested writes also skip the `current_resource` preload (it exists solely for the permission check).
- `stack` is now always created so the guard can be armed for non-`context_aware` reads (`get`) too.

This fixes the cascade uniformly: `patch`→`get`→`update` **and** `get`→`get_meta`→`get_resource_revision`.

## Behavior change ⚠️
Permission is now authorized **once per request**, at the outermost operation. A policy that *denied* `read`/`update` but *allowed* `patch` previously blocked the patch and now lets it through (a blind write). Express "can't see → can't write" via `access_scope`, not a deny-read rule. Documented in `CHANGELOG.md` (`[Unreleased]`).

## Tests
- New `tests/permission/test_request_boundary_auth.py` (6): outermost checked once, nested **not** re-checked, **nested events still fire** for non-permission handlers, granting only `patch` now suffices, outermost still enforced for non-owner (no security regression).
- Removed 3 `read: any_user` cascade workarounds from `test_current_resource.py` (kept the one needed for a genuine top-level `get_meta`).
- Full fast suite: **3162 passed** (the only failure, `test_blob_lifecycle`, is a pre-existing local content-type/env issue that also fails on `master` and passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)