### PR TITLE
fix(mq): stamp last_heartbeat_at at claim so recover_stale_jobs can't false-positive a fresh job (#404)

### DIFF
--- a/specstar/message_queue/basic.py
+++ b/specstar/message_queue/basic.py
@@ -157,6 +157,19 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
         """Deprecated: use ``_rm_using`` instead."""
         return self._rm_using(user)
 
+    @staticmethod
+    def _initial_heartbeat() -> dt.datetime:
+        """Proof-of-life stamped on a job at claim time (#404).
+
+        Claiming a job *is* its first heartbeat: a job just moved to PROCESSING
+        has, by definition, just shown life. Without this, ``last_heartbeat_at``
+        stays ``None`` until the HeartbeatThread's first tick — one
+        ``_heartbeat_interval`` away — and :meth:`recover_stale_jobs` treats that
+        ``None`` window as a dead worker, falsely recovering a live,
+        freshly-claimed job. Wall-clock UTC, consistent with HeartbeatThread.
+        """
+        return dt.datetime.now(dt.timezone.utc)
+
     # ------------------------------------------------------------------
     # Enqueue + partition serialization (#384)
     # ------------------------------------------------------------------

--- a/specstar/message_queue/celery_queue.py
+++ b/specstar/message_queue/celery_queue.py
@@ -175,6 +175,9 @@ class CeleryMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 resource = queue.rm.get(resource_id)
                 job = resource.data
                 job.status = TaskStatus.PROCESSING
+                # Claiming the job is its first proof of life (#404) — the
+                # HeartbeatThread's first tick is one interval away.
+                job.last_heartbeat_at = queue._initial_heartbeat()
                 with queue._rm_using(resource.info.created_by):
                     queue.rm.create_or_update(
                         resource_id,

--- a/specstar/message_queue/rabbitmq.py
+++ b/specstar/message_queue/rabbitmq.py
@@ -560,6 +560,9 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
                         return
 
                     job.status = TaskStatus.PROCESSING
+                    # Claiming the job is its first proof of life (#404) — the
+                    # HeartbeatThread's first tick is one interval away.
+                    job.last_heartbeat_at = self._initial_heartbeat()
                     with self._rm_using(resource.info.created_by):
                         self.rm.create_or_update(
                             resource_id,

--- a/specstar/message_queue/simple.py
+++ b/specstar/message_queue/simple.py
@@ -147,6 +147,9 @@ class SimpleMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 # Update status to processing
                 updated_job = resource.data
                 updated_job.status = TaskStatus.PROCESSING
+                # Claiming the job is its first proof of life (#404) — the
+                # HeartbeatThread's first tick is one interval away.
+                updated_job.last_heartbeat_at = self._initial_heartbeat()
 
                 # Update revision as draft so heartbeat can use modify()
                 with self._rm_using(meta.created_by):

--- a/tests/test_message_queue/test_heartbeat.py
+++ b/tests/test_message_queue/test_heartbeat.py
@@ -357,6 +357,36 @@ class TestRecoverStaleJobsWithHeartbeat:
         recovered2 = queue.recover_stale_jobs(heartbeat_timeout_seconds=30)
         assert len(recovered2) == 0
 
+    def test_freshly_claimed_job_not_recovered(self, rm_and_queue):
+        """A job just claimed via pop() — PROCESSING but whose first heartbeat
+        is still one interval away — must NOT be recovered.
+
+        Regression for #404: claiming a job is its first proof of life, so
+        pop() stamps an initial ``last_heartbeat_at``. Without it the
+        ``[0, interval)`` window leaves ``last_heartbeat_at`` None and
+        ``recover_stale_jobs`` mistakes the live, freshly-claimed worker for a
+        dead one and marks it FAILED.
+        """
+        rm, queue = rm_and_queue
+
+        with rm.meta_provide(user="u", now=dt.datetime.now(dt.timezone.utc)):
+            rm.create(Job(payload=Payload(task_name="fresh_claim")))
+
+        # Claim it (sets PROCESSING). The HeartbeatThread has NOT been started,
+        # so this mirrors the real window between claim and the first tick.
+        job_resource = queue.pop()
+        assert job_resource is not None
+        assert job_resource.data.status == TaskStatus.PROCESSING
+        # The claim itself must record a heartbeat — the invariant that fixes #404.
+        assert job_resource.data.last_heartbeat_at is not None
+
+        recovered = queue.recover_stale_jobs(heartbeat_timeout_seconds=30)
+        assert job_resource.info.resource_id not in recovered
+
+        with rm.meta_provide(user="u", now=dt.datetime.now(dt.timezone.utc)):
+            res = rm.get(job_resource.info.resource_id)
+            assert res.data.status == TaskStatus.PROCESSING
+
 
 class TestProcessingAsDraft:
     """Tests that PROCESSING jobs use draft revision for heartbeat compatibility."""


### PR DESCRIPTION
## 問題

下游 app 偶爾出現 `Recovered stale job: worker was likely killed while processing this job.`，但該 job 其實還活著（`updated_time` 一直在被 HeartbeatThread 更新）。

## 根因

job 在 claim 時被設成 `PROCESSING`，但 `last_heartbeat_at` 一直是 `None`，直到 HeartbeatThread 的**第一次 tick**（一個 `_heartbeat_interval`，預設 5s 之後）。而 `recover_stale_jobs` 把 `None` 心跳當成 worker 已死：

```python
hb = job.last_heartbeat_at
if hb is not None:
    elapsed = (now - hb).total_seconds()
    if elapsed < heartbeat_timeout_seconds:
        continue          # 還活著 → 跳過
# ← hb is None 時 fall-through → 一律標 FAILED
```

於是任何「剛 claim、第一次心跳還沒跳」的活 job，只要在這 `[0, interval)` 空窗內被 recovery sweep 掃到就被誤判 FAILED。週期性 recovery 在**每個 consumer** 上掃**全域** `PROCESSING` 集合、加上把大 job fan-out 成許多常在 5s 內跑完的小 job（整個生命週期都在空窗內），讓它間歇性發生並卡住下游。

## 修法

claim 一個 job **就是它的第一次 proof-of-life**。在三個 backend 設 `PROCESSING` 的同處，透過共用 helper `_initial_heartbeat()` stamp `last_heartbeat_at = now`（wall-clock UTC，與 HeartbeatThread 一致）：

- `specstar/message_queue/basic.py` — 新增 `_initial_heartbeat()`
- `specstar/message_queue/simple.py` — `pop()` claim
- `specstar/message_queue/rabbitmq.py` — consume callback claim
- `specstar/message_queue/celery_queue.py` — `_execute_job` claim

建立不變量「**`PROCESSING` 的 job 一定有 `last_heartbeat_at`**」，於是 recover 的 timeout grace 正常生效；worker 若在第一次 tick 前就死掉，其 claim 時間仍會過 timeout 而被正確 recover。`recover_stale_jobs` 對 `None` 的既有判死保留，當作真正從未心跳過的 legacy/malformed row 的 backstop。

## 測試

- 新增回歸測試 `test_freshly_claimed_job_not_recovered`：`pop()` 一個 job（PROCESSING、心跳尚未啟動）後立刻 `recover_stale_jobs` → 斷言它**不**被 recover，且 claim 後 `last_heartbeat_at is not None`。修法前紅、修法後綠。
- in-memory 測試全綠：`test_heartbeat.py`（17 passed）、`test_message_queue.py` 非-broker（29 passed）、`test_celery_heartbeat.py`（4 passed）。
- `ruff check` 全過。
- 註：rabbitmq 整合測試需實體 broker，請由 CI 的 broker service 驗證。

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
