### PR TITLE
feat(#406): push Sum/Min/Max/Avg group-by down to the backend

### DIFF
--- a/specstar/query_types.py
+++ b/specstar/query_types.py
@@ -257,13 +257,23 @@ class AggSpec(Struct, frozen=True):
     """Storage-facing description of one aggregate in a group-by pushdown.
 
     ``op`` is the reducer and ``result_name`` is the caller's label (echoed
-    back per group). v1 ships ``"count"`` only; ``field`` is unused for count
-    and reserved for ``sum``/``min``/``max``/``avg`` when they push down.
+    back per group). ``field`` is unused for ``count`` and required for the
+    value reducers (``sum``/``min``/``max``) — ``avg`` never reaches a store,
+    the ResourceManager decomposes it into pushed ``sum`` + ``count`` and
+    divides in Python (byte-parity with the reference path).
+
+    ``value_type`` tells the store how to shape the SQL for a value reducer:
+    ``"numeric"`` reduces the field as a number (``SUM((… )::numeric)`` /
+    ``SUM(json_extract(…))``); ``"datetime"`` reduces a datetime column /
+    field and returns a Unix-epoch ``float`` (``EXTRACT(EPOCH FROM … AT TIME
+    ZONE 'UTC')`` / the SQLite ``REAL`` epoch), which the ResourceManager
+    turns back into a tz-aware UTC ``datetime``. ``None`` for ``count``.
     """
 
     result_name: str
-    op: Literal["count"]
+    op: Literal["count", "sum", "min", "max"]
     field: AggKeyRef | None = None
+    value_type: Literal["numeric", "datetime"] | None = None
 
 
 __all__ = [

--- a/specstar/resource_manager/_pg_pool.py
+++ b/specstar/resource_manager/_pg_pool.py
@@ -38,7 +38,9 @@ _pools: dict[Any, Any] = {}
 _configs: dict[Any, tuple[int, int]] = {}
 
 
-def get_pool(dsn: str, *, minconn: int = DEFAULT_MINCONN, maxconn: int = DEFAULT_MAXCONN):
+def get_pool(
+    dsn: str, *, minconn: int = DEFAULT_MINCONN, maxconn: int = DEFAULT_MAXCONN
+):
     """Return the shared pool for *dsn*, creating it on first use.
 
     The pool is keyed by a normalized DSN so equivalent connection strings
@@ -58,7 +60,14 @@ def get_pool(dsn: str, *, minconn: int = DEFAULT_MINCONN, maxconn: int = DEFAULT
                     f"{(minconn, maxconn)}; use one consistent pool size per DSN"
                 )
             return existing
-        pool = psycopg2.pool.ThreadedConnectionPool(minconn, maxconn, dsn=dsn)
+        # Force every connection's session TimeZone to UTC. SpecStar normalises
+        # all datetimes to tz-aware UTC (see ResourceManager), and the SQL
+        # metastore's naive TIMESTAMP columns then store/read a UTC wall-clock
+        # regardless of the server's default timezone — which keeps time filters
+        # and the datetime Min/Max push-down (#406) coordinate-free.
+        pool = psycopg2.pool.ThreadedConnectionPool(
+            minconn, maxconn, dsn=dsn, options="-c timezone=UTC"
+        )
         _pools[key] = pool
         _configs[key] = (minconn, maxconn)
         return pool

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2924,6 +2924,13 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             )
         return out
 
+    #: ResourceMeta datetime attributes eligible for Min/Max push-down. They are
+    #: stored as absolute instants (SQLite REAL epoch / Postgres TIMESTAMP read
+    #: as UTC), so a pushed Min/Max round-trips exactly to the Python-path value.
+    _META_TIME_COLUMNS = frozenset(
+        {"created_time", "updated_time", "rev_created_time", "rev_updated_time"}
+    )
+
     def _declared_data_field_type(self, name: str) -> "type | None":
         """The declared Python type of a data-source indexed field (matched by
         ``index_key or field_path``), or ``None`` when the field is unindexed
@@ -2966,13 +2973,40 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 lambda st, _n=result_name: int(st[_n]),
             )
 
-        # Value reducers + Avg need a data-source field with a declared numeric
-        # type; anything else keeps the Python path.
         op = {Sum: "sum", Min: "min", Max: "max"}.get(type(agg))
         is_avg = isinstance(agg, Avg)
         if op is None and not is_avg:
             return None
         field = agg.field
+
+        # Min/Max over a meta time column (created_time / updated_time / rev_*):
+        # push it as an absolute Unix epoch and rebuild the tz-aware UTC datetime
+        # in Python — SQLite stores those columns as REAL epochs; Postgres
+        # EXTRACTs the epoch (see the store _agg_expr). The float epoch
+        # round-trips to the microsecond, so it equals the Python-path datetime.
+        if (
+            op in ("min", "max")
+            and field.source == "meta"
+            and (field.name in self._META_TIME_COLUMNS)
+        ):
+            return (
+                [
+                    AggSpec(
+                        result_name=result_name,
+                        op=op,
+                        field=AggKeyRef(source="meta", name=field.name),
+                        value_type="datetime",
+                    )
+                ],
+                lambda st, _n=result_name: (
+                    None
+                    if st[_n] is None
+                    else dt.datetime.fromtimestamp(float(st[_n]), dt.timezone.utc)
+                ),
+            )
+
+        # Numeric value reducers + Avg need a data-source field with a declared
+        # numeric type; anything else keeps the Python path.
         ftype = self._declared_data_field_type(field.name)
         if field.source != "data" or ftype not in (int, float):
             return None

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2943,23 +2943,25 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         self-aggregate down to an ``IMetaWithAgg`` store, or ``None`` when it
         must fall back to the Python reduction.
 
-        v1 (#406): ``Count`` (any group), and ``Sum`` over a **data-source**
-        field with a declared numeric (``int``/``float``) type. Everything else
-        — ``Avg`` (decomposed elsewhere), ``str``/undeclared fields, meta
-        columns — returns ``None`` so the caller keeps the Python path."""
-        from specstar.aggregates import Count, Sum
+        v1 (#406): ``Count`` (any group), and ``Sum``/``Min``/``Max`` over a
+        **data-source** field with a declared numeric (``int``/``float``) type.
+        Everything else — ``Avg`` (decomposed elsewhere), ``str``/undeclared
+        fields, meta columns — returns ``None`` so the caller keeps the Python
+        path."""
+        from specstar.aggregates import Count, Max, Min, Sum
         from specstar.query_types import AggKeyRef, AggSpec
 
         if isinstance(agg, Count):
             return AggSpec(result_name=result_name, op="count")
-        if isinstance(agg, Sum):
+        op = {Sum: "sum", Min: "min", Max: "max"}.get(type(agg))
+        if op is not None:
             field = agg.field
             if field.source == "data" and self._declared_data_field_type(
                 field.name
             ) in (int, float):
                 return AggSpec(
                     result_name=result_name,
-                    op="sum",
+                    op=op,  # ty: ignore[invalid-argument-type]
                     field=AggKeyRef(source="data", name=field.name),
                     value_type="numeric",
                 )
@@ -2970,13 +2972,13 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         reduction would have produced — e.g. a SQL ``SUM`` over an ``int``
         column can come back as ``Decimal`` on Postgres; a numeric field
         declared ``int`` must stay ``int``."""
-        from specstar.aggregates import Count, Sum
+        from specstar.aggregates import Count, Max, Min, Sum
 
         if isinstance(agg, Count):
             return int(value)  # type: ignore[arg-type]
         if value is None:
             return None
-        if isinstance(agg, Sum):
+        if isinstance(agg, (Sum, Min, Max)):
             ftype = self._declared_data_field_type(agg.field.name)
             if ftype is int:
                 return int(value)  # type: ignore[arg-type]

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2835,14 +2835,26 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             # Python path below; a pushed result MUST equal it (enforced
             # cross-backend by tests/meta_store/test_aggregate_by.py).
             ms = self.storage.meta_store
+            pushed_specs: list[object] | None = None
             if (
                 self_aggs
                 and not foreign_aggs
                 and by.source in ("meta", "data")
-                and all(isinstance(a, Count) for a in self_aggs.values())
                 and isinstance(ms, IMetaWithAgg)
             ):
-                from specstar.query_types import AggKeyRef, AggSpec
+                specs: list[object] | None = []
+                for n, a in self_aggs.items():
+                    spec = self._agg_pushdown_spec(n, a)
+                    if spec is None:
+                        # An ineligible aggregate (Avg / str / undeclared field)
+                        # drops the WHOLE call to the Python path — never push a
+                        # partial or type-mismatched result.
+                        specs = None
+                        break
+                    specs.append(spec)
+                pushed_specs = specs
+            if pushed_specs is not None:
+                from specstar.query_types import AggKeyRef
                 from specstar.query_types import ResourceMetaSearchQuery as _RMSQ
 
                 if query is None:
@@ -2858,9 +2870,15 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     AggKeyRef(
                         source=cast(Literal["meta", "data"], by.source), name=by.name
                     ),
-                    [AggSpec(result_name=n, op="count") for n in self_aggs],
+                    pushed_specs,
                 )
-                groups = {key: dict(state) for key, state in rows}
+                groups = {
+                    key: {
+                        n: self._coerce_pushed_value(self_aggs[n], state[n])
+                        for n in self_aggs
+                    }
+                    for key, state in rows
+                }
             else:
                 for meta in self.iter_all(query):
                     key = self._read_field(meta, by)
@@ -2906,6 +2924,65 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs)
             )
         return out
+
+    def _declared_data_field_type(self, name: str) -> "type | None":
+        """The declared Python type of a data-source indexed field (matched by
+        ``index_key or field_path``), or ``None`` when the field is unindexed
+        or was registered without a concrete ``field_type`` (``field_type`` may
+        be ``UNSET`` or a ``SpecialIndex``). Used to decide push-down
+        eligibility for value reducers and to coerce a pushed result back to the
+        exact type the Python reduction produces."""
+        for f in self._indexed_fields:
+            if (f.index_key or f.field_path) == name:
+                ft = f.field_type
+                return ft if isinstance(ft, type) else None
+        return None
+
+    def _agg_pushdown_spec(self, result_name: str, agg: "object") -> "object | None":
+        """The :class:`~specstar.query_types.AggSpec` to push this
+        self-aggregate down to an ``IMetaWithAgg`` store, or ``None`` when it
+        must fall back to the Python reduction.
+
+        v1 (#406): ``Count`` (any group), and ``Sum`` over a **data-source**
+        field with a declared numeric (``int``/``float``) type. Everything else
+        — ``Avg`` (decomposed elsewhere), ``str``/undeclared fields, meta
+        columns — returns ``None`` so the caller keeps the Python path."""
+        from specstar.aggregates import Count, Sum
+        from specstar.query_types import AggKeyRef, AggSpec
+
+        if isinstance(agg, Count):
+            return AggSpec(result_name=result_name, op="count")
+        if isinstance(agg, Sum):
+            field = agg.field
+            if field.source == "data" and self._declared_data_field_type(
+                field.name
+            ) in (int, float):
+                return AggSpec(
+                    result_name=result_name,
+                    op="sum",
+                    field=AggKeyRef(source="data", name=field.name),
+                    value_type="numeric",
+                )
+        return None
+
+    def _coerce_pushed_value(self, agg: "object", value: "object") -> "object":
+        """Coerce a store-returned aggregate value to the type the Python
+        reduction would have produced — e.g. a SQL ``SUM`` over an ``int``
+        column can come back as ``Decimal`` on Postgres; a numeric field
+        declared ``int`` must stay ``int``."""
+        from specstar.aggregates import Count, Sum
+
+        if isinstance(agg, Count):
+            return int(value)  # type: ignore[arg-type]
+        if value is None:
+            return None
+        if isinstance(agg, Sum):
+            ftype = self._declared_data_field_type(agg.field.name)
+            if ftype is int:
+                return int(value)  # type: ignore[arg-type]
+            if ftype is float:
+                return float(value)  # type: ignore[arg-type]
+        return value
 
     def _read_field(self, meta: ResourceMeta, field: "object") -> object:
         """Read a ``Field``'s value from a meta, honouring ``Field.source``.

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2829,31 +2829,33 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     )
                     state[n] = _update(a, state[n], val)
         else:
-            # Push a pure-``Count`` group-by down to the metastore engine when
-            # it advertises the capability (typed ``isinstance``, not
-            # ``hasattr``). Sum/Min/Max/Avg and ForeignAggregate stay on the
-            # Python path below; a pushed result MUST equal it (enforced
+            # Push the group-by down to the metastore engine when it advertises
+            # the capability (typed ``isinstance``, not ``hasattr``) AND every
+            # self-aggregate is push-eligible. Each aggregate contributes a
+            # push-down *plan* (store AggSpecs + a finalizer); an ineligible one
+            # (str/undeclared field, …) drops the WHOLE call to the Python path
+            # below so a partial/type-mismatched result is never pushed. A
+            # pushed result MUST equal the Python reduction (enforced
             # cross-backend by tests/meta_store/test_aggregate_by.py).
             ms = self.storage.meta_store
-            pushed_specs: list[object] | None = None
-            if (
+            pushable = bool(
                 self_aggs
                 and not foreign_aggs
                 and by.source in ("meta", "data")
                 and isinstance(ms, IMetaWithAgg)
-            ):
-                specs: list[object] | None = []
+            )
+            store_specs: list[object] = []
+            to_state: dict[str, "Callable[[dict[str, object]], object]"] = {}
+            if pushable:
                 for n, a in self_aggs.items():
-                    spec = self._agg_pushdown_spec(n, a)
-                    if spec is None:
-                        # An ineligible aggregate (Avg / str / undeclared field)
-                        # drops the WHOLE call to the Python path — never push a
-                        # partial or type-mismatched result.
-                        specs = None
+                    plan = self._agg_pushdown_plan(n, a)
+                    if plan is None:
+                        pushable = False
                         break
-                    specs.append(spec)
-                pushed_specs = specs
-            if pushed_specs is not None:
+                    specs, make_state = plan
+                    store_specs.extend(specs)
+                    to_state[n] = make_state
+            if pushable:
                 from specstar.query_types import AggKeyRef
                 from specstar.query_types import ResourceMetaSearchQuery as _RMSQ
 
@@ -2870,13 +2872,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     AggKeyRef(
                         source=cast(Literal["meta", "data"], by.source), name=by.name
                     ),
-                    pushed_specs,
+                    store_specs,
                 )
                 groups = {
-                    key: {
-                        n: self._coerce_pushed_value(self_aggs[n], state[n])
-                        for n in self_aggs
-                    }
+                    key: {n: to_state[n](state) for n in self_aggs}
                     for key, state in rows
                 }
             else:
@@ -2938,53 +2937,75 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 return ft if isinstance(ft, type) else None
         return None
 
-    def _agg_pushdown_spec(self, result_name: str, agg: "object") -> "object | None":
-        """The :class:`~specstar.query_types.AggSpec` to push this
-        self-aggregate down to an ``IMetaWithAgg`` store, or ``None`` when it
-        must fall back to the Python reduction.
+    def _agg_pushdown_plan(self, result_name: str, agg: "object"):
+        """A push-down *plan* for one self-aggregate, or ``None`` to keep the
+        Python reduction.
 
-        v1 (#406): ``Count`` (any group), and ``Sum``/``Min``/``Max`` over a
+        Returns ``(store_specs, to_state)``: ``store_specs`` are the
+        :class:`~specstar.query_types.AggSpec`\\ s to send to the store, and
+        ``to_state(store_dict)`` maps the store's per-group dict (keyed by those
+        specs' ``result_name``) to the SAME per-group *state* the Python
+        reduction accumulates — which step 5's ``_finalize`` then turns into the
+        final value. For ``Count``/``Sum``/``Min``/``Max`` the state IS the
+        (declared-type-coerced) value and ``_finalize`` is identity; ``Avg`` is
+        decomposed into a pushed ``Sum`` + a pushed non-null ``Count`` and
+        returns the ``[running_sum, n]`` state so ``_finalize`` divides it —
+        byte-parity with the reference path and no backend ``AVG`` float
+        divergence.
+
+        v1 (#406): ``Count`` (any group); ``Sum``/``Min``/``Max``/``Avg`` over a
         **data-source** field with a declared numeric (``int``/``float``) type.
-        Everything else — ``Avg`` (decomposed elsewhere), ``str``/undeclared
-        fields, meta columns — returns ``None`` so the caller keeps the Python
-        path."""
-        from specstar.aggregates import Count, Max, Min, Sum
+        Everything else — ``str``/undeclared fields, meta columns — returns
+        ``None``."""
+        from specstar.aggregates import Avg, Count, Max, Min, Sum
         from specstar.query_types import AggKeyRef, AggSpec
 
         if isinstance(agg, Count):
-            return AggSpec(result_name=result_name, op="count")
+            return (
+                [AggSpec(result_name=result_name, op="count")],
+                lambda st, _n=result_name: int(st[_n]),
+            )
+
+        # Value reducers + Avg need a data-source field with a declared numeric
+        # type; anything else keeps the Python path.
         op = {Sum: "sum", Min: "min", Max: "max"}.get(type(agg))
-        if op is not None:
-            field = agg.field
-            if field.source == "data" and self._declared_data_field_type(
-                field.name
-            ) in (int, float):
-                return AggSpec(
-                    result_name=result_name,
-                    op=op,  # ty: ignore[invalid-argument-type]
-                    field=AggKeyRef(source="data", name=field.name),
-                    value_type="numeric",
-                )
-        return None
-
-    def _coerce_pushed_value(self, agg: "object", value: "object") -> "object":
-        """Coerce a store-returned aggregate value to the type the Python
-        reduction would have produced — e.g. a SQL ``SUM`` over an ``int``
-        column can come back as ``Decimal`` on Postgres; a numeric field
-        declared ``int`` must stay ``int``."""
-        from specstar.aggregates import Count, Max, Min, Sum
-
-        if isinstance(agg, Count):
-            return int(value)  # type: ignore[arg-type]
-        if value is None:
+        is_avg = isinstance(agg, Avg)
+        if op is None and not is_avg:
             return None
-        if isinstance(agg, (Sum, Min, Max)):
-            ftype = self._declared_data_field_type(agg.field.name)
-            if ftype is int:
-                return int(value)  # type: ignore[arg-type]
-            if ftype is float:
-                return float(value)  # type: ignore[arg-type]
-        return value
+        field = agg.field
+        ftype = self._declared_data_field_type(field.name)
+        if field.source != "data" or ftype not in (int, float):
+            return None
+        ref = AggKeyRef(source="data", name=field.name)
+
+        if op is not None:
+            coerce = int if ftype is int else float
+            return (
+                [
+                    AggSpec(
+                        result_name=result_name, op=op, field=ref, value_type="numeric"
+                    )
+                ],
+                lambda st, _n=result_name, _c=coerce: (
+                    None if st[_n] is None else _c(st[_n])
+                ),
+            )
+
+        # Avg → pushed Sum + non-null Count, returned as the reference
+        # ``[running_sum, n]`` state for ``_finalize`` to divide. Postgres SUM is
+        # Decimal → float() so the divided result is a float; a group with no
+        # non-null values has ``n == 0`` (and NULL sum) ⇒ ``_finalize`` → None.
+        s_key, c_key = f"{result_name}__sum", f"{result_name}__count"
+        return (
+            [
+                AggSpec(result_name=s_key, op="sum", field=ref, value_type="numeric"),
+                AggSpec(result_name=c_key, op="count", field=ref),
+            ],
+            lambda st, _s=s_key, _c=c_key: [
+                0.0 if st[_s] is None else float(st[_s]),
+                st[_c],
+            ],
+        )
 
     def _read_field(self, meta: ResourceMeta, field: "object") -> object:
         """Read a ``Field``'s value from a meta, honouring ``Field.source``.

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -103,7 +103,7 @@ from specstar.events import (
     OnSuccessSwitch,
     OnSuccessUpdate,
 )
-from specstar.query_types import ResourceMetaSearchQuery
+from specstar.query_types import AggSpec, ResourceMetaSearchQuery
 from specstar.resource_manager.partial import (
     classify_partial_fields,
     create_partial_type,
@@ -2844,7 +2844,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 and by.source in ("meta", "data")
                 and isinstance(ms, IMetaWithAgg)
             )
-            store_specs: list[object] = []
+            store_specs: list[AggSpec] = []
             to_state: dict[str, "Callable[[dict[str, object]], object]"] = {}
             if pushable:
                 for n, a in self_aggs.items():
@@ -2856,6 +2856,9 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     store_specs.extend(specs)
                     to_state[n] = make_state
             if pushable:
+                # ``pushable`` already required ``isinstance(ms, IMetaWithAgg)``;
+                # re-assert so the type checker narrows ``ms`` for aggregate_by.
+                assert isinstance(ms, IMetaWithAgg)
                 from specstar.query_types import AggKeyRef
                 from specstar.query_types import ResourceMetaSearchQuery as _RMSQ
 
@@ -2977,7 +2980,8 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         is_avg = isinstance(agg, Avg)
         if op is None and not is_avg:
             return None
-        field = agg.field
+        # op is not None or is_avg ⇒ a _FieldAggregate carrying ``.field``.
+        field = agg.field  # ty: ignore[unresolved-attribute]
 
         # Min/Max over a meta time column (created_time / updated_time / rev_*):
         # push it as an absolute Unix epoch and rebuild the tz-aware UTC datetime
@@ -2993,7 +2997,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 [
                     AggSpec(
                         result_name=result_name,
-                        op=op,
+                        op=op,  # ty: ignore[invalid-argument-type]
                         field=AggKeyRef(source="meta", name=field.name),
                         value_type="datetime",
                     )
@@ -3017,7 +3021,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return (
                 [
                     AggSpec(
-                        result_name=result_name, op=op, field=ref, value_type="numeric"
+                        result_name=result_name,
+                        op=op,  # ty: ignore[invalid-argument-type]
+                        field=ref,
+                        value_type="numeric",
                     )
                 ],
                 lambda st, _n=result_name, _c=coerce: (

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -67,9 +67,7 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         # Share one process-global pool per DSN (#380). The pool is owned by
         # the registry for the process lifetime; this store never closes it.
         self._pg_dsn = pg_dsn
-        self._conn_pool = _pg_pool.get_pool(
-            pg_dsn, minconn=minconn, maxconn=maxconn
-        )
+        self._conn_pool = _pg_pool.get_pool(pg_dsn, minconn=minconn, maxconn=maxconn)
         self.table_name = table_name
         # field_path → (indexed_dim, distance) for pgvector columns
         self._vec_columns: dict[str, tuple[int, str]] = {}
@@ -817,17 +815,21 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
         aggregate spans the whole filtered set.
         """
-        # v1 supports Count only; the ResourceManager's dispatch predicate
-        # guarantees this, so the assert is a defensive guard, not control flow.
-        assert all(a.op == "count" for a in aggregates), (
-            "PostgresMetaStore.aggregate_by v1 supports Count only"
+        # Push-down ops: Count + numeric Sum/Min/Max (Avg is decomposed by the
+        # ResourceManager into Sum+Count and never reaches a store). The RM's
+        # dispatch predicate only sends eligible specs, so the assert is a
+        # defensive guard, not control flow.
+        assert all(a.op in ("count", "sum", "min", "max") for a in aggregates), (
+            "PostgresMetaStore.aggregate_by supports count/sum/min/max"
         )
         if by.source == "meta":
             key_expr = by.name  # a real column
         else:
             key_expr = f"indexed_data->>'{by.name}'"
         where_clause, params = self._build_where(query)
-        select_aggs = ", ".join(f"COUNT(*) AS a{i}" for i in range(len(aggregates)))
+        select_aggs = ", ".join(
+            f"{self._agg_expr(a)} AS a{i}" for i, a in enumerate(aggregates)
+        )
         sql = (
             f"SELECT {key_expr} AS k, {select_aggs} "
             f'FROM "{self.table_name}" {where_clause} GROUP BY {key_expr}'
@@ -838,6 +840,23 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
                 (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
                 for row in cur
             ]
+
+    def _agg_expr(self, a: AggSpec) -> str:
+        """SQL for one aggregate's value (not the GROUP BY key). ``Count``
+        ignores the field; a numeric value reducer reads a ``resource_meta``
+        column (``source="meta"``) or casts the JSONB text
+        ``(indexed_data->>'f')::numeric`` (``source="data"``) so ``SUM``/``MIN``/
+        ``MAX`` reduce as numbers (the ResourceManager coerces the result back to
+        the field's declared ``int``/``float``)."""
+        if a.op == "count":
+            return "COUNT(*)"
+        ref = a.field
+        assert ref is not None, "value reducer requires a field"
+        if ref.source == "meta":
+            base = f'"{ref.name}"'
+        else:
+            base = f"(indexed_data->>'{ref.name}')::numeric"
+        return f"{a.op.upper()}({base})"
 
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 PostgreSQL 查詢條件 (支援 Meta 欄位與 JSONB 欄位)"""

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -861,6 +861,14 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
                 else f"(indexed_data->>'{ref.name}')"
             )
             return f"COUNT({base})"
+        if a.value_type == "datetime":
+            # Reduce a TIMESTAMP meta column and return an absolute Unix epoch:
+            # interpret the naive column AS UTC (writes go through a UTC session —
+            # see _pg_pool) so the ResourceManager rebuilds the same tz-aware UTC
+            # datetime the Python path holds.
+            return (
+                f"EXTRACT(EPOCH FROM {a.op.upper()}(\"{ref.name}\") AT TIME ZONE 'UTC')"
+            )
         if ref.source == "meta":
             base = f'"{ref.name}"'
         else:

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -842,16 +842,25 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             ]
 
     def _agg_expr(self, a: AggSpec) -> str:
-        """SQL for one aggregate's value (not the GROUP BY key). ``Count``
-        ignores the field; a numeric value reducer reads a ``resource_meta``
-        column (``source="meta"``) or casts the JSONB text
+        """SQL for one aggregate's value (not the GROUP BY key). A field-less
+        ``count`` is ``COUNT(*)``; a ``count`` WITH a field counts that field's
+        non-null values (the denominator for a decomposed ``Avg``) — the raw
+        JSONB text, no numeric cast. A numeric value reducer reads a
+        ``resource_meta`` column (``source="meta"``) or casts the JSONB text
         ``(indexed_data->>'f')::numeric`` (``source="data"``) so ``SUM``/``MIN``/
         ``MAX`` reduce as numbers (the ResourceManager coerces the result back to
         the field's declared ``int``/``float``)."""
-        if a.op == "count":
+        if a.op == "count" and a.field is None:
             return "COUNT(*)"
         ref = a.field
         assert ref is not None, "value reducer requires a field"
+        if a.op == "count":
+            base = (
+                f'"{ref.name}"'
+                if ref.source == "meta"
+                else f"(indexed_data->>'{ref.name}')"
+            )
+            return f"COUNT({base})"
         if ref.source == "meta":
             base = f'"{ref.name}"'
         else:

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -415,17 +415,21 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
         :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
         aggregate spans the whole filtered set.
         """
-        # v1 supports Count only; the ResourceManager's dispatch predicate
-        # guarantees this, so the assert is a defensive guard, not control flow.
-        assert all(a.op == "count" for a in aggregates), (
-            "SqliteMetaStore.aggregate_by v1 supports Count only"
+        # Push-down ops: Count + numeric Sum/Min/Max (Avg is decomposed by the
+        # ResourceManager into Sum+Count and never reaches a store). The RM's
+        # dispatch predicate only sends eligible specs, so the assert is a
+        # defensive guard, not control flow.
+        assert all(a.op in ("count", "sum", "min", "max") for a in aggregates), (
+            "SqliteMetaStore.aggregate_by supports count/sum/min/max"
         )
         if by.source == "meta":
             key_expr = by.name  # a real resource_meta column
         else:
             key_expr = f"json_extract(indexed_data, '$.\"{by.name}\"')"
         where_clause, params = self._build_where(query)
-        select_aggs = ", ".join(f"COUNT(*) AS a{i}" for i in range(len(aggregates)))
+        select_aggs = ", ".join(
+            f"{self._agg_expr(a)} AS a{i}" for i, a in enumerate(aggregates)
+        )
         sql = (
             f"SELECT {key_expr} AS k, {select_aggs} "
             f"FROM resource_meta {where_clause} GROUP BY {key_expr}"
@@ -435,6 +439,24 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
             (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
             for row in cursor
         ]
+
+    def _agg_expr(self, a: AggSpec) -> str:
+        """SQL for one aggregate's value (not the GROUP BY key). ``Count``
+        ignores the field; a value reducer reads a ``resource_meta`` column
+        (``source="meta"``) or ``json_extract(indexed_data, …)``
+        (``source="data"``). The time columns are stored as ``REAL`` Unix
+        epochs, so ``MIN``/``MAX`` over a ``value_type="datetime"`` meta column
+        already yield an epoch the ResourceManager turns back into a UTC
+        datetime — no special expression needed on SQLite."""
+        if a.op == "count":
+            return "COUNT(*)"
+        ref = a.field
+        assert ref is not None, "value reducer requires a field"
+        if ref.source == "meta":
+            val = ref.name
+        else:
+            val = f"json_extract(indexed_data, '$.\"{ref.name}\"')"
+        return f"{a.op.upper()}({val})"
 
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 SQLite 查詢條件 (支援 Meta 欄位與 JSON 欄位)"""

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -447,8 +447,10 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
         (``source="data"``). The time columns are stored as ``REAL`` Unix
         epochs, so ``MIN``/``MAX`` over a ``value_type="datetime"`` meta column
         already yield an epoch the ResourceManager turns back into a UTC
-        datetime — no special expression needed on SQLite."""
-        if a.op == "count":
+        datetime — no special expression needed on SQLite. A field-less
+        ``count`` is ``COUNT(*)``; a ``count`` WITH a field counts that field's
+        non-null values (the denominator for a decomposed ``Avg``)."""
+        if a.op == "count" and a.field is None:
             return "COUNT(*)"
         ref = a.field
         assert ref is not None, "value reducer requires a field"

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -200,6 +200,28 @@ class TestAggregateByReducerParity:
         assert got == {"a": (5, 9.0), "b": (2, 4.0)}
         assert type(got["a"][0]) is int and type(got["a"][1]) is float
 
+    def test_avg_parity_is_float(self):
+        from specstar.aggregates import Avg
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 10, 1.0), ("a", 5, 1.0), ("b", 2, 1.0)])
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"mean": Avg(QB["size"])})
+        result = {r.key: r.mean for r in rows}
+        assert result == {"a": 7.5, "b": 2.0}
+        assert all(type(v) is float for v in result.values())
+
+    def test_mixed_count_sum_avg_in_one_call(self):
+        from specstar.aggregates import Avg, Count, Sum
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 10, 1.0), ("a", 6, 1.0), ("b", 2, 1.0)])
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"],
+            {"n": Count(), "total": Sum(QB["size"]), "mean": Avg(QB["size"])},
+        )
+        got = {r.key: (r.n, r.total, r.mean) for r in rows}
+        assert got == {"a": (2, 16, 8.0), "b": (1, 2, 2.0)}
+
 
 @pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
 def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -188,6 +188,18 @@ class TestAggregateByReducerParity:
         assert result == {"a": 4.0, "b": 4.0}
         assert all(type(v) is float for v in result.values())
 
+    def test_min_max_parity_and_type(self):
+        from specstar.aggregates import Max, Min
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 10, 2.5), ("a", 5, 9.0), ("b", 2, 4.0)])
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"lo": Min(QB["size"]), "hi": Max(QB["score"])}
+        )
+        got = {r.key: (r.lo, r.hi) for r in rows}
+        assert got == {"a": (5, 9.0), "b": (2, 4.0)}
+        assert type(got["a"][0]) is int and type(got["a"][1]) is float
+
 
 @pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
 def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -126,6 +126,69 @@ class TestAggregateByCountParity:
         assert [(r.key, r.count) for r in rows] == [(None, 3)]
 
 
+class Rec(msgspec.Struct):
+    bucket: str
+    size: int
+    score: float
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestAggregateByReducerParity:
+    """#406 — Sum/Min/Max/Avg (+ datetime Min/Max) must return IDENTICAL
+    results and Python types on every backend, whether the reducer pushes down
+    (SQLite / Postgres) or falls back to the core Python reduction."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self._meta_store_type = meta_store_type
+        self._tmpdir = my_tmpdir
+        yield
+
+    def _mgr(self):
+        from specstar.types import IndexableField
+
+        meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        return ResourceManager(
+            Rec,
+            storage=storage,
+            name="rec",
+            default_user="t",
+            indexed_fields=[
+                IndexableField(field_path="bucket", field_type=str),
+                IndexableField(field_path="size", field_type=int),
+                IndexableField(field_path="score", field_type=float),
+            ],
+        )
+
+    def _seed(self, mgr, rows):
+        for bucket, size, score in rows:
+            mgr.create(Rec(bucket=bucket, size=size, score=score))
+
+    def test_sum_int_field_parity_and_type(self):
+        from specstar.aggregates import Sum
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 10, 1.5), ("a", 5, 2.5), ("b", 2, 4.0)])
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"total": Sum(QB["size"])})
+        result = {r.key: r.total for r in rows}
+        assert result == {"a": 15, "b": 2}
+        assert all(type(v) is int for v in result.values())
+
+    def test_sum_float_field_parity_and_type(self):
+        from specstar.aggregates import Sum
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 10, 1.5), ("a", 5, 2.5), ("b", 2, 4.0)])
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"total": Sum(QB["score"])})
+        result = {r.key: r.total for r in rows}
+        assert result == {"a": 4.0, "b": 4.0}
+        assert all(type(v) is float for v in result.values())
+
+
 @pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
 def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):
     """On a push-down backend (``IMetaWithAgg``) the Count group-by must reach

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -280,6 +280,56 @@ def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):
     )
 
 
+@pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
+def test_reducers_are_pushed_down_not_iterated(meta_store_type):
+    """#406 — Sum, Avg (Sum+Count) and datetime Max(updated_time) reach
+    ``aggregate_by`` on a push-down backend rather than walking ``iter_all``
+    (proves Postgres/SQLite take the fast path, not a correct-but-slow
+    fallback)."""
+    from specstar.aggregates import Avg, Max, Sum
+
+    meta_store = get_meta_store(meta_store_type)
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    mgr = ResourceManager(
+        Rec,
+        storage=storage,
+        name="rec",
+        default_user="t",
+        indexed_fields=[
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+        ],
+    )
+    for bucket, size in [("a", 1), ("a", 3), ("b", 5)]:
+        mgr.create(Rec(bucket=bucket, size=size, score=0.0))
+
+    called = False
+    orig_iter_all = mgr.iter_all
+
+    def spy(*a, **k):
+        nonlocal called
+        called = True
+        return orig_iter_all(*a, **k)
+
+    mgr.iter_all = spy
+    rows = mgr.exp_aggregate_by(
+        QB["bucket"],
+        {
+            "total": Sum(QB["size"]),
+            "mean": Avg(QB["size"]),
+            "latest": Max(QB.updated_time()),
+        },
+    )
+
+    assert {r.key: (r.total, r.mean) for r in rows} == {"a": (4, 2.0), "b": (5, 5.0)}
+    assert called is False, (
+        f"exp_aggregate_by walked iter_all on {meta_store_type} — reducers not pushed"
+    )
+
+
 @pytest.fixture
 def my_tmpdir():
     import tempfile

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -222,6 +222,25 @@ class TestAggregateByReducerParity:
         got = {r.key: (r.n, r.total, r.mean) for r in rows}
         assert got == {"a": (2, 16, 8.0), "b": (1, 2, 2.0)}
 
+    def test_datetime_max_over_meta_column_parity(self):
+        from specstar.aggregates import Max
+
+        mgr = self._mgr()
+        created = []
+        for bucket, size in [("a", 1), ("a", 2), ("b", 3)]:
+            rev = mgr.create(Rec(bucket=bucket, size=size, score=0.0))
+            created.append((bucket, rev.resource_id))
+        expected: dict[str, object] = {}
+        for bucket, rid in created:
+            ut = mgr.get_meta(rid).updated_time
+            expected[bucket] = (
+                ut if bucket not in expected else max(expected[bucket], ut)
+            )
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"latest": Max(QB.updated_time())})
+        got = {r.key: r.latest for r in rows}
+        assert got == expected
+        assert all(v.tzinfo is not None for v in got.values()), "tz-aware UTC"
+
 
 @pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
 def test_count_groupby_is_pushed_down_not_iterated(meta_store_type):

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -13,7 +13,7 @@ Python path instead of pushing an incorrect result.
 
 import msgspec
 
-from specstar.aggregates import Max, Min, Sum
+from specstar.aggregates import Avg, Max, Min, Sum
 from specstar.query import QB
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
@@ -103,3 +103,14 @@ def test_min_max_push_down_numeric_and_keep_type():
     # Min over int stays int, Max over float stays float.
     assert type(by_key["a"][0]) is int and type(by_key["a"][1]) is float
     assert spy.walked is False, "Min/Max did not push down — walked iter_all"
+
+
+def test_avg_push_down_returns_float_via_sum_over_count():
+    mgr = _sqlite_mgr()
+    _seed(mgr, [("a", 10, 1.0), ("a", 5, 1.0), ("b", 2, 1.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"mean": Avg(QB["size"])})
+    result = {r.key: r.mean for r in rows}
+    assert result == {"a": 7.5, "b": 2.0}
+    assert all(type(v) is float for v in result.values())
+    assert spy.walked is False, "Avg did not push down — walked iter_all"

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -114,3 +114,21 @@ def test_avg_push_down_returns_float_via_sum_over_count():
     assert result == {"a": 7.5, "b": 2.0}
     assert all(type(v) is float for v in result.values())
     assert spy.walked is False, "Avg did not push down — walked iter_all"
+
+
+def test_datetime_max_over_meta_column_pushes_down_as_aware_utc():
+    mgr = _sqlite_mgr()
+    created = []
+    for bucket, size in [("a", 1), ("a", 2), ("b", 3)]:
+        rev = mgr.create(Item(bucket=bucket, size=size, score=0.0))
+        created.append((bucket, rev.resource_id))
+    expected: dict[str, object] = {}
+    for bucket, rid in created:
+        ut = mgr.get_meta(rid).updated_time
+        expected[bucket] = ut if bucket not in expected else max(expected[bucket], ut)
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"latest": Max(QB.updated_time())})
+    got = {r.key: r.latest for r in rows}
+    assert got == expected
+    assert all(v.tzinfo is not None for v in got.values()), "must be tz-aware UTC"
+    assert spy.walked is False, "Max(updated_time) did not push down — walked iter_all"

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -13,7 +13,7 @@ Python path instead of pushing an incorrect result.
 
 import msgspec
 
-from specstar.aggregates import Avg, Max, Min, Sum
+from specstar.aggregates import Avg, Count, ForeignAggregate, Max, Min, Sum
 from specstar.query import QB
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
@@ -132,3 +132,134 @@ def test_datetime_max_over_meta_column_pushes_down_as_aware_utc():
     assert got == expected
     assert all(v.tzinfo is not None for v in got.values()), "must be tz-aware UTC"
     assert spy.walked is False, "Max(updated_time) did not push down — walked iter_all"
+
+
+# --- fallback: ineligible aggregates keep the Python path (correct, not pushed)
+
+
+def test_sum_over_undeclared_numeric_field_falls_back_but_is_correct():
+    # ``size`` is indexed but WITHOUT a declared field_type — the reducer can't
+    # guarantee return-type parity, so it must fall back to the Python path.
+    mgr = _sqlite_mgr(
+        indexed=[
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size"),  # no field_type
+        ]
+    )
+    _seed(mgr, [("a", 10, 0.0), ("a", 5, 0.0), ("b", 2, 0.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"total": Sum(QB["size"])})
+    assert {r.key: r.total for r in rows} == {"a": 15, "b": 2}
+    assert spy.walked is True, "undeclared field must NOT push down"
+
+
+def test_min_max_over_str_field_falls_back_but_is_correct():
+    # str Min/Max is deferred (collation) — Python path, codepoint ordering.
+    mgr = _sqlite_mgr()
+    _seed(mgr, [("a", 1, 0.0), ("a", 1, 0.0), ("b", 1, 0.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(QB["size"], {"lo": Min(QB["bucket"])})
+    assert {r.key: r.lo for r in rows} == {1: "a"}
+    assert spy.walked is True, "str Min/Max must NOT push down"
+
+
+def test_mixed_eligible_and_ineligible_drops_whole_call_to_python():
+    # One ineligible aggregate forces the WHOLE call onto the Python path so a
+    # partial/typed-wrong result is never pushed — but the answer stays correct.
+    mgr = _sqlite_mgr(
+        indexed=[
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+            IndexableField(field_path="score"),  # undeclared → ineligible
+        ]
+    )
+    _seed(mgr, [("a", 10, 1.5), ("a", 5, 2.5), ("b", 2, 4.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"],
+            {"total": Sum(QB["size"]), "smean": Sum(QB["score"])},
+        )
+    got = {r.key: (r.total, r.smean) for r in rows}
+    assert got == {"a": (15, 4.0), "b": (2, 4.0)}
+    assert spy.walked is True, "a mixed-eligibility call must fall back wholesale"
+
+
+# --- ForeignAggregate end-to-end: the collections-dashboard shape (#406)
+
+
+class _Coll(msgspec.Struct):
+    name: str
+
+
+class _Doc(msgspec.Struct):
+    collection_id: str
+    size: int
+
+
+def _sqlite_dashboard():
+    def rm(struct, name, indexed):
+        return ResourceManager(
+            struct,
+            storage=SimpleStorage(
+                meta_store=MemorySqliteMetaStore(encoding="msgpack"),
+                resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+            ),
+            name=name,
+            default_user="t",
+            indexed_fields=indexed,
+        )
+
+    coll_rm = rm(_Coll, "coll", [])
+    doc_rm = rm(
+        _Doc,
+        "doc",
+        [
+            IndexableField(field_path="collection_id", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+        ],
+    )
+    return coll_rm, doc_rm
+
+
+def test_foreign_aggregate_sum_and_datetime_max_push_down_in_child():
+    coll_rm, doc_rm = _sqlite_dashboard()
+    c1 = coll_rm.create(_Coll(name="c1")).resource_id
+    c2 = coll_rm.create(_Coll(name="c2")).resource_id
+    latest_doc_time = {}
+    for cid, size in [(c1, 10), (c1, 5), (c2, 2)]:
+        rev = doc_rm.create(_Doc(collection_id=cid, size=size))
+        latest_doc_time[cid] = doc_rm.get_meta(rev.resource_id).updated_time
+
+    with _IterSpy(doc_rm) as child_spy:
+        rows = coll_rm.exp_aggregate_by(
+            QB.resource_id(),
+            {
+                "size_total": ForeignAggregate(
+                    doc_rm, QB["collection_id"], Sum(QB["size"])
+                ),
+                "latest_doc": ForeignAggregate(
+                    doc_rm, QB["collection_id"], Max(QB.updated_time())
+                ),
+            },
+        )
+    by_id = {r.key: (r.size_total, r.latest_doc) for r in rows}
+    assert by_id[c1] == (15, latest_doc_time[c1])
+    assert by_id[c2] == (2, latest_doc_time[c2])
+    assert type(by_id[c1][0]) is int and by_id[c1][1].tzinfo is not None
+    assert child_spy.walked is False, "child ForeignAggregate did not push down"
+
+
+def test_foreign_aggregate_parent_with_no_children_gets_zero_and_none():
+    coll_rm, doc_rm = _sqlite_dashboard()
+    empty = coll_rm.create(_Coll(name="empty")).resource_id
+    rows = coll_rm.exp_aggregate_by(
+        QB.resource_id(),
+        {
+            "n": ForeignAggregate(doc_rm, QB["collection_id"], Count()),
+            "size_total": ForeignAggregate(
+                doc_rm, QB["collection_id"], Sum(QB["size"])
+            ),
+        },
+    )
+    got = {r.key: (r.n, r.size_total) for r in rows}
+    assert got == {empty: (0, None)}

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -1,0 +1,90 @@
+"""Push-down of Sum/Min/Max/Avg (and datetime Min/Max) to an ``IMetaWithAgg``
+metastore — the #406 continuation of the Count-only push-down (#361).
+
+Service-free: uses an in-memory SQLite metastore (``MemorySqliteMetaStore``),
+which implements ``IMetaWithAgg``, so these run in the fast CI job (the
+``tests/meta_store/`` folder is integration-only and excluded there). The
+cross-backend parity contract — including real Postgres — lives in
+``tests/meta_store/test_aggregate_by.py``; here we assert (a) the reducer
+push-down is actually TAKEN (spying on ``iter_all``), (b) results + Python
+types match the reference path, and (c) ineligible aggregates fall BACK to the
+Python path instead of pushing an incorrect result.
+"""
+
+import msgspec
+
+from specstar.aggregates import Sum
+from specstar.query import QB
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField
+
+
+class Item(msgspec.Struct):
+    bucket: str
+    size: int
+    score: float
+
+
+def _mgr(meta_store, *, indexed):
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(
+        Item,
+        storage=storage,
+        name="item",
+        default_user="t",
+        indexed_fields=indexed,
+    )
+
+
+def _sqlite_mgr(*, indexed=None):
+    if indexed is None:
+        indexed = [
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+            IndexableField(field_path="score", field_type=float),
+        ]
+    return _mgr(MemorySqliteMetaStore(encoding="msgpack"), indexed=indexed)
+
+
+def _seed(mgr, rows):
+    for bucket, size, score in rows:
+        mgr.create(Item(bucket=bucket, size=size, score=score))
+
+
+class _IterSpy:
+    """Wrap a manager's ``iter_all`` to record whether the Python reduction
+    path was walked (i.e. the push-down was NOT taken)."""
+
+    def __init__(self, mgr):
+        self.mgr = mgr
+        self.walked = False
+        self._orig = mgr.iter_all
+
+    def __enter__(self):
+        def spy(*a, **k):
+            self.walked = True
+            return self._orig(*a, **k)
+
+        self.mgr.iter_all = spy
+        return self
+
+    def __exit__(self, *exc):
+        self.mgr.iter_all = self._orig
+
+
+def test_sum_pushes_down_and_keeps_int_type():
+    mgr = _sqlite_mgr()
+    _seed(mgr, [("a", 10, 1.0), ("a", 5, 1.0), ("b", 2, 1.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(QB["bucket"], {"total": Sum(QB["size"])})
+    result = {r.key: r.total for r in rows}
+    assert result == {"a": 15, "b": 2}
+    # Sum over an int field stays int (not Decimal/float) — parity with the
+    # Python reduction path.
+    assert all(type(v) is int for v in result.values())
+    assert spy.walked is False, "Sum did not push down — walked iter_all"

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -13,7 +13,7 @@ Python path instead of pushing an incorrect result.
 
 import msgspec
 
-from specstar.aggregates import Sum
+from specstar.aggregates import Max, Min, Sum
 from specstar.query import QB
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
@@ -88,3 +88,18 @@ def test_sum_pushes_down_and_keeps_int_type():
     # Python reduction path.
     assert all(type(v) is int for v in result.values())
     assert spy.walked is False, "Sum did not push down — walked iter_all"
+
+
+def test_min_max_push_down_numeric_and_keep_type():
+    mgr = _sqlite_mgr()
+    _seed(mgr, [("a", 10, 2.5), ("a", 5, 9.0), ("b", 2, 4.0)])
+    with _IterSpy(mgr) as spy:
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"],
+            {"lo": Min(QB["size"]), "hi": Max(QB["score"])},
+        )
+    by_key = {r.key: (r.lo, r.hi) for r in rows}
+    assert by_key == {"a": (5, 9.0), "b": (2, 4.0)}
+    # Min over int stays int, Max over float stays float.
+    assert type(by_key["a"][0]) is int and type(by_key["a"][1]) is float
+    assert spy.walked is False, "Min/Max did not push down — walked iter_all"


### PR DESCRIPTION
Closes #406. Continuation of #361 (Count push-down) under the #353 umbrella.

## What

Extends `exp_aggregate_by`'s group-by push-down beyond `Count` to `Sum` / `Min` / `Max` / `Avg`, so a reducer over an `IMetaWithAgg` store (Postgres / SQLite) runs as a real `GROUP BY` instead of streaming every matching meta row into Python. `ForeignAggregate` benefits **for free** — its recursive inner `exp_aggregate_by` call is exactly the pushable shape — which is what makes the motivating dashboard fast.

### Eligibility (correct-by-construction; anything else keeps the Python path)

| op | pushes down when… |
|---|---|
| `Count` | any group (unchanged) |
| `Sum` / `Avg` | data-source field with a declared numeric `field_type` (`int`/`float`) |
| `Min` / `Max` | data-source numeric field, **or** a meta time column (`created_time` / `updated_time` / `rev_*`) |

Undeclared / `str` / data-source-datetime fields fall back to the reference reduction — a single ineligible aggregate drops the **whole** call to Python so a partial or type-mismatched result is never pushed.

## How the tricky bits stay correct (parity with the Python path is the contract)

- **Return type**: the RM coerces the store result to the field's declared type — Postgres `SUM` comes back `Decimal`, an `int` field must stay `int`.
- **Avg**: decomposed into a pushed `Sum` + a pushed **non-null** `COUNT(field)` (the reference denominator counts non-null values, not rows) and divided in Python — byte-parity with the `[running_sum, n]` reduction, no cross-backend `AVG` float divergence.
- **datetime Min/Max**: pushed as an absolute Unix epoch (SQLite stores those columns as `REAL` epochs; Postgres `EXTRACT(EPOCH FROM MAX(col) AT TIME ZONE 'UTC')`) and rebuilt as a tz-aware UTC `datetime` (`fromtimestamp` round-trips to the microsecond). Every pooled PG connection is pinned to `timezone=UTC` so the naive `TIMESTAMP` columns are a UTC wall-clock regardless of server default.

## Tests

- `tests/test_agg_pushdown.py` (**service-free, runs in the fast CI job**): push-taken (spies `iter_all`), result + Python-type parity, fallback cases, and the `ForeignAggregate` dashboard shape — all over in-memory SQLite.
- `tests/meta_store/test_aggregate_by.py` (integration, cross-backend incl. **real Postgres**): the parity contract for the new ops + a push-taken assertion for Postgres/SQLite.

> Note: `tests/meta_store/` is `@pytest.mark.integration` (excluded from the service-free CI job), so the cross-backend/Postgres parity was verified **locally** against a live PG 16; the SQLite push path + all RM logic are covered by the service-free file that CI runs. Full local unit suite: 3234 passed (one unrelated, pre-existing timing flake in `test_message_queue/test_heartbeat.py` that passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
