### PR TITLE
fix(#408): allow vec search via http QB string param

### DIFF
--- a/docs/en/howto/vector-search.md
+++ b/docs/en/howto/vector-search.md
@@ -214,20 +214,20 @@ Vector conditions compose with scalar conditions via `&` / `|` / `~`:
 
 ### REST
 
-Use the standard `GET /{model}` endpoint with JSON-encoded conditions.
-Vector and scalar conditions live in the same `conditions` list and sorts
-share the same `sorts` list:
+Use the query-builder (`qb`) param on the search route — the same `QB[...]`
+expression you'd write in Python, URL-encoded. `cosine`, `l2` and `ip` are
+supported:
 
 ```http
-GET /docs?conditions=[
-  {"type":"DataSearchCondition","field_path":"doctype","operator":"eq","value":"abc"},
-  {"type":"VectorDistanceCondition","field_path":"embedding",
-   "query_vector":"how to use vectors","operator":"lt","threshold":0.3,
-   "distance":"cosine"}
-]&sorts=[
-  {"type":"VectorDistanceSort","field_path":"embedding",
-   "query_vector":"how to use vectors","direction":"+"}
-]&limit=10
+GET /docs/data?qb=QB['embedding'].cosine('how to use vectors') < 0.3
+```
+
+Add a vector ranking with `.sort(...)`. A scalar/threshold filter must lead so
+the expression is a full query rather than a bare distance (use a loose
+threshold like `< 2.0` — cosine distance maxes at 2.0 — if you only want ranking):
+
+```http
+GET /docs/data?qb=(QB['embedding'].cosine('how to use vectors') < 2.0).sort(QB['embedding'].cosine('how to use vectors')).limit(10)
 ```
 
 `query_vector` can be either:
@@ -236,6 +236,12 @@ GET /docs?conditions=[
 
 The string form keeps URLs short and lets you debug from `curl`. Pass a
 raw 1536-dim vector via the URL only if you accept the URL-length tradeoff.
+Combine clauses with `&`/`|` as usual, but URL-encode them (`%26`/`%7C`) so
+they aren't parsed as query-string separators.
+
+> **Not yet supported:** the raw `conditions=[...]` / `sorts=[...]` JSON params
+> do not accept `VectorDistanceCondition` / `VectorDistanceSort` — use the `qb`
+> form above for vector search over REST.
 
 ---
 

--- a/specstar/crud/qb_parser.py
+++ b/specstar/crud/qb_parser.py
@@ -98,6 +98,11 @@ class SafeQBParser:
         "last_n_days",
         # 字段轉換
         "length",
+        # 向量距離 (vec search)：query_vector 可為 list[float] 或字串
+        # （字串會在 search 時由 encoder 解析為向量）
+        "cosine",
+        "l2",
+        "ip",
         # 排序方向
         "asc",
         "desc",

--- a/tests/routes/test_qb_search_vector_http.py
+++ b/tests/routes/test_qb_search_vector_http.py
@@ -1,0 +1,108 @@
+"""HTTP-level tests for vector search via the ``qb=`` query-builder param (#408).
+
+Vector search was fully wired in the direct ResourceManager API and the object
+QB (``QB['f'].cosine(q) < t``), but the string QB parser used by the HTTP
+``qb=`` param rejected ``cosine``/``l2``/``ip`` (not in the whitelist), so every
+such request 400'd. These tests drive the real HTTP search route and assert both
+the list-of-floats form and the natural-language string form (server-side
+encoder) work end-to-end.
+"""
+
+from typing import Annotated, Any
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from msgspec import Struct
+
+from specstar import SpecStar, Vector
+
+
+def _stub_encoder(text: str) -> list[float]:
+    # Natural-language queries map to a fixed direction so ordering is assertable.
+    if text in ("what is foo?", "near_query"):
+        return [1.0, 0.0]
+    if text == "far_query":
+        return [0.0, 1.0]
+    return [0.5, 0.5]
+
+
+class Doc(Struct):
+    title: str
+    embedding: Annotated[list[float], Vector(dim=2, encoder="stub")]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app: FastAPI = FastAPI()
+    router: APIRouter = APIRouter()
+    spec: SpecStar = SpecStar()
+    spec.configure(vector_encoders={"stub": _stub_encoder})
+    spec.add_model(Doc)
+    spec.apply(router)
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_docs(client: TestClient) -> None:
+    docs: list[dict[str, Any]] = [
+        {"title": "aligned", "embedding": [1.0, 0.0]},
+        {"title": "close", "embedding": [0.9, 0.1]},
+        {"title": "opposed", "embedding": [0.0, 1.0]},
+    ]
+    for d in docs:
+        resp = client.post("/doc", json=d)
+        assert resp.status_code == 200, resp.text
+
+
+# #408 core ask: natural-language string query resolved server-side via encoder.
+def test_qb_cosine_string_query_over_http(
+    client: TestClient, sample_docs: None
+) -> None:
+    resp = client.get(
+        "/doc/data",
+        params={"qb": "QB['embedding'].cosine('what is foo?') < 0.3"},
+    )
+    assert resp.status_code == 200, resp.text
+    titles = sorted(d["title"] for d in resp.json())
+    assert titles == ["aligned", "close"]  # "opposed" excluded by threshold
+
+
+# List-of-floats form parses through the whitelist too.
+def test_qb_cosine_float_list_over_http(client: TestClient, sample_docs: None) -> None:
+    resp = client.get(
+        "/doc/data",
+        params={"qb": "QB['embedding'].cosine([1.0, 0.0]) < 0.3"},
+    )
+    assert resp.status_code == 200, resp.text
+    titles = sorted(d["title"] for d in resp.json())
+    assert titles == ["aligned", "close"]
+
+
+# l2 and ip are reachable (were previously rejected as "Method not allowed").
+@pytest.mark.parametrize("distance", ["l2", "ip"])
+def test_qb_other_distances_reachable(
+    client: TestClient, sample_docs: None, distance: str
+) -> None:
+    resp = client.get(
+        "/doc/data",
+        params={"qb": f"QB['embedding'].{distance}([1.0, 0.0]) < 5.0"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# Vector ranking via qb sort: nearest to the query comes first.
+def test_qb_cosine_sort_over_http(client: TestClient, sample_docs: None) -> None:
+    resp = client.get(
+        "/doc/data",
+        params={
+            "qb": (
+                "(QB['embedding'].cosine('what is foo?') < 2.0)"
+                ".sort(QB['embedding'].cosine('what is foo?'))"
+            ),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    titles = [d["title"] for d in resp.json()]
+    assert titles == ["aligned", "close", "opposed"]


### PR DESCRIPTION
Fixes #408 — `http QB 不支援 vec search`.

## Problem
The string QB parser (`SafeQBParser`, used by the `?qb=` search param) whitelists every scalar/logical method but **not** the vector-distance methods. So a request like:

```
GET /doc/data?qb=QB['embedding'].cosine('what is foo?') < 0.3
```

always returned **HTTP 400** `Invalid QB expression: ... Method not allowed: cosine`.

Vector search was already wired end-to-end everywhere else — the object QB (`QB['f'].cosine(q) < t`), the direct `ResourceManager` API, `str → vector` encoding at search time, and both the brute-force and pgvector backends. The **only** missing link was this HTTP string-parser gate.

## Fix
Add `cosine` / `l2` / `ip` to `SafeQBParser.ALLOWED_METHODS`. Nothing downstream changes — the parser already handles `<`/`<=`/`>`/`>=`, `.asc()`/`.desc()`, and `ConditionBuilder.build()` already emits `VectorDistanceCondition`. Both `query_vector` forms now work over HTTP:

- `cosine([1.0, 0.0])` — raw vector
- `cosine('what is foo?')` — natural-language string, encoded server-side via the field's registered encoder

## Scope
Only the `?qb=` string path (**Gap A**). The raw `?conditions=`/`?sorts=` JSON params still do not build vector conditions (a separate, larger surface — **Gap B**, intentionally out of scope). The vector-search howto's REST section is updated to point at the working `qb=` form and to note the JSON path is unsupported, replacing a previously-broken `conditions=[...VectorDistanceCondition...]` example.

## Tests
`tests/routes/test_qb_search_vector_http.py` drives the real FastAPI search route:
- string-form `cosine('what is foo?') < 0.3` (the #408 ask) — resolved via encoder, correct filtering
- list-of-floats form
- `l2` / `ip` reachability (previously 400'd)
- vector-sort ranking over HTTP

Verified: 82 targeted tests pass (new + `test_qb_parser` + `test_qb_vector` + `test_str_query_vector`), plus 80 more across QB route integration + vector regression. Negative control confirms the three methods were blocked pre-fix and parse correctly post-fix. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BVZCJBPKHNw5DXC9CWPkF