### PR TITLE
fix(#409): stale/killed jobs go through the retry budget (sweep + RabbitMQ redelivery guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [0.11.14] — 2026-07-03
+
+
+### Fixed
+
+- Stale/killed jobs now go through the retry budget instead of failing
+  outright. `recover_stale_jobs` spends one retry — requeuing the job while
+  budget remains and marking it FAILED only once exhausted — rather than
+  terminally failing a stuck PROCESSING job with zero retries. On RabbitMQ a
+  new consume-time guard classifies each (re)delivery by the job's persisted
+  status, so a job that outlives `consumer_timeout` is counted and eventually
+  dead-lettered instead of re-running forever, and a duplicate delivery of a
+  COMPLETED job (lost ack) is dropped instead of re-run. (#409)
+
 ## [0.11.13] — 2026-07-01
 
 

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -108,4 +108,4 @@ __all__ = [
     "pydantic_to_struct",
     "struct_to_pydantic",
 ]
-__version__ = "0.11.13"
+__version__ = "0.11.14"

--- a/specstar/message_queue/basic.py
+++ b/specstar/message_queue/basic.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import enum
 import inspect
 import threading
 import warnings
@@ -52,6 +53,18 @@ class DelayRetry(Exception):
     def __init__(self, delay_seconds: int):
         self.delay_seconds = delay_seconds
         super().__init__(f"Job will be retried after {delay_seconds} seconds")
+
+
+class RedeliveryAction(enum.Enum):
+    """What a broker backend should do with a (re)delivered message, decided
+    from the job's persisted status by :meth:`BasicMessageQueue._redelivery_decision` (#409)."""
+
+    RUN = "run"
+    """(Re)process this delivery."""
+    DEAD_LETTER = "dead_letter"
+    """Retry budget exhausted — mark FAILED and route to the dead-letter queue."""
+    DROP = "drop"
+    """Already completed (lost ack) — ack the duplicate without re-running."""
 
 
 class BasicMessageQueue(IMessageQueue[T], Generic[T]):
@@ -409,6 +422,39 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
         guard a ``PENDING`` (which would read as a fresh, uncounted delivery).
         """
         return TaskStatus.PENDING
+
+    def _redelivery_decision(self, job: Job[T]) -> tuple[RedeliveryAction, int]:
+        """Classify a (re)delivered job by its persisted status (#409).
+
+        A broker (RabbitMQ) re-delivers a message without knowing whether the
+        prior attempt finished; the persisted status disambiguates:
+
+        - ``PENDING`` — first, fresh delivery → run.
+        - ``PROCESSING`` — the prior worker was killed mid-flight and never
+          reached a terminal state, so this re-delivery is an *uncounted*
+          retry. Count it; run while budget remains, else dead-letter.
+        - ``FAILED`` — an *already-counted* re-attempt (the retry queue and the
+          stale sweep both bump ``retries`` when they write ``FAILED``). Do not
+          count again; run while budget remains, else dead-letter.
+        - ``COMPLETED`` — finished but the ack was lost → drop, never re-run.
+
+        Returns ``(action, retries_to_persist)``.
+        """
+        status = job.status
+        if status == TaskStatus.COMPLETED:
+            return RedeliveryAction.DROP, job.retries
+        max_retries = self._effective_max_retries(job)
+        if status == TaskStatus.PROCESSING:
+            retries = job.retries + 1
+            if retries > max_retries:
+                return RedeliveryAction.DEAD_LETTER, retries
+            return RedeliveryAction.RUN, retries
+        if status == TaskStatus.FAILED:
+            if job.retries > max_retries:
+                return RedeliveryAction.DEAD_LETTER, job.retries
+            return RedeliveryAction.RUN, job.retries
+        # PENDING (or any unexpected status) → fresh run.
+        return RedeliveryAction.RUN, job.retries
 
     def recover_stale_jobs(self, heartbeat_timeout_seconds: float) -> list[str]:
         """Recover jobs stuck in PROCESSING status.

--- a/specstar/message_queue/basic.py
+++ b/specstar/message_queue/basic.py
@@ -68,6 +68,10 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
         self._handler_wants_ctx = self._check_handler_wants_context(do)
         self._heartbeat_interval: float = 5.0
         self._recovery_interval: float = 60.0
+        # Queue-level default retry budget. Subclasses override this in their
+        # own ``__init__`` (after ``super().__init__``); it lives on the base
+        # so ``recover_stale_jobs`` can consult it uniformly (#409).
+        self.max_retries: int = 3
         self._recovery_stop_event: threading.Event = threading.Event()
         self._recovery_thread: threading.Thread | None = None
         # When a job is held back because a same-``partition_key`` peer is
@@ -388,6 +392,24 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
         resource.data = job
         return resource
 
+    def _effective_max_retries(self, job: Job[T]) -> int:
+        """The retry budget for *job*: its per-job ``max_retries`` if set,
+        otherwise this queue's default. Shared by the stale sweep and the
+        broker re-delivery guard (#409)."""
+        return job.max_retries if job.max_retries is not None else self.max_retries
+
+    def _stale_retry_status(self) -> TaskStatus:
+        """Status a stale-but-still-retryable job is set to on recovery.
+
+        Store-backed queues (Simple) re-run a job by moving it back to
+        ``PENDING`` so ``pop()`` re-selects it. Broker-backed queues override
+        this to ``FAILED`` — their broker re-delivers the unacked message and
+        the consume-time guard (:meth:`_redelivery_decision`) treats ``FAILED``
+        as an already-counted re-attempt, so a stale sweep must NOT hand the
+        guard a ``PENDING`` (which would read as a fresh, uncounted delivery).
+        """
+        return TaskStatus.PENDING
+
     def recover_stale_jobs(self, heartbeat_timeout_seconds: float) -> list[str]:
         """Recover jobs stuck in PROCESSING status.
 
@@ -431,11 +453,26 @@ class BasicMessageQueue(IMessageQueue[T], Generic[T]):
                         if elapsed < heartbeat_timeout_seconds:
                             continue  # Still alive
 
-                job.status = TaskStatus.FAILED
-                job.errmsg = (
-                    "Recovered stale job: worker was likely killed "
-                    "while processing this job."
-                )
+                # #409: a stale job is a failed attempt — spend its retry
+                # budget instead of terminally failing it. Under budget it is
+                # requeued (``_stale_retry_status`` — PENDING for store-backed
+                # queues, FAILED for broker-backed ones whose broker re-delivers
+                # the message); exhausted, it is FAILED for good.
+                job.retries += 1
+                max_retries = self._effective_max_retries(job)
+                if job.retries <= max_retries:
+                    job.status = self._stale_retry_status()
+                    job.errmsg = (
+                        f"Recovered stale job (retry {job.retries}/{max_retries}): "
+                        "worker was likely killed while processing this job."
+                    )
+                else:
+                    job.status = TaskStatus.FAILED
+                    job.errmsg = (
+                        "Recovered stale job: worker was likely killed while "
+                        "processing this job; retries exhausted "
+                        f"({job.retries - 1}/{max_retries})."
+                    )
                 with self._rm_using(resource.info.created_by):
                     self.rm.create_or_update(meta.resource_id, job)
                 recovered.append(meta.resource_id)

--- a/specstar/message_queue/celery_queue.py
+++ b/specstar/message_queue/celery_queue.py
@@ -114,6 +114,14 @@ class CeleryMessageQueue(DelayableMessageQueue[T], Generic[T]):
         # Register the task with Celery
         self._register_task()
 
+    def _stale_retry_status(self) -> TaskStatus:
+        """#409: broker-backed like RabbitMQ — a stale-but-retryable job is set
+        to ``FAILED`` (not ``PENDING``), since Celery re-delivers the task
+        itself. A consume-time re-delivery guard is a follow-up; this override
+        only keeps the shared stale sweep from parking the job in an inert
+        ``PENDING`` on a broker backend."""
+        return TaskStatus.FAILED
+
     def _register_task(self):
         """Register the job processing task with Celery."""
 

--- a/specstar/message_queue/rabbitmq.py
+++ b/specstar/message_queue/rabbitmq.py
@@ -4,7 +4,12 @@ import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
-from specstar.message_queue.basic import DelayableMessageQueue, DelayRetry, NoRetry
+from specstar.message_queue.basic import (
+    DelayableMessageQueue,
+    DelayRetry,
+    NoRetry,
+    RedeliveryAction,
+)
 from specstar.types import (
     Job,
     Resource,
@@ -255,6 +260,31 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
                 headers={
                     "x-retry-count": new_retry_count,
                     "x-last-error": error_msg[:500],  # Limit error message length
+                },
+            ),
+        )
+
+    def _stale_retry_status(self) -> TaskStatus:
+        """#409: broker-backed, so a stale-but-retryable job is set to
+        ``FAILED`` rather than ``PENDING``. RabbitMQ re-delivers the unacked
+        message on its own; the consume-time guard treats ``FAILED`` as an
+        already-counted re-attempt. A ``PENDING`` here would instead read as a
+        fresh, uncounted delivery and re-open the infinite-redelivery loop."""
+        return TaskStatus.FAILED
+
+    def _send_to_dead(
+        self, ch: BlockingChannel, resource_id: str, retry_count: int, error_msg: str
+    ) -> None:
+        """Publish a message straight to the dead-letter queue (#409 exhaustion)."""
+        ch.basic_publish(
+            exchange="",
+            routing_key=self.dead_queue_name,
+            body=resource_id.encode("utf-8"),
+            properties=pika.BasicProperties(
+                delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE,
+                headers={
+                    "x-retry-count": retry_count,
+                    "x-last-error": error_msg[:500],
                 },
             ),
         )
@@ -559,6 +589,39 @@ class RabbitMQMessageQueue(DelayableMessageQueue[T], Generic[T]):
                         ch.basic_ack(delivery_tag=method.delivery_tag)  # ty:ignore[invalid-argument-type]
                         return
 
+                    # #409: classify this (re)delivery by the job's persisted
+                    # status. The broker re-delivers a message without knowing
+                    # whether the prior attempt finished; a killed/hung
+                    # in-flight job is still PROCESSING, so count it against the
+                    # retry budget (dead-letter when exhausted) instead of
+                    # looping forever, and drop a duplicate delivery of a job
+                    # that already COMPLETED (lost ack).
+                    action, new_retries = self._redelivery_decision(job)
+                    if action == RedeliveryAction.DROP:
+                        ch.basic_ack(delivery_tag=method.delivery_tag)  # ty:ignore[invalid-argument-type]
+                        return
+                    if action == RedeliveryAction.DEAD_LETTER:
+                        job.retries = new_retries
+                        job.status = TaskStatus.FAILED
+                        job.errmsg = (
+                            "Stale/killed job exceeded its retry budget "
+                            f"({new_retries}/{self._effective_max_retries(job)}); "
+                            "dead-lettered."
+                        )
+                        with self._rm_using(resource.info.created_by):
+                            self.rm.create_or_update(resource_id, job)
+                        self._send_to_dead(ch, resource_id, new_retries, job.errmsg)
+                        ch.basic_ack(delivery_tag=method.delivery_tag)  # ty:ignore[invalid-argument-type]
+                        return
+
+                    # action == RUN: persist the (possibly bumped) retry count.
+                    # Downstream retry accounting uses the larger of the broker
+                    # header (set by _send_to_retry_or_dead on a retry-queue
+                    # republish) and what the guard counted (the header is stale
+                    # on a broker requeue of an in-flight job), so neither the
+                    # in-handler failure path nor the guard under-counts.
+                    job.retries = new_retries
+                    retry_count = max(retry_count, new_retries)
                     job.status = TaskStatus.PROCESSING
                     # Claiming the job is its first proof of life (#404) — the
                     # HeartbeatThread's first tick is one interval away.

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -2581,8 +2581,13 @@ class IMessageQueue(ABC, Generic[T]):
     def recover_stale_jobs(self, heartbeat_timeout_seconds: float) -> list[str]:
         """Recover jobs stuck in PROCESSING status.
 
-        This is used to handle cases where a worker was killed (e.g. OOM)
-        and left jobs in PROCESSING status. These jobs will be marked as FAILED.
+        This handles cases where a worker was killed (e.g. OOM) and left jobs
+        in PROCESSING status. A recovered job spends one unit of its retry
+        budget (``retries`` is incremented): while budget remains it is
+        requeued for another attempt, and only once the budget is exhausted is
+        it marked FAILED (#409). Store-backed queues requeue by moving the job
+        back to PENDING; broker-backed queues instead leave it FAILED and rely
+        on the broker to re-deliver the message.
 
         Args:
             heartbeat_timeout_seconds: Only recover jobs whose

--- a/tests/test_message_queue/test_ensure_fail_status.py
+++ b/tests/test_message_queue/test_ensure_fail_status.py
@@ -244,8 +244,9 @@ class TestEnsureFailStatusOnJobFail:
 class TestRecoverStaleJobs:
     """Tests for recovering jobs stuck in PROCESSING after worker crash (e.g. OOM kill)."""
 
-    def test_recover_stale_jobs_marks_processing_as_failed(self, rm_and_queue):
-        """Jobs stuck in PROCESSING should be marked as FAILED by recover_stale_jobs."""
+    def test_recover_stale_jobs_requeues_processing(self, rm_and_queue):
+        """#409: a stale PROCESSING job under budget is requeued (PENDING) with
+        its retry count bumped, not terminally FAILED."""
         rm, queue = rm_and_queue
         user = "test_user"
         now = dt.datetime.now(dt.timezone.utc)
@@ -270,10 +271,11 @@ class TestRecoverStaleJobs:
         assert len(recovered) == 1
         assert recovered[0] == resource_id
 
-        # Job should now be FAILED
+        # Job should now be requeued (PENDING) with its retry count bumped.
         with rm.meta_provide(user=user, now=now):
             res = rm.get(resource_id)
-            assert res.data.status == TaskStatus.FAILED
+            assert res.data.status == TaskStatus.PENDING
+            assert res.data.retries == 1
             assert res.data.errmsg is not None
             assert (
                 "stale" in res.data.errmsg.lower()
@@ -333,7 +335,8 @@ class TestRecoverStaleJobs:
         for rid in resource_ids:
             with rm.meta_provide(user=user, now=now):
                 res = rm.get(rid)
-                assert res.data.status == TaskStatus.FAILED
+                assert res.data.status == TaskStatus.PENDING
+                assert res.data.retries == 1
 
     def test_start_consume_calls_recover_stale_jobs(self, rm_and_queue):
         """start_consume should automatically recover stale jobs before processing new ones."""
@@ -357,11 +360,13 @@ class TestRecoverStaleJobs:
         queue.stop_consuming()
         consumer_thread.join(timeout=2.0)
 
-        # The stuck job should have been recovered to FAILED
+        # The stuck job should have been recovered (unstuck from PROCESSING).
+        # #409: recovery requeues it (PENDING); the running consumer then pops
+        # and runs it (no-op handler → COMPLETED).
         with rm.meta_provide(user=user, now=now):
             res = rm.get(resource_id)
-            assert res.data.status == TaskStatus.FAILED, (
-                f"Expected FAILED but got {res.data.status}. "
+            assert res.data.status != TaskStatus.PROCESSING, (
+                f"Expected recovered (not PROCESSING) but got {res.data.status}. "
                 "start_consume should recover stale PROCESSING jobs."
             )
 
@@ -381,11 +386,13 @@ class TestRecoverStaleJobs:
         recovered1 = queue.recover_stale_jobs(heartbeat_timeout_seconds=0)
         assert len(recovered1) == 1
 
-        # Second recovery - no more stale jobs
+        # Second recovery - no more stale jobs (the first requeued it to
+        # PENDING, so it is no longer PROCESSING).
         recovered2 = queue.recover_stale_jobs(heartbeat_timeout_seconds=0)
         assert len(recovered2) == 0
 
-        # Status should still be FAILED
+        # Status is PENDING (requeued once) with a single retry counted.
         with rm.meta_provide(user=user, now=now):
             res = rm.get(info.resource_id)
-            assert res.data.status == TaskStatus.FAILED
+            assert res.data.status == TaskStatus.PENDING
+            assert res.data.retries == 1

--- a/tests/test_message_queue/test_heartbeat.py
+++ b/tests/test_message_queue/test_heartbeat.py
@@ -275,9 +275,11 @@ class TestRecoverStaleJobsWithHeartbeat:
         recovered = queue.recover_stale_jobs(heartbeat_timeout_seconds=30)
         assert resource_id in recovered
 
+        # #409: still within the retry budget → requeued (PENDING), not FAILED.
         with rm.meta_provide(user=user, now=now):
             res = rm.get(resource_id)
-            assert res.data.status == TaskStatus.FAILED
+            assert res.data.status == TaskStatus.PENDING
+            assert res.data.retries == 1
 
     def test_skip_job_with_recent_heartbeat(self, rm_and_queue):
         """Jobs with recent heartbeat should NOT be recovered (still alive)."""
@@ -466,11 +468,13 @@ class TestPeriodicRecovery:
         queue.stop_consuming()
         consumer_thread.join(timeout=2.0)
 
-        # The stale job should have been recovered
+        # The stale job should have been recovered (unstuck from PROCESSING).
+        # #409: recovery requeues it (PENDING) rather than terminally failing;
+        # the live consumer then pops and runs it (no-op handler → COMPLETED).
         with rm.meta_provide(user=user, now=now):
             res = rm.get(resource_id)
-            assert res.data.status == TaskStatus.FAILED, (
-                f"Expected FAILED but got {res.data.status}. "
+            assert res.data.status != TaskStatus.PROCESSING, (
+                f"Expected recovered (not PROCESSING) but got {res.data.status}. "
                 "Periodic recovery should have cleaned this stale job."
             )
 

--- a/tests/test_message_queue/test_rabbitmq_long_job.py
+++ b/tests/test_message_queue/test_rabbitmq_long_job.py
@@ -29,6 +29,7 @@ from specstar.types import (
     Resource,
     RevisionInfo,
     RevisionStatus,
+    TaskStatus,
 )
 
 
@@ -397,3 +398,89 @@ class TestFactoryForwardsHeartbeatSeconds:
         builder = factory.build(lambda j: None)
         queue = builder(rm)
         assert queue.amqp_heartbeat_seconds == 120
+
+
+def _register_callback(queue):
+    """Drive ``start_consume`` just far enough (stale sweep neutered, since the
+    MagicMock rm can't be swept) to register the consumer callback on the mock
+    channel, then return once the thread has finished registering."""
+    queue.recover_stale_jobs = lambda **kw: []  # ty:ignore[invalid-assignment]
+    queue._start_periodic_recovery = lambda: None  # ty:ignore[invalid-assignment]
+    t = threading.Thread(target=queue.start_consume, daemon=True)
+    t.start()
+    t.join(timeout=2.0)
+
+
+class TestRedeliveryGuard:
+    """#409: the consume-time guard bounds the broker's uncounted redelivery
+    loop by classifying each (re)delivery from the job's persisted status."""
+
+    def test_stale_retry_status_is_failed(self, make_queue):
+        """Broker-backed queue parks a stale-but-retryable job in FAILED (not
+        PENDING) so the guard reads the redelivery as already-counted."""
+        queue, _ch, _rm = make_queue()
+        assert queue._stale_retry_status() == TaskStatus.FAILED
+
+    def test_completed_redelivery_is_dropped(self, make_queue):
+        """A COMPLETED job redelivered (lost ack) is acked without re-running."""
+        ran: list[int] = []
+        queue, ch, rm = make_queue(lambda r: ran.append(1))
+        rm.get.return_value = Resource(
+            info=_make_revision_info("rid-done"),
+            data=Job(payload=Payload(task_name="done"), status=TaskStatus.COMPLETED),
+        )
+        _register_callback(queue)
+        ch.simulate_message(b"rid-done")
+
+        ch.basic_ack.assert_called_once()
+        ch.basic_publish.assert_not_called()  # not dead-lettered
+        rm.create_or_update.assert_not_called()  # not re-persisted
+        assert ran == []  # handler never ran
+
+    def test_processing_over_budget_is_dead_lettered(self, make_queue):
+        """A killed in-flight job (PROCESSING) redelivered past its budget is
+        marked FAILED, routed to the dead-letter queue, and acked."""
+        queue, ch, rm = make_queue(lambda r: None)
+        rm.get.return_value = Resource(
+            info=_make_revision_info("rid-dead"),
+            data=Job(
+                payload=Payload(task_name="x"),
+                status=TaskStatus.PROCESSING,
+                retries=3,  # +1 = 4 > queue max_retries (3) → exhausted
+            ),
+        )
+        _register_callback(queue)
+        ch.simulate_message(b"rid-dead")
+
+        saved = rm.create_or_update.call_args.args[1]
+        assert saved.status == TaskStatus.FAILED
+        assert saved.retries == 4
+        assert ch.basic_publish.call_args.kwargs["routing_key"] == queue.dead_queue_name
+        ch.basic_ack.assert_called_once()
+
+    def test_processing_under_budget_runs_with_bumped_retries(self, make_queue):
+        """A killed in-flight job redelivered under budget runs again with its
+        retry count incremented — the redelivery is finally counted."""
+        seen: dict = {}
+        done = threading.Event()
+
+        def handler(resource):
+            seen["retries"] = resource.data.retries
+            seen["status"] = resource.data.status
+            done.set()
+
+        queue, ch, rm = make_queue(handler)
+        rm.get.return_value = Resource(
+            info=_make_revision_info("rid-run"),
+            data=Job(
+                payload=Payload(task_name="x"),
+                status=TaskStatus.PROCESSING,
+                retries=0,
+            ),
+        )
+        _register_callback(queue)
+        queue._consuming_connection = MockConnection(ch)  # fresh open conn
+        ch.simulate_message(b"rid-run")
+
+        assert done.wait(timeout=3.0)
+        assert seen == {"retries": 1, "status": TaskStatus.PROCESSING}

--- a/tests/test_message_queue/test_stale_retry_budget.py
+++ b/tests/test_message_queue/test_stale_retry_budget.py
@@ -1,0 +1,102 @@
+"""#409 — stale/killed jobs go through the retry budget.
+
+A worker that is killed (or hangs) mid-job leaves its record in
+``PROCESSING``. The sweep (``recover_stale_jobs``) used to mark such a job
+terminally ``FAILED`` with zero retries; now it counts the attempt and
+requeues it while there is retry budget left, only failing once the budget
+is exhausted. On broker backends (RabbitMQ) the re-delivery is instead
+classified at consume time by :meth:`_redelivery_decision`.
+"""
+
+import datetime as dt
+
+import pytest
+from msgspec import Struct
+
+from specstar.message_queue.simple import SimpleMessageQueueFactory
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField, Job, TaskStatus
+
+
+class Payload(Struct):
+    task_name: str
+
+
+def _make_queue(max_retries: int = 3):
+    storage = SimpleStorage(MemoryMetaStore(), MemoryResourceStore())
+    rm = ResourceManager(
+        Job[Payload],
+        storage=storage,
+        message_queue=SimpleMessageQueueFactory(max_retries=max_retries).build(
+            lambda job: None
+        ),
+        indexed_fields=[IndexableField(field_path="status", field_type=str)],
+    )
+    return rm, rm.message_queue
+
+
+@pytest.fixture
+def rm_and_queue():
+    return _make_queue()
+
+
+def _make_processing_job(rm, *, retries: int = 0, max_retries=None) -> str:
+    """Create a job already stuck in PROCESSING (simulating a killed worker)."""
+    user, now = "u", dt.datetime.now(dt.timezone.utc)
+    with rm.using(user=user, now=now):
+        info = rm.create(
+            Job(payload=Payload(task_name="stuck"), max_retries=max_retries)
+        )
+        rid = info.resource_id
+        r = rm.get(rid)
+        r.data.status = TaskStatus.PROCESSING
+        r.data.retries = retries
+        rm.create_or_update(rid, r.data)
+    return rid
+
+
+def _get(rm, rid):
+    with rm.using(user="u", now=dt.datetime.now(dt.timezone.utc)):
+        return rm.get(rid).data
+
+
+def test_stale_job_under_budget_is_requeued_pending(rm_and_queue):
+    """Stale PROCESSING job with retries under budget → PENDING + retries+1."""
+    rm, queue = rm_and_queue
+    rid = _make_processing_job(rm, retries=0)
+
+    recovered = queue.recover_stale_jobs(heartbeat_timeout_seconds=0)
+
+    assert recovered == [rid]
+    job = _get(rm, rid)
+    assert job.status == TaskStatus.PENDING  # requeued for retry, not FAILED
+    assert job.retries == 1
+
+
+def test_stale_job_over_budget_is_failed(rm_and_queue):
+    """Stale job whose retries would exceed the budget → terminal FAILED."""
+    rm, queue = rm_and_queue
+    rid = _make_processing_job(rm, retries=3)  # queue default max_retries=3
+
+    recovered = queue.recover_stale_jobs(heartbeat_timeout_seconds=0)
+
+    assert recovered == [rid]
+    job = _get(rm, rid)
+    assert job.status == TaskStatus.FAILED
+    assert job.retries == 4
+    assert "exhausted" in job.errmsg
+
+
+def test_stale_recovery_respects_per_job_max_retries(rm_and_queue):
+    """A per-job max_retries=0 fails on the first stale recovery, even though
+    the queue default (3) would still have budget."""
+    rm, queue = rm_and_queue
+    rid = _make_processing_job(rm, retries=0, max_retries=0)
+
+    queue.recover_stale_jobs(heartbeat_timeout_seconds=0)
+
+    job = _get(rm, rid)
+    assert job.status == TaskStatus.FAILED
+    assert job.retries == 1

--- a/tests/test_message_queue/test_stale_retry_budget.py
+++ b/tests/test_message_queue/test_stale_retry_budget.py
@@ -13,6 +13,7 @@ import datetime as dt
 import pytest
 from msgspec import Struct
 
+from specstar.message_queue.basic import RedeliveryAction
 from specstar.message_queue.simple import SimpleMessageQueueFactory
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
 from specstar.resource_manager.meta_store.simple import MemoryMetaStore
@@ -100,3 +101,41 @@ def test_stale_recovery_respects_per_job_max_retries(rm_and_queue):
     job = _get(rm, rid)
     assert job.status == TaskStatus.FAILED
     assert job.retries == 1
+
+
+# --- broker re-delivery guard (_redelivery_decision) -----------------------
+
+
+def _job(status: TaskStatus, retries: int = 0, max_retries=None) -> Job:
+    job = Job(payload=Payload(task_name="x"), max_retries=max_retries)
+    job.status = status
+    job.retries = retries
+    return job
+
+
+@pytest.mark.parametrize(
+    "status, retries, max_retries, expected_action, expected_retries",
+    [
+        # fresh first delivery → just run, nothing counted
+        (TaskStatus.PENDING, 0, None, RedeliveryAction.RUN, 0),
+        # uncounted in-flight re-delivery (broker requeue) → count it, run
+        (TaskStatus.PROCESSING, 0, None, RedeliveryAction.RUN, 1),
+        (TaskStatus.PROCESSING, 2, None, RedeliveryAction.RUN, 3),
+        # in-flight re-delivery that exhausts the budget → dead-letter
+        (TaskStatus.PROCESSING, 3, None, RedeliveryAction.DEAD_LETTER, 4),
+        (TaskStatus.PROCESSING, 0, 0, RedeliveryAction.DEAD_LETTER, 1),
+        # already-counted re-delivery (retry queue / stale sweep) → run, no bump
+        (TaskStatus.FAILED, 1, None, RedeliveryAction.RUN, 1),
+        # already-counted but over budget → dead-letter, no bump
+        (TaskStatus.FAILED, 4, None, RedeliveryAction.DEAD_LETTER, 4),
+        # completed but re-delivered (lost ack) → drop, never re-run
+        (TaskStatus.COMPLETED, 0, None, RedeliveryAction.DROP, 0),
+    ],
+)
+def test_redelivery_decision(
+    rm_and_queue, status, retries, max_retries, expected_action, expected_retries
+):
+    _, queue = rm_and_queue  # queue default max_retries=3
+    action, new_retries = queue._redelivery_decision(_job(status, retries, max_retries))
+    assert action == expected_action
+    assert new_retries == expected_retries


### PR DESCRIPTION
Fixes #409.

Continues #404: after that fix a healthy-but-slow / killed job still didn't go through the retry budget. This was **two failure modes across two backends**, unified under one principle: *a stale/killed re-attempt spends the retry budget and is dead-lettered when exhausted — never dropped with zero retries, never looped forever.*

## Problem

- **Simple** — `recover_stale_jobs` marked a stuck `PROCESSING` job terminally `FAILED` with zero retries. Since `pop()` only selects `PENDING`, the sweep is the sole recovery authority, so the job was silently dropped from the queue.
- **RabbitMQ** — a job outliving `consumer_timeout` (#227) is re-delivered by the broker with its `x-retry-count` header untouched and without passing through `_send_to_retry_or_dead`, so it re-ran forever and never dead-lettered. Such a job heartbeats the whole time, so `recover_stale_jobs` never even fires — the only place to intercept the re-delivery is the consume callback.

## Fix

**Key invariant:** whoever writes `FAILED` also bumps `retries` (the in-handler failure path and the stale sweep both do). So at consume time `PROCESSING` = an *uncounted* re-attempt and `FAILED` = an *already-counted* one; exhaustion is decided by `retries > max` regardless of which queue the message came from.

**① Stale sweep (`recover_stale_jobs`, base class)** — `retries += 1`; while under `effective_max_retries` requeue via a new overridable `_stale_retry_status()`, else `FAILED`:

| | under budget | exhausted |
|---|---|---|
| Simple (store-backed) | `PENDING` (`pop()` re-runs) | `FAILED` |
| RabbitMQ / Celery (broker-backed) | `FAILED` (broker re-delivers) | `FAILED` |

**② RabbitMQ consume-time guard** — a new pure `_redelivery_decision(job)` on the base class classifies each (re)delivery:

| persisted status | meaning | action |
|---|---|---|
| `PENDING` | fresh first delivery | run |
| `PROCESSING` | killed/hung in-flight, uncounted | count it; run if under budget, else **dead-letter** |
| `FAILED` | already-counted retry (retry queue / stale sweep) | run if under budget, else **dead-letter**; no double-count |
| `COMPLETED` | finished but ack lost | **drop** the duplicate, never re-run |

Downstream retry accounting uses `max(header, counted)` so neither the in-handler failure path nor the guard under-counts.

## Scope

- **simple + rabbitmq**. **Celery** gets only the `_stale_retry_status → FAILED` override (so the shared sweep doesn't park it in an inert `PENDING`); a Celery consume-time guard is a **follow-up**.

## Tests

- `test_stale_retry_budget.py` (CI-visible): sweep under/over budget, per-job `max_retries`, and the full `_redelivery_decision` table.
- `test_rabbitmq_long_job.py` (mocked pika): guard DROP / DEAD_LETTER / RUN glue + the broker `_stale_retry_status` override.
- Existing tests that locked the old "stale → FAILED" contract updated to the requeue behavior.
- `types.py` interface docstring + CHANGELOG + version bump to **0.11.14**.

CI-parity suite (`-m "not integration and not benchmark and not slow"`) green locally; contract + README markdown-docs steps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbFEjRxtvrgLUb9U8vdV4F
