### PR TITLE
feat(#412): exp_aggregate_by group-level order_by + limit/offset (+ exp_count_groups), pushed down to SQLite & Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [Unreleased]
+
+
+### Added
+
+- Group-level pagination for `exp_aggregate_by`: keyword-only `order_by` (an
+  aggregate result-name or the `"key"` sentinel, with the `+`/`-` direction
+  convention), `limit`, and `offset` page the distinct GROUPS — NULL
+  order-values and NULL keys sort last regardless of direction, and the group
+  key is the stable ascending tiebreak so pages never straddle a tie. Adds
+  `exp_count_groups(by, query=)` for the pager total. The
+  `ORDER BY … LIMIT … OFFSET` pushes down to the SQLite and Postgres engines
+  when the order target is engine-orderable (the group key, or a single-column
+  Count/Sum/Min/Max including datetime Min/Max); an Avg / ForeignAggregate
+  target falls back to the in-process reference, which every backend still
+  matches byte-for-byte. (#412)
+
 ## [0.11.14] — 2026-07-03
 
 

--- a/docs/design/aggregate-group-pagination-plan.md
+++ b/docs/design/aggregate-group-pagination-plan.md
@@ -1,6 +1,6 @@
 # exp_aggregate_by 群組層級 order_by + limit/offset 分頁 — 實作 Plan
 
-> **狀態**:實作中(in-process reference DONE,commit `201571a`)
+> **狀態**:**全 Phase DONE**(in-process reference + SQLite 下推 + Postgres 下推 + 跨後端 parity);待開 PR
 > **Branch**:`issue-412-aggregate-group-pagination`
 > **Issue**:[#412](https://github.com/HYChou0515/specstar/issues/412)
 > **動機**:`exp_aggregate_by(by, aggregates, query=None)` 目前回**所有** group、無序。`IMetaWithAgg.aggregate_by` 明確忽略 `query.limit/offset`(「paging an aggregate is meaningless」——對 *row-level* 分頁正確),但沒有辦法 **order + 分頁 GROUP 結果本身**。下游 ai-workspace #511「依概念分組」待審 inbox 要對 distinct `cluster_key` 依「最新成員時間」分頁;沒有 group-level 分頁,消費端就得把每個 group 撈進 Python 排序切片 = O(all-groups) 全載入,正是要避免的。
@@ -9,17 +9,17 @@
 
 ## Definition of Done
 
-- [ ] `exp_aggregate_by(..., *, order_by=None, limit=None, offset=0)` — keyword-only,group-level 排序 + 分頁
-- [ ] `order_by` 接**聚合 result-name**(如 `"-latest"` 對應 `{"latest": Max(...)}`)或 **group key sentinel `"key"`**;沿用 `Query.sort()` 的 `"-name"`/`"+name"` 方向慣例(asc 預設、`-` = desc);目標非聚合名也非 `"key"` → raise
-- [ ] tie-break = **group key 升序**(穩定次序,pages 穩定);NULL 一律 **NULLS LAST**(order value 與 key tiebreak 皆是)
-- [ ] `exp_count_groups(by, query=None) -> int` distinct-group 總數(pager 的 total),**不受**該 call 的 limit/offset 影響
-- [ ] `Count / Sum / Min / Max / Avg` **全部下推**成引擎 GROUP BY(才能當 ORDER BY 目標);`ForeignAggregate` 仍 Python(per-key 子查詢)
-- [ ] `order_by` 目標可下推(`"key"` 或 scalar self-aggregate)→ `ORDER BY … LIMIT … OFFSET` 整段下推;目標是 `ForeignAggregate`(Python-only)→ **退回 in-process** order+paginate
-- [ ] NULLS LAST 用 `(col IS NULL) ASC, col <dir>` 前綴技巧(免版本依賴、SQLite/PG/in-process 三者一致)
-- [ ] **SQLite** 真下推
-- [ ] **Postgres** 真下推(#511 線上跑 multipod 共用 PG,只有 PG 真下推 grouped 生產才是 O(page))
-- [ ] 跨後端 **parity**:in-process ≡ sqlite ≡ pg,同一組 parametrized 斷言全過(pushed 結果 MUST == in-process reduction)
-- [ ] 既有 testsuite 零 regression;ruff / type 綠;CHANGELOG `[Unreleased]`
+- [x] `exp_aggregate_by(..., *, order_by=None, limit=None, offset=0)` — keyword-only,group-level 排序 + 分頁
+- [x] `order_by` 接**聚合 result-name**(如 `"-latest"` 對應 `{"latest": Max(...)}`)或 **group key sentinel `"key"`**;沿用 `Query.sort()` 的 `"-name"`/`"+name"` 方向慣例(asc 預設、`-` = desc);目標非聚合名也非 `"key"` → raise(front-load 驗證,pushed/非 pushed 皆一致)
+- [x] tie-break = **group key 升序**(穩定次序,pages 穩定);NULL 一律 **NULLS LAST**(order value 與 key tiebreak 皆是)
+- [x] `exp_count_groups(by, query=None) -> int` distinct-group 總數(pager 的 total),**不受**該 call 的 limit/offset 影響
+- [x] `Count / Sum / Min / Max / Avg` **全部下推**成引擎 GROUP BY(值層);`ForeignAggregate` 仍 Python(per-key 子查詢)
+- [x] `order_by` 目標可下推(`"key"` 或**單欄** self-aggregate:Count/Sum/Min/Max 含 datetime Min/Max)→ `ORDER BY … LIMIT … OFFSET` 整段下推;目標是 **Avg**(拆兩欄)或 `ForeignAggregate`(Python-only)→ **退回 in-process** order+paginate(byte-parity 保證)
+- [x] NULLS LAST 用 `(col IS NULL) ASC, col <dir>` 前綴技巧(免版本依賴、SQLite/PG/in-process 三者一致)
+- [x] **SQLite** 真下推(`supports_group_paging=True` + `_group_order_clause`)
+- [x] **Postgres** 真下推(#511 線上跑 multipod 共用 PG,只有 PG 真下推 grouped 生產才是 O(page))
+- [x] 跨後端 **parity**:in-process ≡ sqlite ≡ pg,同一組 parametrized 斷言全過(pushed 結果 MUST == in-process reduction)
+- [x] 既有 testsuite 零 regression;ruff 綠;CHANGELOG `[Unreleased]`(specstar 不 gate ty)
 
 ---
 

--- a/docs/design/aggregate-group-pagination-plan.md
+++ b/docs/design/aggregate-group-pagination-plan.md
@@ -1,0 +1,76 @@
+# exp_aggregate_by 群組層級 order_by + limit/offset 分頁 — 實作 Plan
+
+> **狀態**:實作中(in-process reference DONE,commit `201571a`)
+> **Branch**:`issue-412-aggregate-group-pagination`
+> **Issue**:[#412](https://github.com/HYChou0515/specstar/issues/412)
+> **動機**:`exp_aggregate_by(by, aggregates, query=None)` 目前回**所有** group、無序。`IMetaWithAgg.aggregate_by` 明確忽略 `query.limit/offset`(「paging an aggregate is meaningless」——對 *row-level* 分頁正確),但沒有辦法 **order + 分頁 GROUP 結果本身**。下游 ai-workspace #511「依概念分組」待審 inbox 要對 distinct `cluster_key` 依「最新成員時間」分頁;沒有 group-level 分頁,消費端就得把每個 group 撈進 Python 排序切片 = O(all-groups) 全載入,正是要避免的。
+
+---
+
+## Definition of Done
+
+- [ ] `exp_aggregate_by(..., *, order_by=None, limit=None, offset=0)` — keyword-only,group-level 排序 + 分頁
+- [ ] `order_by` 接**聚合 result-name**(如 `"-latest"` 對應 `{"latest": Max(...)}`)或 **group key sentinel `"key"`**;沿用 `Query.sort()` 的 `"-name"`/`"+name"` 方向慣例(asc 預設、`-` = desc);目標非聚合名也非 `"key"` → raise
+- [ ] tie-break = **group key 升序**(穩定次序,pages 穩定);NULL 一律 **NULLS LAST**(order value 與 key tiebreak 皆是)
+- [ ] `exp_count_groups(by, query=None) -> int` distinct-group 總數(pager 的 total),**不受**該 call 的 limit/offset 影響
+- [ ] `Count / Sum / Min / Max / Avg` **全部下推**成引擎 GROUP BY(才能當 ORDER BY 目標);`ForeignAggregate` 仍 Python(per-key 子查詢)
+- [ ] `order_by` 目標可下推(`"key"` 或 scalar self-aggregate)→ `ORDER BY … LIMIT … OFFSET` 整段下推;目標是 `ForeignAggregate`(Python-only)→ **退回 in-process** order+paginate
+- [ ] NULLS LAST 用 `(col IS NULL) ASC, col <dir>` 前綴技巧(免版本依賴、SQLite/PG/in-process 三者一致)
+- [ ] **SQLite** 真下推
+- [ ] **Postgres** 真下推(#511 線上跑 multipod 共用 PG,只有 PG 真下推 grouped 生產才是 O(page))
+- [ ] 跨後端 **parity**:in-process ≡ sqlite ≡ pg,同一組 parametrized 斷言全過(pushed 結果 MUST == in-process reduction)
+- [ ] 既有 testsuite 零 regression;ruff / type 綠;CHANGELOG `[Unreleased]`
+
+---
+
+## 定案設計(grill 結論)
+
+**API**(reference 已 commit)
+```python
+def exp_aggregate_by(
+    self, by, aggregates, query=None, *,
+    order_by: str | None = None,   # 聚合 result-name 或 "key"(group key sentinel)
+    limit: int | None = None,      # 分頁 GROUP(非 row-level query.limit/offset)
+    offset: int = 0,
+) -> list[GroupRow]: ...
+
+def exp_count_groups(self, by, query=None) -> int: ...   # distinct-group 總數
+```
+
+**排序語意**(reference 已定,pushdown 必須逐字對齊)
+- 主鍵 = `order_by` 目標(聚合值或 key),方向由 `+`/`-` 決定。
+- 次鍵 = **group key 升序**(穩定 tie-break;Python reference 靠 stable sort 兩段排實現)。
+- NULL 一律墊底:in-process 用 `(x is None, x)`;SQL 用 `(col IS NULL) ASC, col <dir>` 前綴 —— 三後端一致,與各引擎 NULL 預設無關。
+- `order_by` 目標非法(不是聚合名也不是 `"key"`)→ raise;`offset/limit` 負值 → raise。
+
+**下推 vs fallback 規則**
+- `order_by` 目標可下推(`"key"` 或 scalar self-aggregate:Count/Sum/Min/Max/Avg)→ WHERE(row-level query)→ GROUP BY → 群層 `ORDER BY … LIMIT … OFFSET` 全下推引擎。
+- `order_by` 目標是 `ForeignAggregate`(Python-only)→ 整段**退回 in-process**(算全群→排序→切片),保正確。
+- 後端未實作 `IMetaWithAgg` → in-process fallback(結果仍須 == reference)。
+
+**後端範圍**:SQLite 真下推 + Postgres 真下推 + in-process reference(正確性基準)三者 parity 強制一致。
+
+---
+
+## Phases(對應 tasks #36–39)
+
+1. **in-process reference**(**DONE**,commit `201571a`):在 groups dict 建好後,依 named aggregate / `"key"` 排序 `GroupRow`s(NULLS LAST + key tiebreak)、切片,加 `exp_count_groups`;`tests/meta_store/test_aggregate_by.py::TestAggregateByOrderAndPaginate` 跨 memory/disk/sqlite/pg parametrize。**此路徑是跨後端正確性參考**,pushdown 必須 match。
+2. **SQLite pushdown**:`IMetaWithAgg.aggregate_by` 加 order/limit/offset;Count/Sum/Min/Max/Avg 進引擎 GROUP BY;`(col IS NULL)` 前綴 + key tiebreak;order_by 為 ForeignAggregate → 不下推(fallback)。
+3. **Postgres pushdown / parity**:同語意下推到 PG。
+4. **跨後端 parity 收尾**:`@pytest.mark.parametrize` 同一組斷言跑 memory / disk / sqlite / pg,結果逐一相同;ruff / type;PR。
+
+---
+
+## 下游對接(為什麼要做)
+
+ai-workspace #511 grouped 待審 inbox:
+```python
+rm.exp_aggregate_by(
+    QB["cluster_key"],
+    {"n": Count(), "latest": Max(QB.created_time())},
+    query=(collection & state=="active" & kind∈{proposal, term_question}),
+    order_by="-latest", offset=o, limit=n,
+)
+# + rm.exp_count_groups(QB["cluster_key"], query=...) 給 pager total
+```
+→ 一頁只回 N 個概念(依最新成員時間),消費端再 `cluster_key IN (當頁)` 載成員,不再 O(all-groups)。

--- a/docs/en/howto/aggregation.md
+++ b/docs/en/howto/aggregation.md
@@ -1,0 +1,217 @@
+# Aggregation and grouping
+
+SpecStar can group resources by a field and reduce each group with aggregates —
+counts, sums, min/max, averages — pushed down to the storage engine as a real
+`GROUP BY`, and (since v0.11.x) **ordered and paginated at the group level** so a
+consumer can page through the *distinct groups* themselves.
+
+Use it when you want *"how many chunks per document"*, *"newest member per
+cluster"*, or *"the top 20 buckets by size, one page at a time"* without
+streaming every matching row into Python.
+
+!!! note "Experimental surface"
+    The entry point is `ResourceManager.exp_aggregate_by` (the `exp_` prefix
+    marks it experimental — the signature may still adjust before it stabilises
+    as `aggregate_by`). `exp_count_groups` follows the same convention.
+
+---
+
+## When to use it
+
+- counting or summarising rows **per group** (a `GROUP BY` in SQL terms)
+- annotating each parent with a **reduction over its children** in another
+  resource (*"this doc's chunk count"*)
+- paging a **grouped list** by an aggregate value or the group key — e.g. a
+  review queue grouped by concept, newest first, 20 concepts per page
+
+For row-level filtering, sorting, and pagination of individual resources, use the
+[Query Builder](/specstar/howto/query-builder) with `search_resources` instead —
+that pages *rows*, this pages *groups*.
+
+---
+
+## Self-aggregates
+
+Import the aggregates from the top-level package and group with a `QB` field:
+
+```python
+from specstar import QB, Count, Sum, Min, Max, Avg
+
+rows = manager.exp_aggregate_by(
+    QB["source_doc_id"],                 # group by an indexed data field
+    {"chunks": Count(), "bytes": Sum(QB["size"])},
+    query=(QB["status"] == "ready").build(),   # optional row filter (WHERE)
+)
+for r in rows:
+    print(r.key, r.chunks, r.bytes)      # one GroupRow per distinct source_doc_id
+```
+
+| Aggregate | Reduces | Empty / all-`None` group |
+|-----------|---------|--------------------------|
+| `Count()` | rows in the group | `0` |
+| `Sum(field)` | numeric field (`None`-skipping) | `None` |
+| `Min(field)` / `Max(field)` | comparable field (`None`-skipping) | `None` |
+| `Avg(field)` | numeric field → `float` (`None`-skipping) | `None` |
+
+`Sum`/`Avg` raise `TypeError` on a non-numeric value; `Min`/`Max` use Python `<`
+ordering, so the field's values must be mutually comparable (numbers, datetimes,
+or strings). A missing / unindexed group-by value collects under `key=None`.
+
+You can group by a **`ResourceMeta` attribute** too — `QB.created_by()`,
+`QB.created_time()`, etc. — and aggregate over one:
+
+```python
+rows = manager.exp_aggregate_by(
+    QB.created_by(),
+    {"n": Count(), "latest": Max(QB.created_time())},
+)
+```
+
+### The result: `GroupRow`
+
+Each row is a `GroupRow` with:
+
+- `.key` — the group-by value (`None` when the value was missing)
+- each named aggregate as **both** an attribute and an item, so
+  `row.chunks` and `row["chunks"]` are equivalent — a dict comprehension like
+  `{r.key: r.chunks for r in rows}` just works
+- `.resource` — populated only in the cross-RM parent mode below (otherwise
+  `None`, because a group can span many rows)
+
+---
+
+## Foreign aggregates: parent rows with children stats
+
+To annotate each parent with a reduction over a **different** resource's rows,
+pass a `ForeignAggregate(child_rm, link_field, aggregate)` — `link_field` is the
+field on the child that holds the parent's `resource_id`:
+
+```python
+from specstar import QB, Count, ForeignAggregate
+
+rows = doc_manager.exp_aggregate_by(
+    QB.resource_id(),                    # one group == one parent row
+    {"chunks": ForeignAggregate(chunk_manager, QB["source_doc_id"], Count())},
+)
+for r in rows:
+    print(r.resource.data.name, r.chunks)   # .resource is the parent row
+```
+
+Grouping by `QB.resource_id()` is the **parent-row mode**: each group is exactly
+one row of *this* manager, so `GroupRow.resource` carries that row's
+`SearchedResource` — read `r.resource.data.<field>` alongside the children stat.
+The foreign reduction runs as one extra query scoped to just the keys the page
+surfaces, not one query per parent.
+
+---
+
+## Ordering and paginating the groups
+
+Pass `order_by`, `limit`, and `offset` to page through the **distinct groups**
+(separate from the row-level `query.limit/offset`, which an aggregate ignores):
+
+```python
+page = manager.exp_aggregate_by(
+    QB["bucket"],
+    {"n": Count(), "hi": Max(QB["size"])},
+    order_by="-hi",      # order by the 'hi' aggregate, descending
+    offset=0, limit=20,  # first 20 groups
+)
+```
+
+- **`order_by`** — an aggregate **result-name** (a key of the `aggregates` dict)
+  or the sentinel **`"key"`** (the group key). It uses the same `"-name"` /
+  `"+name"` convention as `Query.sort()`: ascending by default, `-` for
+  descending. A target that is neither an aggregate name nor `"key"` raises
+  `ValueError`; a negative `offset`/`limit` raises.
+- **Stable pages** — the group key is always the ascending secondary sort, so
+  two groups with equal `order_by` values never straddle a page boundary or
+  reappear on the next page.
+- **NULLs last** — a `None` order-value **and** a `None` group key always sort
+  last, regardless of direction.
+
+### Pager total
+
+`exp_count_groups` returns the number of distinct groups the same `by` + `query`
+would produce — the total a pager needs, independent of any `limit`/`offset`:
+
+```python
+total = manager.exp_count_groups(QB["bucket"], query=q)
+```
+
+### Worked example: a paged, grouped queue
+
+Group members by a cluster key, order each concept by its newest member, and
+return one page of concepts plus the total — then load just that page's members:
+
+```python
+from specstar import QB, Count, Max
+
+q = (
+    (QB["state"] == "active")
+    & (QB["kind"] << ["proposal", "question"])
+).build()
+
+page = member_manager.exp_aggregate_by(
+    QB["cluster_key"],
+    {"n": Count(), "latest": Max(QB.created_time())},
+    query=q,
+    order_by="-latest",          # newest concept first
+    offset=offset, limit=size,
+)
+total = member_manager.exp_count_groups(QB["cluster_key"], query=q)
+
+keys = [r.key for r in page]     # this page's concepts
+members = member_manager.search_resources((QB["cluster_key"] << keys).build())
+```
+
+Each page returns a fixed number of groups no matter how many rows exist — the
+load stays constant as the dataset grows.
+
+---
+
+## Push-down and performance
+
+The value reduction (`Count`/`Sum`/`Min`/`Max`/`Avg`) is pushed down to any meta
+store that implements `IMetaWithAgg` (SQLite and PostgreSQL today) as a real
+engine `GROUP BY`; other backends fall back to an in-process reduction that
+returns **identical** results.
+
+The group-level `ORDER BY … LIMIT … OFFSET` is pushed down as well — so a page
+scans only the groups it returns — when **both** hold:
+
+- the store advertises group paging (SQLite and PostgreSQL do), and
+- the `order_by` target is **engine-orderable**: the group key, or a
+  single-column self-aggregate (`Count`, `Sum`, `Min`, `Max`, including
+  `Min`/`Max` over a `ResourceMeta` datetime column).
+
+Ordering by `Avg` (internally a `Sum` + a `Count`) or by a `ForeignAggregate`
+falls back to ordering the fully-materialised groups in Python — still correct,
+still identical across backends, just not `O(page)` at the engine. NULLs-last is
+spelled with a `(expr IS NULL)` prefix rather than native `NULLS LAST`, so
+SQLite, PostgreSQL, and the in-process reference agree byte-for-byte.
+
+!!! note "Not a counter cache"
+    A pushed-down `GROUP BY` is scan-fast, not `O(1)`. For a genuinely hot,
+    high-fan-out count, maintain a denormalised counter on write instead.
+
+---
+
+## Gotchas
+
+- **Group-by must be a `QB` field.** Pass `QB["field"]` (indexed data) or a
+  meta accessor like `QB.created_by()` — a plain string raises `TypeError`.
+- **Index the fields you group / aggregate on.** An unindexed data field is
+  treated as `None` (and warns, or raises under the `error`
+  `on_unindexed_query` policy) — every row then collapses into the `key=None`
+  group. Add it to `indexed_fields`.
+- **`order_by`/`limit` page groups, not rows.** The row-level `query.limit` /
+  `query.offset` are ignored for an aggregate — an aggregate spans the whole
+  filtered set.
+- **`.resource` is only set in parent-row mode** (`by=QB.resource_id()`); for
+  any other `by` it is `None`.
+
+See the [Query Builder reference](/specstar/reference/query-builder) for the full
+field and operator surface, and the
+[Python API reference](/specstar/reference/python_api) for the generated
+`exp_aggregate_by` / aggregate signatures.

--- a/docs/en/howto/index.md
+++ b/docs/en/howto/index.md
@@ -26,6 +26,7 @@ Use it when you already know what you want to do in SpecStar and need the shorte
 ### Querying and access control
 
 - [Query builder](/specstar/howto/query-builder)
+- [Aggregation and grouping](/specstar/howto/aggregation) — `GROUP BY` with counts / sums / min·max / averages, plus group-level ordering and pagination
 - [Permissions](/specstar/howto/permissions)
 - [Event handlers](/specstar/howto/event-handlers)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ plugins:
                 - howto/audit-user.md
                 - howto/event-handlers.md
                 - howto/query-builder.md
+                - howto/aggregation.md
                 - howto/graphql.md
                 - howto/binary-data.md
                 - howto/vector-search.md

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -776,12 +776,24 @@ class IMetaWithAgg(IMetaStore, ABC):
     ``tests/meta_store/test_aggregate_by.py``.
     """
 
+    #: Whether this store can push the GROUP-level ``order_by`` + ``limit`` /
+    #: ``offset`` (#412) down to its engine. When ``False`` (the default), the
+    #: :class:`ResourceManager` never passes those args — it materialises all
+    #: groups and orders / pages them with its in-process reference reduction.
+    #: A store that implements the engine-side ``ORDER BY … LIMIT … OFFSET``
+    #: overrides this to ``True``; results MUST still equal the reference.
+    supports_group_paging: bool = False
+
     @abstractmethod
     def aggregate_by(
         self,
         query: ResourceMetaSearchQuery,
         by: AggKeyRef,
         aggregates: list[AggSpec],
+        *,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[tuple[object, dict[str, object]]]:
         """Group rows matching ``query`` by ``by`` and reduce each aggregate
         per group, pushed down to the store's engine.
@@ -791,6 +803,20 @@ class IMetaWithAgg(IMetaStore, ABC):
         the ResourceManager's ``iter_all`` semantics. Returns one
         ``(key, {result_name: value})`` per distinct ``by`` value; a missing /
         NULL key groups under ``key=None`` to match the Python reference path.
+
+        **Group-level paging (#412)** — only used when
+        :attr:`supports_group_paging` is ``True`` (else the RM leaves these at
+        their defaults and orders / pages the groups itself):
+
+        * ``order_by`` — a store ``AggSpec.result_name`` or the sentinel
+          ``"key"`` (the group key), with the ``"-name"`` / ``"+name"``
+          direction convention (asc default, ``-`` = desc). The engine MUST
+          order NULL order-values LAST (direction-free) and break ties by the
+          group key ascending (NULLs last) — byte-for-byte the
+          ResourceManager's ``_order_and_page_groups`` reference.
+        * ``limit`` / ``offset`` — page the GROUPS themselves (distinct from the
+          ignored row-level ``query.limit/offset``). Only meaningful with a
+          deterministic ``order_by``.
         """
         ...
 

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -820,6 +820,37 @@ class IMetaWithAgg(IMetaStore, ABC):
         """
         ...
 
+    @staticmethod
+    def _group_order_clause(
+        order_by: str,
+        key_expr: str,
+        aggregates: "list[AggSpec]",
+        agg_expr: "Callable[[AggSpec], str]",
+    ) -> str:
+        """The #412 group-level ``ORDER BY`` shared by every push-down store.
+
+        ``order_by`` is a store ``AggSpec.result_name`` or the ``"key"`` sentinel
+        with the ``+``/``-`` direction convention. NULLS-LAST is spelled with the
+        version-agnostic ``(expr IS NULL) ASC`` prefix (not native ``NULLS
+        LAST``) so SQLite, Postgres, and the in-process reference agree
+        byte-for-byte; the group key is always the ascending secondary sort so
+        pages are stable and never straddle a tie. ``key_expr`` and ``agg_expr``
+        are the engine-specific SQL a concrete store supplies (its group-key
+        expression and its per-aggregate value expression)."""
+        name, descending = order_by, False
+        if name[:1] in ("+", "-"):
+            descending = name[0] == "-"
+            name = name[1:]
+        if name == "key":
+            order_expr = key_expr
+        else:
+            order_expr = agg_expr(next(a for a in aggregates if a.result_name == name))
+        direction = "DESC" if descending else "ASC"
+        return (
+            f" ORDER BY (({order_expr}) IS NULL) ASC, ({order_expr}) {direction}, "
+            f"(({key_expr}) IS NULL) ASC, ({key_expr}) ASC"
+        )
+
 
 class IBlobStore(ABC):
     """Interface for storing and retrieving binary blobs.

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2735,10 +2735,14 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 f"got {type(by).__name__}."
             )
 
-        # 0b) Validate + parse the #412 group-level order/paging up front, so a
-        #     bad order_by target or negative limit/offset raises identically on
-        #     every backend — including the pushed path (which skips the
-        #     in-process _order_and_page_groups that also validates).
+        # 0b) Parse the #412 group order + guard the page bounds up front. The
+        #     negative-bound check MUST be here: on the pushed path a negative
+        #     ``limit`` would otherwise reach the store, where e.g. SQLite reads
+        #     ``LIMIT -1`` as "no limit" instead of raising. An invalid
+        #     ``order_by`` TARGET needs no up-front check — it is never pushable,
+        #     so it always falls through to ``_order_and_page_groups`` below,
+        #     which raises (the single source of that error, covered on every
+        #     backend).
         if offset < 0 or (limit is not None and limit < 0):
             raise ValueError("exp_aggregate_by: offset/limit must be non-negative")
         order_target: "str | None" = None
@@ -2748,11 +2752,6 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             if order_target[:1] in ("+", "-"):
                 order_descending = order_target[0] == "-"
                 order_target = order_target[1:]
-            if order_target != "key" and order_target not in aggregates:
-                raise ValueError(
-                    f"exp_aggregate_by: order_by target {order_target!r} is not "
-                    "an aggregate result-name or 'key'"
-                )
 
         # 1) Split self-aggregates from foreign-aggregates; validate.
         self_aggs: dict[str, Aggregate] = {}
@@ -3003,19 +3002,21 @@ class ResourceManager(IResourceManager[T], Generic[T]):
 
     def _order_and_page_groups(
         self,
-        out: "list[object]",
+        out: "list[Any]",
         aggregates: "dict[str, object]",
         order_by: "str | None",
         limit: "int | None",
         offset: int,
-    ) -> "list[object]":
+    ) -> "list[Any]":
         """#412 in-process reference for group-level ``order_by`` + ``limit`` /
         ``offset``: sort the materialized ``GroupRow``\\ s and slice. Every backend's
         pushed ``ORDER BY … LIMIT … OFFSET`` MUST return the SAME result. NULL
         order-values AND NULL keys sort LAST regardless of direction; the group key
-        is the deterministic secondary sort so pages never straddle on ties."""
-        if offset < 0 or (limit is not None and limit < 0):
-            raise ValueError("exp_aggregate_by: offset/limit must be non-negative")
+        is the deterministic secondary sort so pages never straddle on ties.
+
+        ``offset`` / ``limit`` are already guaranteed non-negative by the caller
+        (``exp_aggregate_by`` validates the page bounds up front, for the pushed
+        path too), so this reference only orders + slices."""
         if order_by is not None:
             name, descending = order_by, False
             if name[:1] in ("+", "-"):

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -10,7 +10,7 @@ import traceback
 import warnings
 from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager, suppress
-from functools import cached_property, wraps
+from functools import cached_property, cmp_to_key, wraps
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -2654,6 +2654,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         by: "object",
         aggregates: "dict[str, object]",
         query: "ResourceMetaSearchQuery | Query | None" = None,
+        *,
+        order_by: "str | None" = None,
+        limit: "int | None" = None,
+        offset: int = 0,
     ) -> "list[object]":
         """Group rows by ``by`` and reduce with the named ``aggregates``.
 
@@ -2925,6 +2929,76 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             out.append(
                 GroupRow(key=key, resource=resource_by_key.get(key), **row_kwargs)
             )
+
+        # 6) Group-level ordering + pagination (#412). ``order_by`` targets an
+        #    aggregate result-name or the sentinel ``"key"`` (the group key), with
+        #    the ``"-name"`` / ``"+name"`` direction convention from ``Query.sort()``
+        #    (asc default, ``-`` = desc). ``limit`` / ``offset`` page the GROUPS —
+        #    distinct from the row-level ``query.limit/offset`` (still ignored for
+        #    aggregates). Applied to the materialized ``GroupRow`` list here — the
+        #    reference semantics every backend, including the store-side ORDER BY /
+        #    LIMIT / OFFSET push-down that follows, MUST match.
+        return self._order_and_page_groups(out, aggregates, order_by, limit, offset)
+
+    def exp_count_groups(
+        self,
+        by: "object",
+        query: "ResourceMetaSearchQuery | Query | None" = None,
+    ) -> int:
+        """The number of DISTINCT groups :meth:`exp_aggregate_by` would return for
+        the same ``by`` + ``query`` — the total a pager needs, independent of any
+        ``limit`` / ``offset``. A missing / UNSET / NULL ``by`` value counts as one
+        group (``key=None``), matching :meth:`exp_aggregate_by`."""
+        from specstar.aggregates import Count
+
+        return len(self.exp_aggregate_by(by, {"__n": Count()}, query=query))
+
+    def _order_and_page_groups(
+        self,
+        out: "list[object]",
+        aggregates: "dict[str, object]",
+        order_by: "str | None",
+        limit: "int | None",
+        offset: int,
+    ) -> "list[object]":
+        """#412 in-process reference for group-level ``order_by`` + ``limit`` /
+        ``offset``: sort the materialized ``GroupRow``\\ s and slice. Every backend's
+        pushed ``ORDER BY … LIMIT … OFFSET`` MUST return the SAME result. NULL
+        order-values AND NULL keys sort LAST regardless of direction; the group key
+        is the deterministic secondary sort so pages never straddle on ties."""
+        if offset < 0 or (limit is not None and limit < 0):
+            raise ValueError("exp_aggregate_by: offset/limit must be non-negative")
+        if order_by is not None:
+            name, descending = order_by, False
+            if name[:1] in ("+", "-"):
+                descending = name[0] == "-"
+                name = name[1:]
+            if name != "key" and name not in aggregates:
+                raise ValueError(
+                    f"exp_aggregate_by: order_by target {name!r} is not an "
+                    "aggregate result-name or 'key'"
+                )
+
+            def _val(r: "Any", _n: str = name) -> "object":
+                return r.key if _n == "key" else r[_n]
+
+            def _cmp(a: "Any", b: "Any") -> int:
+                # Primary: order value by direction, NULLs LAST (direction-free).
+                av, bv = _val(a), _val(b)
+                if av is None or bv is None:
+                    if av is not bv:  # exactly one None → it sorts last
+                        return 1 if av is None else -1
+                elif av != bv:
+                    return (-1 if av < bv else 1) * (-1 if descending else 1)
+                # Secondary: group key ascending, NULLs LAST (stable tiebreak).
+                ak, bk = a.key, b.key
+                if ak is None or bk is None:
+                    return 0 if ak is bk else (1 if ak is None else -1)
+                return 0 if ak == bk else (-1 if ak < bk else 1)
+
+            out.sort(key=cmp_to_key(_cmp))
+        if offset or limit is not None:
+            out = out[offset : None if limit is None else offset + limit]
         return out
 
     #: ResourceMeta datetime attributes eligible for Min/Max push-down. They are

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2735,6 +2735,25 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 f"got {type(by).__name__}."
             )
 
+        # 0b) Validate + parse the #412 group-level order/paging up front, so a
+        #     bad order_by target or negative limit/offset raises identically on
+        #     every backend — including the pushed path (which skips the
+        #     in-process _order_and_page_groups that also validates).
+        if offset < 0 or (limit is not None and limit < 0):
+            raise ValueError("exp_aggregate_by: offset/limit must be non-negative")
+        order_target: "str | None" = None
+        order_descending = False
+        if order_by is not None:
+            order_target = order_by
+            if order_target[:1] in ("+", "-"):
+                order_descending = order_target[0] == "-"
+                order_target = order_target[1:]
+            if order_target != "key" and order_target not in aggregates:
+                raise ValueError(
+                    f"exp_aggregate_by: order_by target {order_target!r} is not "
+                    "an aggregate result-name or 'key'"
+                )
+
         # 1) Split self-aggregates from foreign-aggregates; validate.
         self_aggs: dict[str, Aggregate] = {}
         foreign_aggs: dict[str, ForeignAggregate] = {}
@@ -2818,6 +2837,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         groups: dict[object, dict[str, object]] = {}
         resource_by_key: dict[object, object] = {}
         per_row_mode = by.name == "resource_id" and by.source == "meta"
+        # Set only when the store's engine did the group ORDER BY / LIMIT /
+        # OFFSET (#412) — then step 6 returns ``out`` as-is instead of
+        # re-ordering + re-slicing it (which would double-apply the offset).
+        did_page = False
 
         if per_row_mode:
             parents = self.list_resources(query)
@@ -2850,6 +2873,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             )
             store_specs: list[AggSpec] = []
             to_state: dict[str, "Callable[[dict[str, object]], object]"] = {}
+            # Result-names an engine ORDER BY can target: those whose push-down
+            # plan is exactly ONE store column named after the caller name
+            # (Count / Sum / Min / Max — incl. datetime Min/Max). Avg decomposes
+            # into two columns, so ordering by it stays on the Python path.
+            single_col_aggs: set[str] = set()
             if pushable:
                 for n, a in self_aggs.items():
                     plan = self._agg_pushdown_plan(n, a)
@@ -2859,6 +2887,8 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     specs, make_state = plan
                     store_specs.extend(specs)
                     to_state[n] = make_state
+                    if len(specs) == 1 and specs[0].result_name == n:
+                        single_col_aggs.add(n)
             if pushable:
                 # ``pushable`` already required ``isinstance(ms, IMetaWithAgg)``;
                 # re-assert so the type checker narrows ``ms`` for aggregate_by.
@@ -2872,6 +2902,18 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     q = query.build()
                 else:
                     q = query
+                # #412: push the group-level ORDER BY / LIMIT / OFFSET too, but
+                # only when the store advertises the capability AND the order
+                # target is engine-orderable (the group key, or a single-column
+                # aggregate). Anything else — an Avg / ForeignAggregate / non-
+                # paging store — keeps the in-process reorder over all groups.
+                store_order: "str | None" = None
+                if order_target is not None and getattr(
+                    ms, "supports_group_paging", False
+                ):
+                    if order_target == "key" or order_target in single_col_aggs:
+                        store_order = ("-" if order_descending else "") + order_target
+                did_page = store_order is not None
                 rows = ms.aggregate_by(
                     q,
                     # ``by.source`` is narrowed to meta/data by the guard above;
@@ -2880,6 +2922,9 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                         source=cast(Literal["meta", "data"], by.source), name=by.name
                     ),
                     store_specs,
+                    order_by=store_order,
+                    limit=limit if did_page else None,
+                    offset=offset if did_page else 0,
                 )
                 groups = {
                     key: {n: to_state[n](state) for n in self_aggs}
@@ -2935,9 +2980,12 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         #    the ``"-name"`` / ``"+name"`` direction convention from ``Query.sort()``
         #    (asc default, ``-`` = desc). ``limit`` / ``offset`` page the GROUPS —
         #    distinct from the row-level ``query.limit/offset`` (still ignored for
-        #    aggregates). Applied to the materialized ``GroupRow`` list here — the
-        #    reference semantics every backend, including the store-side ORDER BY /
-        #    LIMIT / OFFSET push-down that follows, MUST match.
+        #    aggregates). When the store's engine already did the ORDER BY / LIMIT /
+        #    OFFSET (``did_page``), ``out`` IS the requested page — return it as-is.
+        #    Otherwise this in-process reference orders + slices the materialized
+        #    ``GroupRow`` list, and every pushed-down path MUST match it.
+        if did_page:
+            return out
         return self._order_and_page_groups(out, aggregates, order_by, limit, offset)
 
     def exp_count_groups(

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -799,6 +799,9 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             for row in cur:
                 yield self._serializer.decode(row["data"])
 
+    #: Postgres pushes the #412 group-level ORDER BY / LIMIT / OFFSET (below).
+    supports_group_paging = True
+
     def aggregate_by(
         self,
         query: ResourceMetaSearchQuery,
@@ -816,20 +819,15 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         ``indexed_data->>'field'`` (JSONB text) for ``source="data"`` (a missing
         field yields SQL ``NULL`` → ``None``, matching the Python path). The
         ``WHERE`` is built by the SAME :meth:`_build_where` as
-        :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
-        aggregate spans the whole filtered set.
+        :meth:`iter_search`, and NO row-level ``LIMIT``/``OFFSET`` is applied —
+        an aggregate spans the whole filtered set.
 
-        ``order_by`` / ``limit`` / ``offset`` (#412 group paging) are accepted
-        for interface parity but NOT yet honoured here — :attr:`supports_group_paging`
-        stays ``False`` on Postgres, so the ResourceManager leaves them at their
-        defaults and orders / pages the groups with its in-process reference.
-        Phase 3 pushes them into the engine and flips the flag.
+        When ``order_by`` is given (#412), the engine also orders and pages the
+        GROUPS: NULL order-values LAST (direction-free), then the group key
+        ascending (NULLs last) as the stable tiebreak, then ``LIMIT``/``OFFSET``
+        over those ordered groups — byte-for-byte the ResourceManager's
+        ``_order_and_page_groups`` reference (and identical to SQLite's push).
         """
-        assert order_by is None and limit is None and offset == 0, (
-            "PostgresMetaStore.aggregate_by does not yet push group paging "
-            "(supports_group_paging is False); the ResourceManager must not "
-            "pass order_by/limit/offset until Phase 3 implements them."
-        )
         # Push-down ops: Count + numeric Sum/Min/Max (Avg is decomposed by the
         # ResourceManager into Sum+Count and never reaches a store). The RM's
         # dispatch predicate only sends eligible specs, so the assert is a
@@ -849,12 +847,43 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             f"SELECT {key_expr} AS k, {select_aggs} "
             f'FROM "{self.table_name}" {where_clause} GROUP BY {key_expr}'
         )
+        if order_by is not None:
+            sql += self._group_order_clause(order_by, key_expr, aggregates)
+            if limit is not None or offset:
+                # Postgres: ``LIMIT NULL`` = no limit (offset still applies).
+                sql += " LIMIT %s OFFSET %s"
+                params = [*params, limit, offset]
         with self.stream_cursor() as cur:
             cur.execute(sql, params)
             return [
                 (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
                 for row in cur
             ]
+
+    def _group_order_clause(
+        self, order_by: str, key_expr: str, aggregates: list[AggSpec]
+    ) -> str:
+        """The ``ORDER BY`` for #412 group paging — the Postgres twin of
+        :meth:`SqliteMetaStore._group_order_clause`. ``order_by`` is a store
+        ``result_name`` or ``"key"`` with the ``+``/``-`` direction convention.
+        NULLS-LAST is spelled with the version-agnostic ``(expr IS NULL) ASC``
+        prefix (not native ``NULLS LAST``) so the ordering is byte-for-byte the
+        SQLite push and the in-process reference; the group key is always the
+        ascending secondary sort so pages are stable and never straddle a tie."""
+        name, descending = order_by, False
+        if name[:1] in ("+", "-"):
+            descending = name[0] == "-"
+            name = name[1:]
+        if name == "key":
+            order_expr = key_expr
+        else:
+            spec = next(a for a in aggregates if a.result_name == name)
+            order_expr = self._agg_expr(spec)
+        direction = "DESC" if descending else "ASC"
+        return (
+            f" ORDER BY (({order_expr}) IS NULL) ASC, ({order_expr}) {direction}, "
+            f"(({key_expr}) IS NULL) ASC, ({key_expr}) ASC"
+        )
 
     def _agg_expr(self, a: AggSpec) -> str:
         """SQL for one aggregate's value (not the GROUP BY key). A field-less

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -804,6 +804,10 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         query: ResourceMetaSearchQuery,
         by: AggKeyRef,
         aggregates: list[AggSpec],
+        *,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[tuple[object, dict[str, object]]]:
         """Push a ``Count`` group-by down to PostgreSQL — ``GROUP BY`` over the
         filtered set, never materialising one row per match.
@@ -814,7 +818,18 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         ``WHERE`` is built by the SAME :meth:`_build_where` as
         :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
         aggregate spans the whole filtered set.
+
+        ``order_by`` / ``limit`` / ``offset`` (#412 group paging) are accepted
+        for interface parity but NOT yet honoured here — :attr:`supports_group_paging`
+        stays ``False`` on Postgres, so the ResourceManager leaves them at their
+        defaults and orders / pages the groups with its in-process reference.
+        Phase 3 pushes them into the engine and flips the flag.
         """
+        assert order_by is None and limit is None and offset == 0, (
+            "PostgresMetaStore.aggregate_by does not yet push group paging "
+            "(supports_group_paging is False); the ResourceManager must not "
+            "pass order_by/limit/offset until Phase 3 implements them."
+        )
         # Push-down ops: Count + numeric Sum/Min/Max (Avg is decomposed by the
         # ResourceManager into Sum+Count and never reaches a store). The RM's
         # dispatch predicate only sends eligible specs, so the assert is a

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -848,7 +848,12 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             f'FROM "{self.table_name}" {where_clause} GROUP BY {key_expr}'
         )
         if order_by is not None:
-            sql += self._group_order_clause(order_by, key_expr, aggregates)
+            # Shared NULLS-LAST + key-tiebreak ORDER BY (IMetaWithAgg) — the same
+            # builder SQLite uses, fed this store's key + per-aggregate SQL, so
+            # the two backends order byte-for-byte identically.
+            sql += self._group_order_clause(
+                order_by, key_expr, aggregates, self._agg_expr
+            )
             if limit is not None or offset:
                 # Postgres: ``LIMIT NULL`` = no limit (offset still applies).
                 sql += " LIMIT %s OFFSET %s"
@@ -859,31 +864,6 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
                 (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
                 for row in cur
             ]
-
-    def _group_order_clause(
-        self, order_by: str, key_expr: str, aggregates: list[AggSpec]
-    ) -> str:
-        """The ``ORDER BY`` for #412 group paging — the Postgres twin of
-        :meth:`SqliteMetaStore._group_order_clause`. ``order_by`` is a store
-        ``result_name`` or ``"key"`` with the ``+``/``-`` direction convention.
-        NULLS-LAST is spelled with the version-agnostic ``(expr IS NULL) ASC``
-        prefix (not native ``NULLS LAST``) so the ordering is byte-for-byte the
-        SQLite push and the in-process reference; the group key is always the
-        ascending secondary sort so pages are stable and never straddle a tie."""
-        name, descending = order_by, False
-        if name[:1] in ("+", "-"):
-            descending = name[0] == "-"
-            name = name[1:]
-        if name == "key":
-            order_expr = key_expr
-        else:
-            spec = next(a for a in aggregates if a.result_name == name)
-            order_expr = self._agg_expr(spec)
-        direction = "DESC" if descending else "ASC"
-        return (
-            f" ORDER BY (({order_expr}) IS NULL) ASC, ({order_expr}) {direction}, "
-            f"(({key_expr}) IS NULL) ASC, ({key_expr}) ASC"
-        )
 
     def _agg_expr(self, a: AggSpec) -> str:
         """SQL for one aggregate's value (not the GROUP BY key). A field-less

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -448,7 +448,11 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
             f"FROM resource_meta {where_clause} GROUP BY {key_expr}"
         )
         if order_by is not None:
-            sql += self._group_order_clause(order_by, key_expr, aggregates)
+            # Shared NULLS-LAST + key-tiebreak ORDER BY (IMetaWithAgg), fed this
+            # store's key + per-aggregate SQL expressions.
+            sql += self._group_order_clause(
+                order_by, key_expr, aggregates, self._agg_expr
+            )
             if limit is not None or offset:
                 # SQLite: LIMIT -1 = "no limit" (offset still applies).
                 sql += " LIMIT ? OFFSET ?"
@@ -458,29 +462,6 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
             (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
             for row in cursor
         ]
-
-    def _group_order_clause(
-        self, order_by: str, key_expr: str, aggregates: list[AggSpec]
-    ) -> str:
-        """The ``ORDER BY`` for #412 group paging. ``order_by`` is a store
-        ``result_name`` or ``"key"`` with the ``+``/``-`` direction convention.
-        NULLS-LAST is spelled with the version-agnostic ``(expr IS NULL) ASC``
-        prefix; the group key is always the ascending secondary sort so pages
-        are stable and never straddle a tie."""
-        name, descending = order_by, False
-        if name[:1] in ("+", "-"):
-            descending = name[0] == "-"
-            name = name[1:]
-        if name == "key":
-            order_expr = key_expr
-        else:
-            spec = next(a for a in aggregates if a.result_name == name)
-            order_expr = self._agg_expr(spec)
-        direction = "DESC" if descending else "ASC"
-        return (
-            f" ORDER BY (({order_expr}) IS NULL) ASC, ({order_expr}) {direction}, "
-            f"(({key_expr}) IS NULL) ASC, ({key_expr}) ASC"
-        )
 
     def _agg_expr(self, a: AggSpec) -> str:
         """SQL for one aggregate's value (not the GROUP BY key). ``Count``

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -399,11 +399,18 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
         for row in cursor:
             yield self._serializer.decode(row[0])
 
+    #: SQLite pushes the #412 group-level ORDER BY / LIMIT / OFFSET (below).
+    supports_group_paging = True
+
     def aggregate_by(
         self,
         query: ResourceMetaSearchQuery,
         by: AggKeyRef,
         aggregates: list[AggSpec],
+        *,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[tuple[object, dict[str, object]]]:
         """Push a ``Count`` group-by down to SQLite — ``GROUP BY`` over the
         filtered set, never materialising one row per match.
@@ -412,8 +419,14 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
         ``json_extract`` of ``indexed_data`` for ``source="data"`` (a missing
         field yields SQL ``NULL`` → ``None``, matching the Python path). The
         ``WHERE`` is built by the SAME :meth:`_build_where` as
-        :meth:`iter_search`, and NO ``LIMIT``/``OFFSET`` is applied — an
-        aggregate spans the whole filtered set.
+        :meth:`iter_search`, and NO row-level ``LIMIT``/``OFFSET`` is applied —
+        an aggregate spans the whole filtered set.
+
+        When ``order_by`` is given (#412), the engine also orders and pages the
+        GROUPS: NULL order-values LAST (direction-free), then the group key
+        ascending (NULLs last) as the stable tiebreak, then ``LIMIT``/``OFFSET``
+        over those ordered groups — byte-for-byte the ResourceManager's
+        ``_order_and_page_groups`` reference.
         """
         # Push-down ops: Count + numeric Sum/Min/Max (Avg is decomposed by the
         # ResourceManager into Sum+Count and never reaches a store). The RM's
@@ -434,11 +447,40 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
             f"SELECT {key_expr} AS k, {select_aggs} "
             f"FROM resource_meta {where_clause} GROUP BY {key_expr}"
         )
+        if order_by is not None:
+            sql += self._group_order_clause(order_by, key_expr, aggregates)
+            if limit is not None or offset:
+                # SQLite: LIMIT -1 = "no limit" (offset still applies).
+                sql += " LIMIT ? OFFSET ?"
+                params = [*params, -1 if limit is None else limit, offset]
         cursor = self._conns[threading.get_ident()].execute(sql, params)
         return [
             (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
             for row in cursor
         ]
+
+    def _group_order_clause(
+        self, order_by: str, key_expr: str, aggregates: list[AggSpec]
+    ) -> str:
+        """The ``ORDER BY`` for #412 group paging. ``order_by`` is a store
+        ``result_name`` or ``"key"`` with the ``+``/``-`` direction convention.
+        NULLS-LAST is spelled with the version-agnostic ``(expr IS NULL) ASC``
+        prefix; the group key is always the ascending secondary sort so pages
+        are stable and never straddle a tie."""
+        name, descending = order_by, False
+        if name[:1] in ("+", "-"):
+            descending = name[0] == "-"
+            name = name[1:]
+        if name == "key":
+            order_expr = key_expr
+        else:
+            spec = next(a for a in aggregates if a.result_name == name)
+            order_expr = self._agg_expr(spec)
+        direction = "DESC" if descending else "ASC"
+        return (
+            f" ORDER BY (({order_expr}) IS NULL) ASC, ({order_expr}) {direction}, "
+            f"(({key_expr}) IS NULL) ASC, ({key_expr}) ASC"
+        )
 
     def _agg_expr(self, a: AggSpec) -> str:
         """SQL for one aggregate's value (not the GROUP BY key). ``Count``

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -337,6 +337,52 @@ def test_reducers_are_pushed_down_not_iterated(meta_store_type):
     )
 
 
+@pytest.mark.parametrize("meta_store_type", ["sql3-mem"])
+def test_order_and_page_pushed_to_store_not_sliced_in_python(meta_store_type):
+    """#412 Phase 2 — on a group-paging backend the engine does the group-level
+    ``ORDER BY … LIMIT … OFFSET``: the store's ``aggregate_by`` returns ONLY the
+    requested page, not every group for the ResourceManager to slice in Python.
+    Spying on the store proves the page (not the full group set) crossed the
+    boundary — the same fast-path proof as ``*_is_pushed_down_not_iterated``,
+    one level down."""
+    meta_store = get_meta_store(meta_store_type)
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    mgr = ResourceManager(
+        Rec,
+        storage=storage,
+        name="rec",
+        default_user="t",
+        indexed_fields=[
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+        ],
+    )
+    for b in ("a", "b", "c", "d", "e"):
+        mgr.create(Rec(bucket=b, size=1, score=0.0))
+
+    seen: dict[str, int] = {}
+    orig = meta_store.aggregate_by
+
+    def spy(*a, **k):
+        rows = orig(*a, **k)
+        seen["n"] = len(rows)
+        return rows
+
+    meta_store.aggregate_by = spy
+    page = mgr.exp_aggregate_by(
+        QB["bucket"], {"n": Count()}, order_by="key", offset=1, limit=2
+    )
+
+    assert [r.key for r in page] == ["b", "c"]
+    assert seen.get("n") == 2, (
+        f"store returned {seen.get('n')} groups on {meta_store_type} — "
+        "ORDER BY / LIMIT / OFFSET not pushed to the engine"
+    )
+
+
 @pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
 class TestAggregateByOrderAndPaginate:
     """#412 — group-level ``order_by`` + ``limit`` / ``offset`` + ``exp_count_groups``.

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -132,6 +132,13 @@ class Rec(msgspec.Struct):
     score: float
 
 
+class Opt(msgspec.Struct):
+    # a nullable group field — some rows collapse to the key=None group (#412 NULL last).
+    # str (not int) on purpose: int group-keys have an orthogonal cross-backend type
+    # divergence (Postgres returns them as strings); #511 groups by a str cluster_key.
+    val: str | None = None
+
+
 @pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
 class TestAggregateByReducerParity:
     """#406 — Sum/Min/Max/Avg (+ datetime Min/Max) must return IDENTICAL
@@ -328,6 +335,149 @@ def test_reducers_are_pushed_down_not_iterated(meta_store_type):
     assert called is False, (
         f"exp_aggregate_by walked iter_all on {meta_store_type} — reducers not pushed"
     )
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestAggregateByOrderAndPaginate:
+    """#412 — group-level ``order_by`` + ``limit`` / ``offset`` + ``exp_count_groups``.
+    The SAME ordered+paginated groups on every backend, whether the sort/page pushes
+    down to the engine or falls back to the in-process reference reduction."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self._meta_store_type = meta_store_type
+        self._tmpdir = my_tmpdir
+        yield
+
+    def _mgr(self):
+        meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        return ResourceManager(
+            Rec,
+            storage=storage,
+            name="rec",
+            default_user="t",
+            indexed_fields=[
+                IndexableField(field_path="bucket", field_type=str),
+                IndexableField(field_path="size", field_type=int),
+            ],
+        )
+
+    def _seed(self, mgr, rows):
+        """rows = [(bucket, size), ...]."""
+        for bucket, size in rows:
+            mgr.create(Rec(bucket=bucket, size=size, score=0.0))
+
+    def test_order_by_aggregate_desc_with_limit_pages_the_groups(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        # group counts: a=3, b=1, c=2 → desc-by-count order is a, c, b
+        self._seed(mgr, [("a", 1), ("a", 1), ("a", 1), ("b", 1), ("c", 1), ("c", 1)])
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="-n", limit=2
+        )
+        assert [(r.key, r.n) for r in rows] == [("a", 3), ("c", 2)]
+
+    def test_order_by_group_key_ascending_and_descending(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("b", 1), ("a", 1), ("c", 1)])
+        asc = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="key")
+        desc = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="-key")
+        assert [r.key for r in asc] == ["a", "b", "c"]
+        assert [r.key for r in desc] == ["c", "b", "a"]
+
+    def test_order_by_a_value_reducer_the_511_shape(self):
+        # #511 pages concepts by their newest member: order_by a Max reducer, desc.
+        from specstar.aggregates import Max
+
+        mgr = self._mgr()
+        # per-bucket max size: a=9, b=2, c=5 → desc order a, c, b
+        self._seed(mgr, [("a", 1), ("a", 9), ("b", 2), ("c", 5), ("c", 3)])
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"hi": Max(QB["size"])}, order_by="-hi"
+        )
+        assert [(r.key, r.hi) for r in rows] == [("a", 9), ("c", 5), ("b", 2)]
+
+    def test_offset_pages_past_the_first_groups(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 1), ("b", 1), ("c", 1), ("d", 1)])
+        page = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", offset=1, limit=2
+        )
+        assert [r.key for r in page] == ["b", "c"]
+
+    def test_ties_break_by_group_key_so_pages_are_stable(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        # every group has count 1 → the order_by target ties; key asc is the tiebreak
+        self._seed(mgr, [("c", 1), ("a", 1), ("b", 1), ("d", 1)])
+        p1 = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="-n", limit=2)
+        p2 = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="-n", offset=2, limit=2
+        )
+        assert [r.key for r in p1] == ["a", "b"]  # tie → key asc
+        assert [r.key for r in p2] == ["c", "d"]  # next page, no overlap/gap
+
+    def test_null_group_key_sorts_last_in_both_directions(self):
+        from specstar.aggregates import Count
+
+        meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        mgr = ResourceManager(
+            Opt,
+            storage=storage,
+            name="opt",
+            default_user="t",
+            indexed_fields=[IndexableField(field_path="val", field_type=str)],
+        )
+        for v in ("a", "a", "b", None, None):
+            mgr.create(Opt(val=v))
+        asc = mgr.exp_aggregate_by(QB["val"], {"n": Count()}, order_by="key")
+        desc = mgr.exp_aggregate_by(QB["val"], {"n": Count()}, order_by="-key")
+        assert [r.key for r in asc] == ["a", "b", None]  # NULL last on asc
+        assert [r.key for r in desc] == ["b", "a", None]  # NULL still last on desc
+
+    def test_exp_count_groups_is_the_total_independent_of_limit_offset(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 1), ("b", 1), ("c", 1)])
+        # a limited page returns fewer rows, but the pager total counts all groups
+        page = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", limit=1
+        )
+        assert len(page) == 1
+        assert mgr.exp_count_groups(QB["bucket"]) == 3
+
+    def test_bad_order_by_target_raises(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 1)])
+        with pytest.raises(ValueError, match="order_by target"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="nope")
+
+    def test_negative_offset_or_limit_raises(self):
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 1)])
+        with pytest.raises(ValueError, match="non-negative"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, offset=-1)
+        with pytest.raises(ValueError, match="non-negative"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, limit=-1)
 
 
 @pytest.fixture

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -337,11 +337,12 @@ def test_reducers_are_pushed_down_not_iterated(meta_store_type):
     )
 
 
-@pytest.mark.parametrize("meta_store_type", ["sql3-mem"])
+@pytest.mark.parametrize("meta_store_type", ["sql3-mem", "postgres"])
 def test_order_and_page_pushed_to_store_not_sliced_in_python(meta_store_type):
-    """#412 Phase 2 — on a group-paging backend the engine does the group-level
-    ``ORDER BY … LIMIT … OFFSET``: the store's ``aggregate_by`` returns ONLY the
-    requested page, not every group for the ResourceManager to slice in Python.
+    """#412 — on a group-paging backend (SQLite + Postgres) the engine does the
+    group-level ``ORDER BY … LIMIT … OFFSET``: the store's ``aggregate_by``
+    returns ONLY the requested page, not every group for the ResourceManager to
+    slice in Python.
     Spying on the store proves the page (not the full group set) crossed the
     boundary — the same fast-path proof as ``*_is_pushed_down_not_iterated``,
     one level down."""

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -461,6 +461,19 @@ class TestAggregateByOrderAndPaginate:
         )
         assert [r.key for r in page] == ["b", "c"]
 
+    def test_offset_without_limit_returns_the_rest_ordered(self):
+        # order_by + offset but NO limit: every group past the offset, ordered.
+        # Exercises the push-down "no limit" branch (SQLite LIMIT -1 / Postgres
+        # LIMIT NULL) as well as the in-process reference.
+        from specstar.aggregates import Count
+
+        mgr = self._mgr()
+        self._seed(mgr, [("a", 1), ("b", 1), ("c", 1), ("d", 1)])
+        rest = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", offset=2
+        )
+        assert [r.key for r in rest] == ["c", "d"]
+
     def test_ties_break_by_group_key_so_pages_are_stable(self):
         from specstar.aggregates import Count
 

--- a/tests/test_agg_pushdown.py
+++ b/tests/test_agg_pushdown.py
@@ -12,10 +12,12 @@ Python path instead of pushing an incorrect result.
 """
 
 import msgspec
+import pytest
 
 from specstar.aggregates import Avg, Count, ForeignAggregate, Max, Min, Sum
 from specstar.query import QB
 from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
 from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
 from specstar.resource_manager.resource_store.simple import MemoryResourceStore
 from specstar.types import IndexableField
@@ -263,3 +265,204 @@ def test_foreign_aggregate_parent_with_no_children_gets_zero_and_none():
     )
     got = {r.key: (r.n, r.size_total) for r in rows}
     assert got == {empty: (0, None)}
+
+
+# --- #412: group-level order_by + limit/offset + exp_count_groups -----------
+#
+# The cross-backend parity contract (incl. real Postgres) lives in
+# tests/meta_store/test_aggregate_by.py, which is integration-only and excluded
+# from the fast CI job. These service-free copies (in-process MemoryMetaStore +
+# in-memory MemorySqliteMetaStore) keep the ordering/pagination logic — both the
+# in-process reference and the SQLite ORDER BY / LIMIT / OFFSET push-down —
+# covered in the fast job.
+
+
+def _grp_mgr(kind, *, struct=Item, indexed=None):
+    """A manager over ``memory`` (no IMetaWithAgg → in-process order/page) or
+    ``sqlite`` (IMetaWithAgg → engine ORDER BY/LIMIT/OFFSET). Returns
+    ``(manager, meta_store)`` so a test can spy the store."""
+    meta_store = (
+        MemoryMetaStore(encoding="msgpack")
+        if kind == "memory"
+        else MemorySqliteMetaStore(encoding="msgpack")
+    )
+    if indexed is None:
+        indexed = [
+            IndexableField(field_path="bucket", field_type=str),
+            IndexableField(field_path="size", field_type=int),
+            IndexableField(field_path="score", field_type=float),
+        ]
+    storage = SimpleStorage(
+        meta_store=meta_store,
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    mgr = ResourceManager(
+        struct, storage=storage, name="item", default_user="t", indexed_fields=indexed
+    )
+    return mgr, meta_store
+
+
+@pytest.mark.parametrize("kind", ["memory", "sqlite"])
+class TestGroupOrderAndPaginate:
+    def test_order_by_aggregate_desc_with_limit(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        # counts a=3, b=1, c=2 → desc-by-count is a, c, b
+        _seed(
+            mgr,
+            [("a", 1, 0.0)] * 3 + [("b", 1, 0.0)] + [("c", 1, 0.0)] * 2,
+        )
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="-n", limit=2
+        )
+        assert [(r.key, r.n) for r in rows] == [("a", 3), ("c", 2)]
+
+    def test_order_by_group_key_ascending_and_descending(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [("b", 1, 0.0), ("a", 1, 0.0), ("c", 1, 0.0)])
+        asc = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="key")
+        desc = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="-key")
+        assert [r.key for r in asc] == ["a", "b", "c"]
+        assert [r.key for r in desc] == ["c", "b", "a"]
+
+    def test_order_by_a_value_reducer(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        # per-bucket max size a=9, b=2, c=5 → desc a, c, b
+        _seed(mgr, [("a", 1, 0.0), ("a", 9, 0.0), ("b", 2, 0.0), ("c", 5, 0.0)])
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"hi": Max(QB["size"])}, order_by="-hi"
+        )
+        assert [(r.key, r.hi) for r in rows] == [("a", 9), ("c", 5), ("b", 2)]
+
+    def test_offset_pages_past_the_first_groups(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [(b, 1, 0.0) for b in ("a", "b", "c", "d")])
+        page = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", offset=1, limit=2
+        )
+        assert [r.key for r in page] == ["b", "c"]
+
+    def test_offset_without_limit_returns_the_rest(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [(b, 1, 0.0) for b in ("a", "b", "c", "d")])
+        rest = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", offset=2
+        )
+        assert [r.key for r in rest] == ["c", "d"]
+
+    def test_ties_break_by_group_key_so_pages_are_stable(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [(b, 1, 0.0) for b in ("c", "a", "b", "d")])
+        p1 = mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="-n", limit=2)
+        p2 = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="-n", offset=2, limit=2
+        )
+        assert [r.key for r in p1] == ["a", "b"]
+        assert [r.key for r in p2] == ["c", "d"]
+
+    def test_null_group_key_sorts_last_in_both_directions(self, kind):
+        mgr, _ = _grp_mgr(
+            kind,
+            struct=_OptItem,
+            indexed=[IndexableField(field_path="val", field_type=str)],
+        )
+        for v in ("a", "a", "b", None, None):
+            mgr.create(_OptItem(val=v))
+        asc = mgr.exp_aggregate_by(QB["val"], {"n": Count()}, order_by="key")
+        desc = mgr.exp_aggregate_by(QB["val"], {"n": Count()}, order_by="-key")
+        assert [r.key for r in asc] == ["a", "b", None]
+        assert [r.key for r in desc] == ["b", "a", None]
+
+    def test_exp_count_groups_independent_of_limit_offset(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [(b, 1, 0.0) for b in ("a", "b", "c")])
+        page = mgr.exp_aggregate_by(
+            QB["bucket"], {"n": Count()}, order_by="key", limit=1
+        )
+        assert len(page) == 1
+        assert mgr.exp_count_groups(QB["bucket"]) == 3
+
+    def test_bad_order_by_target_raises(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [("a", 1, 0.0)])
+        with pytest.raises(ValueError, match="order_by target"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, order_by="nope")
+
+    def test_negative_offset_or_limit_raises(self, kind):
+        mgr, _ = _grp_mgr(kind)
+        _seed(mgr, [("a", 1, 0.0)])
+        with pytest.raises(ValueError, match="non-negative"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, offset=-1)
+        with pytest.raises(ValueError, match="non-negative"):
+            mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, limit=-1)
+
+
+class _OptItem(msgspec.Struct):
+    val: str | None = None
+
+
+class _TwoField(msgspec.Struct):
+    grp: str | None = None
+    num: int | None = None
+
+
+def test_in_process_tiebreak_falls_to_key_when_primary_values_are_all_none():
+    # Memory backend → the in-process _order_and_page_groups reference. Every
+    # group's order-value is None (Max over an all-None field), so the primary
+    # sort ties and falls to the group-key tiebreak — which orders the real keys
+    # ascending and still puts the None key last.
+    mgr, _ = _grp_mgr(
+        "memory",
+        struct=_TwoField,
+        indexed=[
+            IndexableField(field_path="grp", field_type=str),
+            IndexableField(field_path="num", field_type=int),
+        ],
+    )
+    for grp in ("y", "x", None):
+        mgr.create(_TwoField(grp=grp, num=None))
+    rows = mgr.exp_aggregate_by(QB["grp"], {"hi": Max(QB["num"])}, order_by="-hi")
+    assert [r.key for r in rows] == ["x", "y", None]
+    assert all(r.hi is None for r in rows)
+
+
+def _spy_store_rows(meta_store, sink):
+    orig = meta_store.aggregate_by
+
+    def spy(*a, **k):
+        rows = orig(*a, **k)
+        sink["n"] = len(rows)
+        return rows
+
+    meta_store.aggregate_by = spy
+
+
+def test_order_and_page_pushed_to_sqlite_engine_returns_only_the_page():
+    # The SQLite engine does ORDER BY / LIMIT / OFFSET: aggregate_by returns
+    # ONLY the page, not every group for the RM to slice in Python.
+    mgr, ms = _grp_mgr("sqlite")
+    _seed(mgr, [(b, 1, 0.0) for b in ("a", "b", "c", "d", "e")])
+    seen = {}
+    _spy_store_rows(ms, seen)
+    page = mgr.exp_aggregate_by(
+        QB["bucket"], {"n": Count()}, order_by="key", offset=1, limit=2
+    )
+    assert [r.key for r in page] == ["b", "c"]
+    assert seen.get("n") == 2, f"store returned {seen.get('n')} groups, not the page"
+
+
+def test_avg_order_target_falls_back_to_in_process_even_on_sqlite():
+    # Avg decomposes into Sum+Count (two columns), so it is NOT an engine ORDER
+    # BY target: the value still pushes down (iter_all not walked), but the
+    # store returns ALL groups and the RM orders them in-process.
+    mgr, ms = _grp_mgr("sqlite")
+    # per-bucket avg size a=2.0, b=5.0, c=8.0 → desc c, b, a
+    _seed(mgr, [("a", 1, 0.0), ("a", 3, 0.0), ("b", 5, 0.0), ("c", 8, 0.0)])
+    seen = {}
+    with _IterSpy(mgr) as spy:
+        _spy_store_rows(ms, seen)
+        rows = mgr.exp_aggregate_by(
+            QB["bucket"], {"mean": Avg(QB["size"])}, order_by="-mean", limit=2
+        )
+    assert [r.key for r in rows] == ["c", "b"]  # ordered in-process, then sliced
+    assert spy.walked is False, "Avg value did not push down — walked iter_all"
+    assert seen.get("n") == 3, "store paged an Avg order — must return all groups"


### PR DESCRIPTION
Closes #412.

## What

`exp_aggregate_by` could only return **all** groups, **unordered**. This adds
group-level ordering + pagination so a consumer can page the *distinct groups*
themselves — and pushes the whole `ORDER BY … LIMIT … OFFSET` down to the
SQLite and Postgres engines.

```python
rm.exp_aggregate_by(
    QB["cluster_key"],
    {"n": Count(), "latest": Max(QB.created_time())},
    query=...,
    order_by="-latest",   # aggregate result-name or the "key" sentinel; +/- direction
    offset=o, limit=n,     # page the GROUPS (not the row-level query.limit/offset)
)
rm.exp_count_groups(QB["cluster_key"], query=...)   # pager total, independent of limit/offset
```

## Semantics (identical on every backend)

- **Order target** — an aggregate `result_name` or the `"key"` sentinel (the
  group key), with the `Query.sort()` `"-name"` / `"+name"` convention (asc
  default, `-` = desc). A target that is neither an aggregate name nor `"key"`
  raises `ValueError`; negative `offset`/`limit` raises. Both are validated
  up front so they raise identically on the pushed and in-process paths.
- **NULLS LAST** — NULL order-values *and* NULL group keys sort last regardless
  of direction, via the version-agnostic `(expr IS NULL) ASC` prefix (not native
  `NULLS LAST`), so SQLite, Postgres and the in-process reference agree byte-for-byte.
- **Stable pages** — the group key is always the ascending secondary sort, so
  pages never straddle or duplicate on a tie.

## Push-down vs fallback

- The in-process `_order_and_page_groups` is the **cross-backend correctness
  reference** — memory / disk always use it.
- SQLite & Postgres (`supports_group_paging = True`) push the ORDER BY / LIMIT /
  OFFSET into the engine when the order target is **engine-orderable**: the
  group key, or a single-column self-aggregate (Count / Sum / Min / Max, incl.
  datetime Min/Max). An **Avg** (decomposes into Sum + Count) or a
  **ForeignAggregate** order target falls back to the in-process reference over
  all groups — still byte-parity.
- The value-level reduction (Count/Sum/Min/Max/Avg) already pushed down (#406);
  this PR adds only the group-level order + page on top.

## Phases

1. In-process reference + `exp_count_groups` (`6075f01`)
2. SQLite pushdown (`472a227`)
3. Postgres pushdown + parity (`a7885ef`)

## Tests

`tests/meta_store/test_aggregate_by.py`:
- `TestAggregateByOrderAndPaginate` — the SAME parametrized assertions over
  memory / disk / **sqlite** / **postgres**: aggregate-desc + limit, key
  asc/desc, a Max reducer (the #511 shape), offset paging, tie→key-stable
  pages, NULL-key-last both directions, `exp_count_groups` total, bad-target /
  negative-page raises. Postgres now runs through the **pushed** path and stays
  identical to the reference.
- `test_order_and_page_pushed_to_store_not_sliced_in_python[sql3-mem, postgres]`
  — spies the store's `aggregate_by` and asserts only the *page* (not every
  group) crosses the boundary, proving the engine did the paging.

## Downstream

Unblocks ai-workspace #511 (paged grouped review inbox): page concepts by
distinct `cluster_key` ordered by newest member time, returning O(page) groups
instead of loading every group into Python — on multipod-shared Postgres, only
real PG pushdown makes that O(page) in production.

Design: `docs/design/aggregate-group-pagination-plan.md`. CHANGELOG under
`[Unreleased]` (no version bump — maintainer's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)