### PR TITLE
perf(#414): push count_resources down to SQL COUNT(*) instead of decoding every row

### DIFF
--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -760,6 +760,49 @@ class ISlowMetaStore(IMetaStore):
         """
 
 
+class IMetaWithCount(IMetaStore, ABC):
+    """Meta stores that can push a row COUNT down to their engine.
+
+    Mixed into a concrete store ALONGSIDE its base — e.g.
+    ``class SqliteMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore)``.
+    The abstract ``count`` forces an implementation, so ``isinstance(ms,
+    IMetaWithCount)`` is a typed, typo-proof capability check (no ``hasattr``
+    sniffing) — the same shape as :class:`IMetaWithAgg`.
+    :meth:`~specstar.resource_manager.core.SimpleStorage.count` uses it to
+    decide whether to push the count down or fall back to counting decoded
+    rows in Python.
+
+    Why it exists (#414): the fallback is
+    ``more_itertools.ilen(store.iter_search(query))``, which streams EVERY
+    matching row's meta blob over the wire and decodes it into a
+    :class:`ResourceMeta` purely to discard it — an O(n) count. A store whose
+    engine can answer ``SELECT COUNT(*)`` should.
+
+    Contract: an implementation MUST return exactly what that ``ilen``
+    reference path returns for the same query — including honouring
+    ``query.limit`` / ``query.offset`` (the size of the paged window, i.e.
+    ``clamp(matching - offset, 0, limit)``) and returning ``0`` when nothing
+    matches. Enforced cross-backend by ``tests/meta_store/test_count.py``.
+
+    ``query.sorts`` is irrelevant to a count and MAY be ignored: the size of a
+    ``LIMIT``-ed window does not depend on the order its rows come back in, so
+    a pushed-down count should skip the sort entirely.
+    """
+
+    @abstractmethod
+    def count(self, query: ResourceMetaSearchQuery) -> int:
+        """Count the rows matching ``query`` in the store's engine.
+
+        Arguments:
+            query (ResourceMetaSearchQuery): the same filter ``iter_search``
+                would apply, including ``limit`` / ``offset``.
+
+        Returns:
+            int: the number of matching rows in the ``limit`` / ``offset``
+            window.
+        """
+
+
 class IMetaWithAgg(IMetaStore, ABC):
     """Meta stores that can push a group-by aggregate down to their engine.
 

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -162,6 +162,7 @@ from specstar.resource_manager.basic import (
     IBlobStore,
     IMetaStore,
     IMetaWithAgg,
+    IMetaWithCount,
     IResourceStore,
     IStorage,
     MsgspecSerializer,
@@ -358,6 +359,13 @@ class SimpleStorage(IStorage):
         yield from self._meta_store.iter_search(query)
 
     def count(self, query: ResourceMetaSearchQuery) -> int:
+        # #414: push the count into the store's engine when it can do it
+        # (SQL COUNT(*)). The fallback below streams EVERY matching row's meta
+        # blob over the wire and decodes it into a ResourceMeta just to discard
+        # it — an O(n) count. `IMetaWithCount` implementations are contracted to
+        # return exactly what this fallback returns (tests/meta_store/test_count.py).
+        if isinstance(self._meta_store, IMetaWithCount):
+            return self._meta_store.count(query)
         return mit.ilen(self._meta_store.iter_search(query))
 
     def purge_meta(self, resource_id: str) -> None:

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -24,6 +24,7 @@ from specstar.resource_manager import _pg_pool
 from specstar.resource_manager.basic import (
     Encoding,
     IMetaWithAgg,
+    IMetaWithCount,
     ISlowMetaStore,
     MsgspecSerializer,
 )
@@ -40,7 +41,7 @@ except ImportError:  # pragma: no cover
     execute_batch = None  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
 
 
-class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
+class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
     """PostgreSQL-backed metadata store.
 
     All stores resolving to the same DSN share one process-global
@@ -798,6 +799,28 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             cur.execute(sql, params)
             for row in cur:
                 yield self._serializer.decode(row["data"])
+
+    def count(self, query: ResourceMetaSearchQuery) -> int:
+        """#414: ``COUNT(*)`` in the engine — no row data crosses the wire.
+
+        The ``IMetaWithCount`` contract is "identical to
+        ``ilen(iter_search(query))``", so the LIMIT/OFFSET window is preserved
+        by counting over a sub-select. ``ORDER BY`` is deliberately dropped: the
+        SIZE of a limited window does not depend on the order its rows come back
+        in, so sorting for a count is pure waste (``iter_search`` pays it today).
+        """
+        where_clause, params = self._build_where(query)
+        sql = (
+            f'SELECT COUNT(*) AS n FROM (SELECT 1 FROM "{self.table_name}" '
+            f"{where_clause} LIMIT %s OFFSET %s) AS sub"
+        )
+        params.append(query.limit)
+        params.append(query.offset)
+
+        with self.stream_cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+            return int(row["n"])
 
     #: Postgres pushes the #412 group-level ORDER BY / LIMIT / OFFSET (below).
     supports_group_paging = True

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -23,6 +23,7 @@ from specstar.query_types import (
 from specstar.resource_manager.basic import (
     Encoding,
     IMetaWithAgg,
+    IMetaWithCount,
     ISlowMetaStore,
     MsgspecSerializer,
 )
@@ -31,7 +32,7 @@ from specstar.types import ResourceMeta
 T = TypeVar("T")
 
 
-class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
+class SqliteMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
     def __init__(
         self,
         *,
@@ -398,6 +399,25 @@ class SqliteMetaStore(IMetaWithAgg, ISlowMetaStore):
 
         for row in cursor:
             yield self._serializer.decode(row[0])
+
+    def count(self, query: ResourceMetaSearchQuery) -> int:
+        """#414: ``COUNT(*)`` in the engine — no row data is decoded.
+
+        The ``IMetaWithCount`` contract is "identical to
+        ``ilen(iter_search(query))``", so the LIMIT/OFFSET window is preserved
+        by counting over a sub-select. ``ORDER BY`` is deliberately dropped: the
+        SIZE of a limited window does not depend on the order its rows come back
+        in, so sorting for a count is pure waste (``iter_search`` pays it today).
+        """
+        where_clause, params = self._build_where(query)
+        sql = (
+            f"SELECT COUNT(*) FROM (SELECT 1 FROM resource_meta {where_clause} "
+            "LIMIT ? OFFSET ?)"
+        )
+        params.extend([query.limit, query.offset])
+
+        cursor = self._conns[threading.get_ident()].execute(sql, params)
+        return int(cursor.fetchone()[0])
 
     #: SQLite pushes the #412 group-level ORDER BY / LIMIT / OFFSET (below).
     supports_group_paging = True
@@ -1045,6 +1065,17 @@ class S3SqliteMetaStore(SqliteMetaStore):
         """Search resources, checking S3 for updates first if enabled"""
         self._check_and_reload_if_needed()
         return super().iter_search(query)
+
+    def count(self, query):
+        """Count resources, checking S3 for updates first if enabled.
+
+        Required for parity (#414): before the pushed-down ``count`` existed,
+        ``SimpleStorage.count`` went through ``iter_search`` above and so
+        inherited its reload. Counting straight in SQLite would silently skip
+        that and read a stale snapshot.
+        """
+        self._check_and_reload_if_needed()
+        return super().count(query)
 
     def save_many(self, metas):
         super().save_many(metas)

--- a/tests/meta_store/test_count.py
+++ b/tests/meta_store/test_count.py
@@ -1,0 +1,198 @@
+"""Cross-backend behaviour parity for ``ResourceManager.count_resources`` (#414).
+
+Every metastore MUST return the same count — whether it pushes ``COUNT(*)``
+down to its engine (``IMetaWithCount``: SQLite / Postgres) or falls back to the
+core's ``ilen(iter_search(...))`` Python reduction (memory / disk / redis).
+This file is the contract: the SAME parametrized tests run over
+``ALL_META_STORE_TYPES``, and each asserts the count against the **reference**
+``len(search_resources(query))`` — the rows the same query actually returns — so
+a pushed-down count can never silently disagree with the path it replaced.
+
+The ``limit`` / ``offset`` cases are the sharp edge: ``ilen(iter_search(q))``
+counts the *paged window*, not the whole match set, so a naive
+``SELECT COUNT(*) ... WHERE`` pushdown would be wrong. See
+``IMetaWithCount``'s contract.
+"""
+
+import msgspec
+import pytest
+
+from specstar.query import QB
+from specstar.resource_manager.basic import IMetaWithCount
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField
+
+from .common import ALL_META_STORE_TYPES, get_meta_store
+
+
+class Chunk(msgspec.Struct):
+    text: str
+    source_doc_id: str
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestCountParity:
+    """count_resources(q) MUST equal len(search_resources(q)) on every backend."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self._meta_store_type = meta_store_type
+        self._tmpdir = my_tmpdir
+        yield
+
+    def _mgr(self):
+        self._meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=self._meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        return ResourceManager(
+            Chunk,
+            storage=storage,
+            name="chunk",
+            default_user="t",
+            indexed_fields=[IndexableField(field_path="source_doc_id", field_type=str)],
+        )
+
+    def _seed(self, mgr, plan: dict[str, int]):
+        """plan = {source_doc_id: n_chunks}."""
+        for sid, n in plan.items():
+            for _ in range(n):
+                mgr.create(Chunk(text="x", source_doc_id=sid))
+
+    def _parity(self, mgr, query=None) -> int:
+        """Assert the count matches the rows the SAME query returns, and return it."""
+        counted = mgr.count_resources(query)
+        reference = len(mgr.search_resources(query))
+        assert counted == reference
+        return counted
+
+    # -- filter parity -----------------------------------------------------
+
+    def test_unfiltered_counts_everything(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5})
+        assert self._parity(mgr) == 8
+
+    def test_equality_filter(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5})
+        assert self._parity(mgr, (QB["source_doc_id"] == "d1").build()) == 3
+
+    def test_in_filter_is_the_page_pattern(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3, "d2": 5, "d3": 2})
+        q = QB["source_doc_id"].in_(["d1", "d2"]).build()
+        assert self._parity(mgr, q) == 8
+
+    def test_no_match_is_zero(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3})
+        assert self._parity(mgr, (QB["source_doc_id"] == "nope").build()) == 0
+
+    def test_empty_store_is_zero(self):
+        mgr = self._mgr()
+        assert self._parity(mgr) == 0
+
+    # -- the sharp edge: the count is of the LIMIT/OFFSET window -----------
+
+    def test_limit_caps_the_count(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 10})
+        assert self._parity(mgr, QB.all().limit(4).build()) == 4
+
+    def test_limit_larger_than_matches_is_not_padded(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3})
+        assert self._parity(mgr, QB.all().limit(99).build()) == 3
+
+    def test_offset_shrinks_the_window(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 10})
+        assert self._parity(mgr, QB.all().offset(6).build()) == 4
+
+    def test_offset_past_the_end_is_zero(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 3})
+        assert self._parity(mgr, QB.all().offset(99).build()) == 0
+
+    def test_limit_and_offset_together(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 10})
+        # window = rows 6..10 capped at 3
+        assert self._parity(mgr, QB.all().offset(6).limit(3).build()) == 3
+
+    def test_limit_offset_with_filter(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 10, "d2": 5})
+        q = (QB["source_doc_id"] == "d1").limit(4).offset(8).build()
+        assert self._parity(mgr, q) == 2
+
+    # -- ordering must not change a count ---------------------------------
+
+    def test_sort_does_not_change_the_count(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 4, "d2": 6})
+        unsorted = mgr.count_resources(QB.all().build())
+        sorted_ = mgr.count_resources(QB.all().sort("source_doc_id").build())
+        assert unsorted == sorted_ == 10
+
+    def test_sort_with_limit_counts_the_same_window(self):
+        mgr = self._mgr()
+        self._seed(mgr, {"d1": 4, "d2": 6})
+        q = QB.all().sort("-source_doc_id").limit(7).build()
+        assert self._parity(mgr, q) == 7
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+def test_capable_stores_never_decode_rows_to_count(meta_store_type, my_tmpdir):
+    """#414 regression: a store that declares IMetaWithCount must answer a count
+    WITHOUT going through iter_search (which decodes every matching row).
+
+    Positive assertion — a store that lacks the capability is expected to use
+    the iter_search fallback, so this only pins the pushdown backends.
+    """
+    meta_store = get_meta_store(meta_store_type, tmpdir=my_tmpdir)
+    mgr = ResourceManager(
+        Chunk,
+        storage=SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        ),
+        name="chunk",
+        default_user="t",
+        indexed_fields=[IndexableField(field_path="source_doc_id", field_type=str)],
+    )
+    for _ in range(5):
+        mgr.create(Chunk(text="x", source_doc_id="d1"))
+
+    calls: list[object] = []
+    real_iter_search = meta_store.iter_search
+
+    def spy(query):
+        calls.append(query)
+        return real_iter_search(query)
+
+    meta_store.iter_search = spy  # type: ignore[method-assign]
+    try:
+        assert mgr.count_resources() == 5
+    finally:
+        meta_store.iter_search = real_iter_search  # type: ignore[method-assign]
+
+    if isinstance(meta_store, IMetaWithCount):
+        assert calls == [], (
+            f"{type(meta_store).__name__} declares IMetaWithCount but still counted "
+            f"via iter_search ({len(calls)} call(s)) — the O(n) decode is back"
+        )
+    else:
+        assert calls, "non-capable store should use the iter_search fallback"
+
+
+@pytest.fixture
+def my_tmpdir():
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)

--- a/tests/test_count_pushdown.py
+++ b/tests/test_count_pushdown.py
@@ -1,0 +1,135 @@
+"""#414 count push-down — the service-free half, so the FAST CI job guards it.
+
+``tests/meta_store/test_count.py`` is the full cross-backend contract, but the
+whole ``meta_store/`` folder is auto-marked ``integration`` (root conftest), so
+none of it runs in the fast, service-free CI job. In-memory SQLite implements
+``IMetaWithCount`` and needs no external service, so the push-down itself CAN be
+guarded there — that is what this file is for. Memory is included as the
+fallback side of the branch.
+
+Keep this in sync with the cross-backend contract file; the assertions here are
+a service-free subset of the same rules.
+"""
+
+import more_itertools as mit
+import msgspec
+import pytest
+
+from specstar.query import QB
+from specstar.resource_manager.basic import IMetaWithCount
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.meta_store.sqlite3 import MemorySqliteMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import IndexableField
+
+
+class Doc(msgspec.Struct):
+    text: str
+    collection_id: str
+
+
+def _mgr(meta_store):
+    return ResourceManager(
+        Doc,
+        storage=SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        ),
+        name="doc",
+        default_user="t",
+        indexed_fields=[IndexableField(field_path="collection_id", field_type=str)],
+    )
+
+
+def _seed(mgr, plan: dict[str, int]):
+    for cid, n in plan.items():
+        for _ in range(n):
+            mgr.create(Doc(text="x", collection_id=cid))
+
+
+# sql3-mem pushes the count down; memory takes the ilen fallback. Both are
+# service-free, so the fast CI job exercises BOTH sides of the branch.
+STORES = [
+    pytest.param(
+        lambda: MemorySqliteMetaStore(encoding="msgpack"), id="sql3-mem-pushdown"
+    ),
+    pytest.param(MemoryMetaStore, id="memory-fallback"),
+]
+
+
+@pytest.mark.parametrize("make_store", STORES)
+class TestCountPushdownServiceFree:
+    def _parity(self, mgr, query=None) -> int:
+        """The contract: the count must equal the rows the same query returns."""
+        counted = mgr.count_resources(query)
+        assert counted == len(mgr.search_resources(query))
+        return counted
+
+    def test_unfiltered(self, make_store):
+        mgr = _mgr(make_store())
+        _seed(mgr, {"c1": 3, "c2": 5})
+        assert self._parity(mgr) == 8
+
+    def test_filtered(self, make_store):
+        mgr = _mgr(make_store())
+        _seed(mgr, {"c1": 3, "c2": 5})
+        assert self._parity(mgr, (QB["collection_id"] == "c1").build()) == 3
+
+    def test_no_match_is_zero(self, make_store):
+        mgr = _mgr(make_store())
+        _seed(mgr, {"c1": 3})
+        assert self._parity(mgr, (QB["collection_id"] == "nope").build()) == 0
+
+    def test_counts_the_limit_offset_window_not_the_whole_match(self, make_store):
+        """The sharp edge: ilen(iter_search(q)) counts the PAGED window, so a
+        naive `SELECT COUNT(*) ... WHERE` push-down would over-count."""
+        mgr = _mgr(make_store())
+        _seed(mgr, {"c1": 10})
+        assert self._parity(mgr, QB.all().limit(4).build()) == 4
+        assert self._parity(mgr, QB.all().offset(6).build()) == 4
+        assert self._parity(mgr, QB.all().offset(6).limit(3).build()) == 3
+        assert self._parity(mgr, QB.all().offset(99).build()) == 0
+        assert self._parity(mgr, QB.all().limit(99).build()) == 10
+
+    def test_ordering_does_not_change_the_count(self, make_store):
+        mgr = _mgr(make_store())
+        _seed(mgr, {"c1": 4, "c2": 6})
+        plain = mgr.count_resources(QB.all().build())
+        ordered = mgr.count_resources(QB.all().sort("collection_id").build())
+        assert plain == ordered == 10
+
+
+def test_sqlite_counts_without_decoding_any_row():
+    """#414 regression: the whole point — a capable store must NOT reach
+    iter_search (which decodes every matching row) to answer a count."""
+    meta_store = MemorySqliteMetaStore(encoding="msgpack")
+    assert isinstance(meta_store, IMetaWithCount)
+    mgr = _mgr(meta_store)
+    _seed(mgr, {"c1": 5})
+
+    calls: list[object] = []
+    real = meta_store.iter_search
+
+    def spy(query):
+        calls.append(query)
+        return real(query)
+
+    meta_store.iter_search = spy  # type: ignore[method-assign]
+    try:
+        assert mgr.count_resources() == 5
+    finally:
+        meta_store.iter_search = real  # type: ignore[method-assign]
+
+    assert calls == [], "count fell back to iter_search — the O(n) row decode is back"
+
+
+def test_memory_store_keeps_the_ilen_fallback():
+    """The other side of the branch: a store without the capability must still
+    work, via the untouched reference path."""
+    meta_store = MemoryMetaStore()
+    assert not isinstance(meta_store, IMetaWithCount)
+    mgr = _mgr(meta_store)
+    _seed(mgr, {"c1": 7})
+    q = (QB["collection_id"] == "c1").build()
+    assert mgr.count_resources(q) == mit.ilen(meta_store.iter_search(q)) == 7


### PR DESCRIPTION
Closes #414.

## What

`SimpleStorage.count` — the count behind `ResourceManager.count_resources` — was:

```python
return mit.ilen(self._meta_store.iter_search(query))
```

It streamed **every matching row's full meta blob** over the wire and msgspec-decoded each into a `ResourceMeta`, purely to count and throw them away. Because `ResourceMetaSearchQuery.limit` defaults to `DEFAULT_QUERY_LIMIT` (`2**32 - 1`), a plain `count_resources(...)` on Postgres issued:

```sql
SELECT data FROM "t" WHERE ... ORDER BY ... LIMIT 4294967295 OFFSET 0
```

— an O(n) count that even paid for a full `ORDER BY`, which cannot affect a count. `SimpleStorage` is the only `IStorage` impl and all six storage factories return it, so no backend escaped it.

## How

Mirrors the existing `IMetaWithAgg` capability-interface pattern — a store that can count in its engine declares `IMetaWithCount`; `SimpleStorage.count` pushes down behind a typed `isinstance` check and otherwise keeps the **exact** `ilen` fallback:

```python
def count(self, query):
    if isinstance(self._meta_store, IMetaWithCount):
        return self._meta_store.count(query)
    return mit.ilen(self._meta_store.iter_search(query))
```

Implemented for Postgres + SQLite:

```sql
SELECT COUNT(*) FROM (SELECT 1 FROM "t" <where> LIMIT ? OFFSET ?) sub
```

Two deliberate details:

- **LIMIT/OFFSET are preserved inside a sub-select.** The contract is "identical to `ilen(iter_search(q))`", which counts the **paged window**, not the whole match set. A naive `SELECT COUNT(*) ... WHERE` would be wrong whenever a caller passes a limit.
- **`ORDER BY` is dropped.** The *size* of a limited window is order-independent (`clamp(matching - offset, 0, limit)`), so the sort `iter_search` pays today is pure waste for a count.

**`S3SqliteMetaStore.count` is overridden** alongside its existing `iter_search` override. Without it, counting straight in SQLite would skip the `_check_and_reload_if_needed()` that the old count inherited *via* `iter_search`, and would read a stale S3 snapshot. (The `sql3-s3` parametrization covers this.)

## Measured

Localhost Postgres, counting N matching rows:

| N | old `ilen(iter_search)` | new `COUNT(*)` | speedup |
|---|---|---|---|
| 500 | 12.8 ms | 9.2 ms | 1.4x |
| 2,000 | 15.5 ms | 6.1 ms | 2.6x |
| 10,000 | 85.1 ms | 13.8 ms | **6.2x** |

The gap widens with N, and would widen further over a real network — the old path transfers every meta JSON. In-memory SQLite (decode cost only, no network): 3.3x.

## Tests

`tests/meta_store/test_count.py` is the cross-backend contract, in the shape of `test_aggregate_by.py`: the same parametrized cases run over `ALL_META_STORE_TYPES` and each asserts

```python
count_resources(q) == len(search_resources(q))
```

— the count against the rows **the same query actually returns** — so a pushed-down count can never silently disagree with the path it replaced. Covers limit/offset windows (the sharp edge), filters (`==`, `in_`), no-match, empty store, and ordering-independence; plus a spy asserting capable stores never touch `iter_search` (and that non-capable stores still do).

**84 passed** across `memory / disk / postgres / sql3-mem / sql3-s3 / redis`.

Full suite: **4963 passed**. The 9 failures are pre-existing / environmental, verified against a pristine `master` worktree:
- 4× `test_list_resources_error_skip` — **fails identically on pristine master** (`assert 2 == 1`); unrelated to this change, but you may want to look at it.
- 4× RabbitMQ + 1× S3 mtime — services not running locally.

## Notes for the maintainer

- **`master` is not `ruff format --check` clean** with the currently-pinned ruff (0.15.0): 36 files would be reformatted on a pristine checkout, so `make check` / `make test` fail before any change. I deliberately kept that reformat **out** of this PR (my 5 files were already clean). Probably worth a separate formatting commit or a ruff pin.
- **Latent, not fixed here:** `S3SqliteMetaStore` overrides `iter_search` for the S3 reload but **not** `aggregate_by` — so `exp_aggregate_by` on the S3-backed store can read a stale snapshot today. Same class of bug as the one this PR had to avoid for `count`. Happy to file it separately.
