### PR TITLE
perf(#416): probe indexed_data with @> so the GIN it already maintains is used

### DIFF
--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -29,6 +29,39 @@ from specstar.resource_manager.basic import (
 )
 from specstar.types import ResourceMeta
 
+
+def _gin_probeable(condition: "DataSearchFilter", value: Any) -> bool:
+    """Can *value* be matched by a top-level ``indexed_data @> …`` probe?
+
+    Two cases must keep the old ``->>`` path (#416):
+
+    * a ``transform`` compares a DERIVED value (``length`` etc.), while ``@>``
+      only ever matches what is actually stored;
+    * ``None`` — the reference matcher returns Unknown for ``field == None``
+      (``basic.py``), and so does ``->>' f' = 'None'``. ``@> '{"f": null}'``
+      would instead MATCH rows storing a JSON null, which is a behaviour
+      change, not a speed-up.
+    """
+    return getattr(condition, "transform", None) is None and value is not None
+
+
+def _containment(field_path: str, value: Any) -> tuple[str, list]:
+    """A top-level containment probe, served by ``idx_indexed_data_gin``.
+
+    The value is encoded with :func:`json.dumps` — symmetric with the write path
+    (``_meta_row_values``) — so its JSON type survives. This matters: ``@>`` is
+    type-strict and silently returns ZERO rows on a mismatch, so the ``str(value)``
+    the old path used would turn a perf fix into wrong results. Type-strictness
+    also brings Postgres in line with the reference matcher, which compares with
+    a plain Python ``==``.
+    """
+    import json
+
+    return "indexed_data @> %s::jsonb", [
+        json.dumps({field_path: value}, ensure_ascii=False)
+    ]
+
+
 try:
     import psycopg2 as pg
     import psycopg2.pool
@@ -1047,10 +1080,13 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
 
         if operator == DataSearchOperator.equals:
             if isinstance(value, (list, dict)):
-                # For list/dict, use JSONB comparison
+                # Equality on a composite value must stay EXACT: containment
+                # would make ``{"f": [1, 2, 3]}`` match a query for ``[1]``.
                 import json
 
                 return f"indexed_data->'{field_path}' = %s::jsonb", [json.dumps(value)]
+            if _gin_probeable(condition, value):
+                return _containment(field_path, value)
             if isinstance(value, bool):
                 return f"{jsonb_text_extract} = %s", ["true" if value else "false"]
             return f"{jsonb_text_extract} = %s", [str(value)]
@@ -1083,6 +1119,12 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             if field_path in self._list_fields:
                 import json
 
+                if _gin_probeable(condition, value):
+                    # Probe at the TOP level: ``indexed_data->'f' @> …`` applies
+                    # containment to the extract, which the GIN on
+                    # ``indexed_data`` cannot serve any more than ``->>`` can.
+                    # Element membership stays exact either way (#362/#378).
+                    return _containment(field_path, [value])
                 return (
                     f"indexed_data->'{field_path}' @> %s::jsonb",
                     [json.dumps(value)],
@@ -1096,9 +1138,20 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             return f"{jsonb_text_extract} ~ %s", [value]
         if operator == DataSearchOperator.in_list:
             if isinstance(value, (list, tuple, set)):
-                placeholders = ",".join(["%s"] * len(value))
+                vals = list(value)
+                if not vals:
+                    return "FALSE", []  # ``IN ()`` is not valid SQL
+                if all(_gin_probeable(condition, v) for v in vals):
+                    # Postgres BitmapOr's the probes across the one GIN.
+                    import json
+
+                    ors = " OR ".join(["indexed_data @> %s::jsonb"] * len(vals))
+                    return f"({ors})", [
+                        json.dumps({field_path: v}, ensure_ascii=False) for v in vals
+                    ]
+                placeholders = ",".join(["%s"] * len(vals))
                 return f"{jsonb_text_extract} IN ({placeholders})", [
-                    str(v) for v in value
+                    str(v) for v in vals
                 ]
         elif operator == DataSearchOperator.not_in_list:
             if isinstance(value, (list, tuple, set)):

--- a/tests/meta_store/test_gin_containment_parity.py
+++ b/tests/meta_store/test_gin_containment_parity.py
@@ -1,0 +1,116 @@
+"""#416: rewriting ``->>`` to ``@>`` must not change a single result.
+
+The contract is parity with the reference matcher (``basic.py``, plain Python
+``==``), which the memory store uses directly. Postgres is the only backend whose
+SQL was rewritten, so every case here runs against BOTH and asserts they agree.
+
+``tests/test_gin_containment.py`` pins the generated SQL in CI's service-free lane;
+this file needs a live Postgres and is auto-marked ``integration``.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from specstar.query import QB
+from specstar.types import ResourceMeta
+
+from .common import get_meta_store
+
+# (id, indexed_data) — deliberately mixes JSON types on `n` and `flag` so a
+# type-blind rewrite would show up as a parity break.
+ROWS = [
+    (
+        "a",
+        {"coll": "c1", "n": 5000, "flag": True, "tags": ["team-a", "x"], "opt": None},
+    ),
+    ("b", {"coll": "c2", "n": 1, "flag": False, "tags": ["team-b"], "opt": "set"}),
+    ("c", {"coll": "c10", "n": 0, "flag": True, "tags": ["team"], "opt": None}),
+    ("d", {"coll": "c1", "n": 5000, "flag": False, "tags": [], "opt": "set"}),
+]
+
+QUERIES = {
+    "equals str": QB["coll"] == "c1",
+    "equals str no match": QB["coll"] == "nope",
+    "equals int": QB["n"] == 5000,
+    "equals int zero": QB["n"] == 0,
+    "equals bool true": QB["flag"] == True,  # noqa: E712
+    "equals bool false": QB["flag"] == False,  # noqa: E712
+    "equals none": QB["opt"] == None,  # noqa: E711
+    "in_list str": QB["coll"].in_(["c1", "c2"]),
+    "in_list one": QB["coll"].in_(["c10"]),
+    "in_list int": QB["n"].in_([0, 1]),
+    "in_list no match": QB["coll"].in_(["zz"]),
+    "contains exact element": QB["tags"].contains("team"),
+    "contains other element": QB["tags"].contains("team-a"),
+    "not_equals": QB["coll"] != "c1",
+    "greater_than": QB["n"] > 1,
+}
+
+
+def _meta(rid: str, indexed: dict) -> ResourceMeta:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=str(uuid.uuid4()),
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, **indexed},
+    )
+
+
+def _seed(store):
+    for rid, indexed in ROWS:
+        m = _meta(rid, indexed)
+        store[m.resource_id] = m
+    return store
+
+
+def _ids(store, cond) -> list[str]:
+    return sorted(m.indexed_data["id"] for m in store.iter_search(cond.build()))
+
+
+@pytest.fixture(scope="module")
+def reference():
+    # No ``register_list_field``: that is Postgres-only plumbing to tell the SQL
+    # builder a field is list-typed. The reference matcher sees real Python lists.
+    return _seed(get_meta_store("memory"))
+
+
+@pytest.fixture(scope="module")
+def postgres():
+    store = _seed(get_meta_store("postgres"))
+    store.register_list_field("tags")
+    return store
+
+
+@pytest.mark.parametrize("label", list(QUERIES))
+def test_postgres_matches_the_reference_matcher(label, reference, postgres):
+    cond = QUERIES[label]
+    assert _ids(postgres, cond) == _ids(reference, cond), label
+
+
+def test_contains_does_not_match_a_prefix_of_another_element(postgres):
+    """#362/#378: ``"team"`` must not match a row whose tag is ``"team-a"``."""
+    assert _ids(postgres, QB["tags"].contains("team")) == ["c"]
+
+
+def test_equality_is_type_strict_like_the_reference(postgres, reference):
+    """``->>' n' = str(5000)`` used to match the STRING "5000" too.
+
+    The reference compares with Python ``==``, where ``5000 != "5000"``, so the
+    old Postgres path was the odd one out. Containment lines them up.
+    """
+    assert _ids(postgres, QB["n"] == "5000") == _ids(reference, QB["n"] == "5000") == []
+
+
+def test_empty_in_list_matches_nothing_instead_of_raising(postgres, reference):
+    """``IN ()`` is a syntax error; the old path emitted it verbatim."""
+    assert (
+        _ids(postgres, QB["coll"].in_([])) == _ids(reference, QB["coll"].in_([])) == []
+    )

--- a/tests/test_contains_list_pushdown.py
+++ b/tests/test_contains_list_pushdown.py
@@ -48,7 +48,14 @@ def test_contains_on_list_field_emits_jsonb_containment():
     match ``contains("c1")`` because ``LIKE '%c1%'`` matches the literal
     substring inside ``"c10"``. The ``@>`` form rejects that row because
     ``"c1"`` is not an element of the array.
+
+    #416 moved the probe from the extract (``indexed_data->'f' @> '"c1"'``) to
+    the top level (``indexed_data @> '{"f": ["c1"]}'``): both are exact element
+    membership, but only the top-level form can be served by the GIN on
+    ``indexed_data``. The membership semantics this test guards are unchanged.
     """
+    import json
+
     store = _make_store()
     store.register_list_field("source_chunk_ids")
 
@@ -60,8 +67,12 @@ def test_contains_on_list_field_emits_jsonb_containment():
     sql, params = store._build_condition(cond)
     assert "@>" in sql, f"expected JSONB containment for list field, got: {sql!r}"
     assert "LIKE" not in sql, f"list-field contains must not fall back to LIKE: {sql!r}"
-    # The parameter is JSON-encoded so PG can compare arrays of strings.
-    assert params == ['"c1"'], f"expected JSON-encoded element, got: {params!r}"
+    assert "indexed_data @> " in sql, f"probe must be top-level for the GIN: {sql!r}"
+    # The element is wrapped in its field + a one-element array, so containment
+    # scopes to THIS field and stays element-exact.
+    assert json.loads(params[0]) == {"source_chunk_ids": ["c1"]}, (
+        f"expected a scoped JSON-encoded element, got: {params!r}"
+    )
 
 
 def test_contains_on_unregistered_field_falls_back_to_like():
@@ -143,7 +154,9 @@ def test_add_model_auto_registers_list_typed_indexed_fields(monkeypatch):
         indexed_fields=[
             IndexableField(field_path="title", field_type=str),  # str → not registered
             IndexableField(field_path="note"),  # field_type UNSET → skipped
-            IndexableField(field_path="tags", field_type=list[str]),  # list → registered
+            IndexableField(
+                field_path="tags", field_type=list[str]
+            ),  # list → registered
         ],
     )
 

--- a/tests/test_gin_containment.py
+++ b/tests/test_gin_containment.py
@@ -1,0 +1,210 @@
+"""#416: indexed_data filters must use the GIN, via ``@>`` containment.
+
+``indexed_data->>'f' = %s`` is a function call on every row, so Postgres seq-scans
+the whole table and the GIN it already maintains is never used. Rewriting to
+top-level containment (``indexed_data @> '{"f": "v"}'``) is served by that index.
+
+These tests pin the generated SQL and live in CI's service-free lane on purpose:
+``tests/meta_store/`` is auto-marked ``integration`` and never runs in CI, so a
+regression there would be invisible. Cross-backend result parity is pinned by
+``tests/meta_store/test_gin_containment_parity.py``.
+"""
+
+import json
+from enum import Enum
+
+import pytest
+
+from specstar.query_types import (
+    DataSearchCondition,
+    DataSearchOperator,
+    FieldTransform,
+)
+from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+
+
+def _builder(list_fields=(), set_columns=None) -> PostgresMetaStore:
+    """A store whose SQL builder runs without a live server.
+
+    ``__init__`` eagerly opens a pool and creates tables; ``_build_condition``
+    only reads ``_list_fields`` / ``_set_columns``, so bypassing it keeps these
+    tests service-free.
+    """
+    store = object.__new__(PostgresMetaStore)
+    store._list_fields = set(list_fields)
+    store._set_columns = dict(set_columns or {})
+    return store
+
+
+def _cond(op, value, field_path="collection_id", transform=None):
+    return DataSearchCondition(
+        field_path=field_path, operator=op, value=value, transform=transform
+    )
+
+
+class Colour(str, Enum):
+    red = "red"
+
+
+class Level(Enum):
+    high = 3
+
+
+# --- equality ------------------------------------------------------------
+
+
+def test_equals_uses_top_level_containment_so_the_gin_can_serve_it():
+    sql, params = _builder()._build_condition(_cond(DataSearchOperator.equals, "c1"))
+    assert sql == "indexed_data @> %s::jsonb"
+    assert json.loads(params[0]) == {"collection_id": "c1"}
+    assert "->>" not in sql  # the seq-scan forcing extraction is gone
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(5000, id="int"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("5000", id="str"),
+    ],
+)
+def test_equals_preserves_the_json_type_of_the_value(value):
+    """``@>`` is type-strict: ``{"n": "5000"}`` does NOT match a stored ``5000``.
+
+    ``str(value)`` would silently return zero rows, so the value must be encoded
+    with its real JSON type — matching how the write path stores it
+    (``json.dumps(meta.indexed_data)``).
+    """
+    sql, params = _builder()._build_condition(
+        _cond(DataSearchOperator.equals, value, field_path="n")
+    )
+    assert sql == "indexed_data @> %s::jsonb"
+    assert json.loads(params[0]) == {"n": value}
+    assert type(json.loads(params[0])["n"]) is type(value)
+
+
+def test_equals_none_is_not_rewritten():
+    """The reference matcher returns Unknown for ``field == None`` (no match).
+
+    ``@> '{"f": null}'`` would instead MATCH rows storing a JSON null — a
+    behaviour change. #416 is a speed change only, so ``None`` keeps the old path.
+    """
+    sql, _ = _builder()._build_condition(_cond(DataSearchOperator.equals, None))
+    assert "@>" not in sql
+
+
+def test_equals_with_a_transform_is_not_rewritten():
+    """``@>`` matches the STORED value; a transform compares a derived one."""
+    sql, _ = _builder()._build_condition(
+        _cond(DataSearchOperator.equals, 3, transform=FieldTransform.length)
+    )
+    assert "@>" not in sql
+    assert "jsonb_array_length" in sql
+
+
+def test_equals_on_a_list_value_stays_exact_equality_not_containment():
+    """``{"f": [1, 2, 3]} @> {"f": [1]}`` is true — but ``[1,2,3] != [1]``.
+
+    Containment is the wrong operator for equality on a composite value.
+    """
+    sql, _ = _builder()._build_condition(_cond(DataSearchOperator.equals, [1]))
+    assert "indexed_data->'collection_id' = %s::jsonb" == sql
+
+
+def test_enum_is_normalised_to_its_value_like_the_reference_matcher():
+    """``basic.py`` compares against ``condition.value.value`` for Enums.
+
+    Without normalising, ``json.dumps(Level.high)`` raises TypeError outright.
+    """
+    _, params = _builder()._build_condition(
+        _cond(DataSearchOperator.equals, Colour.red)
+    )
+    assert json.loads(params[0]) == {"collection_id": "red"}
+
+    _, params = _builder()._build_condition(
+        _cond(DataSearchOperator.equals, Level.high)
+    )
+    assert json.loads(params[0]) == {"collection_id": 3}
+
+
+# --- in_list -------------------------------------------------------------
+
+
+def test_in_list_becomes_an_or_of_containments():
+    """Postgres bitmap-ORs the probes on the one GIN."""
+    sql, params = _builder()._build_condition(
+        _cond(DataSearchOperator.in_list, ["c1", "c2"])
+    )
+    assert sql == "(indexed_data @> %s::jsonb OR indexed_data @> %s::jsonb)"
+    assert [json.loads(p) for p in params] == [
+        {"collection_id": "c1"},
+        {"collection_id": "c2"},
+    ]
+
+
+def test_in_list_preserves_value_types():
+    _, params = _builder()._build_condition(
+        _cond(DataSearchOperator.in_list, [1, 2], field_path="n")
+    )
+    assert [json.loads(p) for p in params] == [{"n": 1}, {"n": 2}]
+
+
+def test_in_list_with_none_is_not_rewritten():
+    sql, _ = _builder()._build_condition(
+        _cond(DataSearchOperator.in_list, ["c1", None])
+    )
+    assert "@>" not in sql
+
+
+def test_in_list_empty_matches_nothing():
+    sql, params = _builder()._build_condition(_cond(DataSearchOperator.in_list, []))
+    assert sql == "FALSE"
+    assert params == []
+
+
+# --- contains on a list field --------------------------------------------
+
+
+def test_contains_on_a_list_field_probes_at_the_top_level():
+    """``indexed_data->'f' @> '"v"'`` is containment on the EXTRACT — the GIN on
+    ``indexed_data`` cannot serve it either. Only a top-level probe is indexed.
+
+    Element membership stays EXACT (#362/#378): ``{"tags": ["team"]}`` must not
+    match a stored ``["team-a"]``.
+    """
+    sql, params = _builder(list_fields=["tags"])._build_condition(
+        _cond(DataSearchOperator.contains, "team", field_path="tags")
+    )
+    assert sql == "indexed_data @> %s::jsonb"
+    assert json.loads(params[0]) == {"tags": ["team"]}
+
+
+def test_contains_on_a_string_field_still_uses_like():
+    sql, _ = _builder()._build_condition(_cond(DataSearchOperator.contains, "abc"))
+    assert "LIKE" in sql
+    assert "@>" not in sql
+
+
+# --- what must NOT change ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        DataSearchOperator.not_equals,
+        DataSearchOperator.not_in_list,
+        DataSearchOperator.greater_than,
+        DataSearchOperator.less_than,
+        DataSearchOperator.starts_with,
+        DataSearchOperator.regex,
+    ],
+)
+def test_operators_a_gin_cannot_serve_are_left_alone(op):
+    """A GIN is a value->row inverted index: no ordering, no negation, no prefix.
+
+    Rewriting these would be a lie. They stay Seq Scans until #418.
+    """
+    value = ["c1"] if op == DataSearchOperator.not_in_list else "c1"
+    sql, _ = _builder()._build_condition(_cond(op, value))
+    assert "indexed_data @> " not in sql


### PR DESCRIPTION
Fixes #416.

Every `indexed_data` filter was a full table scan. `indexed_data->>'f' = %s` is a function call evaluated per row, and a jsonb GIN only answers `@>` / `?` / `?|` / `?&` — so `idx_indexed_data_gin` was **never used**, and the cost scaled with the **total row count of the table** rather than the size of the result. Registering `indexed_fields` bought queryability but, on Postgres, no speed at all.

## Measured (100k rows, the filter selects 1000)

| operator | before | after | |
|---|---|---|---|
| `equals` | Seq Scan **23.6 ms** | Bitmap **0.665 ms** | **35x** |
| `in_list` | Seq Scan **24.6 ms** | Bitmap **0.818 ms** | **30x** |
| `contains` (list field) | Seq Scan **22.8 ms** | Bitmap **1.021 ms** | **22x** |

No new index, no per-field DDL, no migration, no `Schema` bump — this is purely a change in generated SQL, served by the index specstar already creates.

`contains` on a list field already used `@>`, but applied it to the *extract* (`indexed_data->'f' @> …`), which the GIN on `indexed_data` cannot serve either; only a top-level probe is indexed. Element membership stays exact (#362/#378) — verified.

## Three cases deliberately keep the old path

`@>` is not equivalent to `->>` everywhere, and each of these would be a silent behaviour change:

- **a `transform`** compares a DERIVED value (`length` etc.); `@>` only ever matches what is actually stored.
- **`value is None`** — the reference matcher (`basic.py`) returns Unknown for `field == None`, and so does `->>'f' = 'None'`. `@> '{"f": null}'` would instead **match** rows storing a JSON null.
- **equality on a list/dict** — `{"f": [1,2,3]} @> {"f": [1]}` is true, but `[1,2,3] != [1]`. Containment is the wrong operator for composite equality.

## The risk this trades into, and how it's pinned

`->>` + `str(value)` is **type-blind**; `@>` is **type-strict** and silently returns **zero rows** on a mismatch — it does not error. The value is therefore encoded with `json.dumps`, symmetric with the write path (`_meta_row_values`), so its JSON type survives.

This also removes a **Postgres-only deviation**: the reference matcher compares with a plain Python `==`, where `5000 != "5000"`, so `->>` was the odd one out. `tests/meta_store/test_gin_containment_parity.py` asserts postgres == the reference for every rewritten operator across `str`/`int`/`float`/`bool`/`None`/list values.

## Drive-by

An empty `in_list` emitted `IN ()` — a syntax error. It now matches nothing, like the reference.

## Out of scope

Ranges, negation, `LIKE`, `starts_with` and regex are untouched: a GIN is a value→row inverted index with no ordering, so it cannot serve them at any index size (jsonpath `@@` doesn't help — it plans as a Seq Scan on `jsonb_ops`, and on `jsonb_path_ops` it uses the index but is *slower* than the scan). Those need #418.

## Testing

- `tests/test_gin_containment.py` — **new**, service-free so it actually runs in CI. `tests/meta_store/` is auto-marked `integration` and CI has no Postgres service, so the parity contract alone would have shipped with **no CI guard**. Pins the SQL shape, the JSON type of every parameter, the three non-rewritten cases, and the operators a GIN cannot serve.
- `tests/meta_store/test_gin_containment_parity.py` — **new**, the cross-backend contract against a live Postgres (18 passed).
- `tests/test_contains_list_pushdown.py` — updated for the top-level probe; its #362 membership intent is unchanged.
- CI lane (`-m "not integration and not benchmark and not slow"`): **3295 passed, 0 failed**.
- Full `tests/meta_store/` against pristine master as a baseline: **identical** failures/errors (50/437 — all pre-existing: missing `boto3`, redis/minio not running), `+18 passed` = exactly the new parity tests. **Zero regressions.**