### PR TITLE
fix(#417): populate the SetIndex column before enabling the && fast path

### DIFF
--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -204,6 +204,13 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         Idempotent; mirrors :meth:`ensure_vector_column` (pgvector). Other
         backends serve ``contains_any`` from the shared path and need no
         shadow column, so this is Postgres-only native acceleration.
+
+        Called from ``add_model``, i.e. on every process start. The freshly
+        added column is NULL for every row written before it existed, so the
+        rows are backfilled BEFORE the field is registered — registering is what
+        switches ``contains_any`` onto the ``&&`` fast path, and a fast path over
+        a NULL column silently returns no rows rather than failing (#417).
+        Restarts are cheap: the backfill only touches rows still missing a value.
         """
         pg_elem = self._SET_ELEM_TYPES.get(elem_type, "text")
         col = self._set_col_name(field_path)
@@ -224,6 +231,9 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
                 )
         finally:
             conn.close()
+        # Order matters: populate first, register second. Mirrors the startup
+        # backfill _migrate_existing_records already does for indexed_data.
+        self._run_set_backfill(field_path, pg_elem, only_missing=True)
         self._set_columns[field_path] = pg_elem
 
     def _extract_set_value(self, meta: ResourceMeta, field_path: str) -> "list | None":
@@ -233,19 +243,19 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
         v = meta.indexed_data.get(field_path)
         return v if isinstance(v, list) else None
 
-    def backfill_set_column(self, field_path: str) -> int:
-        """Repopulate the SetIndex shadow column for *field_path* from
-        ``indexed_data`` across all existing rows — for rows written before the
-        column was added (it defaults to NULL there). One pushed-down ``UPDATE``;
-        returns rows touched. No-op when the field has no shadow column.
+    def _run_set_backfill(
+        self, field_path: str, pg_elem: str, *, only_missing: bool
+    ) -> int:
+        """The backfill ``UPDATE`` itself, without the ``_set_columns`` guard.
 
-        Analogous to :func:`backfill_vectors` for Vector fields, but the value
-        is a pure derivation of ``indexed_data`` (no re-encoding needed), so it
-        runs entirely in SQL.
+        ``ensure_set_column`` must be able to run this BEFORE registering the
+        field, so the ``&&`` fast path is never live against an unpopulated
+        column (#417).
+
+        ``only_missing`` restricts the rewrite to rows the column has no value
+        for. Startup passes True, so a restart is a no-op rather than a full
+        table rewrite; the CLI passes False to force a complete re-derivation.
         """
-        if field_path not in self._set_columns:
-            return 0
-        pg_elem = self._set_columns[field_path]
         col = self._set_col_name(field_path)
         extract = "jsonb_array_elements_text(indexed_data->%s)"
         arr = (
@@ -257,9 +267,31 @@ class PostgresMetaStore(IMetaWithAgg, ISlowMetaStore):
             f'UPDATE "{self.table_name}" SET "{col}" = {arr} '
             f"WHERE jsonb_typeof(indexed_data->%s) = 'array'"
         )
+        if only_missing:
+            sql += f' AND "{col}" IS NULL'
         with self.transaction() as cur:
             cur.execute(sql, [field_path, field_path])
             return cur.rowcount
+
+    def backfill_set_column(self, field_path: str) -> int:
+        """Repopulate the SetIndex shadow column for *field_path* from
+        ``indexed_data`` across all existing rows — for rows written before the
+        column was added (it defaults to NULL there). One pushed-down ``UPDATE``;
+        returns rows touched. No-op when the field has no shadow column.
+
+        Analogous to :func:`backfill_vectors` for Vector fields, but the value
+        is a pure derivation of ``indexed_data`` (no re-encoding needed), so it
+        runs entirely in SQL.
+
+        Since #417 ``ensure_set_column`` backfills on its own, so this is no
+        longer required to make a newly-declared SetIndex field correct. It
+        remains as the way to force a full re-derivation.
+        """
+        if field_path not in self._set_columns:
+            return 0
+        return self._run_set_backfill(
+            field_path, self._set_columns[field_path], only_missing=False
+        )
 
     def _build_vector_condition(
         self, condition: "VectorDistanceCondition"

--- a/tests/meta_store/test_set_index.py
+++ b/tests/meta_store/test_set_index.py
@@ -147,16 +147,23 @@ def test_add_model_with_set_index_annotation_wires_shadow_column_end_to_end():
 
 
 def test_backfill_populates_set_column_for_rows_written_before_it_existed():
-    # The schema-change gap: rows created before the shadow column existed have
-    # a NULL shadow column, so && misses them until a backfill (mirrors how
-    # Vector fields need backfill_vectors for pre-existing rows).
+    # There is no schema-change gap: ensure_set_column populates the column for
+    # rows written before it existed, BEFORE enabling the && fast path (#417).
+    #
+    # This deliberately does NOT mirror Vector fields. backfill_vectors cannot
+    # run implicitly because it must re-embed — expensive, external, and not
+    # something a meta store can do at startup. The SetIndex column is "a pure
+    # derivation of indexed_data (no re-encoding needed), so it runs entirely in
+    # SQL" (backfill_set_column.__doc__) — nothing to defer to an operator, and
+    # deferring it silently hid every pre-existing row.
     store = get_meta_store("postgres")
     _seed(store, {"1": ["a", "b"], "2": ["c"]})  # written BEFORE the column
-    store.ensure_set_column("keys", str)  # column added empty for existing rows
-    assert _ids(store, ["a"]) == []  # NULL shadow column → && misses
-    assert store.backfill_set_column("keys") == 2
-    assert _ids(store, ["a"]) == ["1"]  # now visible
+    store.ensure_set_column("keys", str)
+    assert _ids(store, ["a"]) == ["1"]  # visible immediately, no manual step
     assert _ids(store, ["c"]) == ["2"]
+    # backfill_set_column stays, as the way to force a full re-derivation.
+    assert store.backfill_set_column("keys") == 2
+    assert _ids(store, ["a"]) == ["1"]
 
 
 def _pg_spec_with_foo(extra_field: bool = False):

--- a/tests/meta_store/test_set_index_backfill_window.py
+++ b/tests/meta_store/test_set_index_backfill_window.py
@@ -1,0 +1,139 @@
+"""#417: declaring SetIndex on a table that already has rows must not hide them.
+
+``tests/meta_store/test_set_index.py`` states the invariant — "Declaring SetIndex
+must NOT change results — only how fast they come back" — but every test there
+creates the column BEFORE seeding, so the write path fills it. Real deployments do
+the opposite: the data already exists, then you add the annotation and ship.
+
+These tests pin that order. Without the fix, ``ensure_set_column`` adds the column
+(existing rows -> NULL) and enables the ``&&`` fast path in the same breath, so
+every pre-existing row silently stops matching until an operator remembers to run
+``specstar backfill set-columns``.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from specstar.query import QB
+from specstar.types import ResourceMeta
+
+from .common import get_meta_store
+
+SEED = {"1": ["a", "b"], "2": ["b", "c"], "3": ["x"]}
+
+
+def _meta(rid: str, keys: list) -> ResourceMeta:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=str(uuid.uuid4()),
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, "keys": keys},
+    )
+
+
+def _seed(store, data: dict = SEED):
+    for rid, keys in data.items():
+        m = _meta(rid, keys)
+        store[m.resource_id] = m
+
+
+def _ids(store, values) -> list[str]:
+    q = QB["keys"].contains_any(values).build()
+    return sorted(m.indexed_data["id"] for m in store.iter_search(q))
+
+
+def test_annotating_a_table_that_already_has_rows_keeps_them_visible():
+    """The #417 repro: data first, annotation second — the real deployment order."""
+    store = get_meta_store("postgres")
+    _seed(store)
+    before = _ids(store, ["a", "z"])
+    assert before == ["1"]  # sanity: the fallback path is correct
+
+    # A developer adds Annotated[list[str], SetIndex()] and deploys. add_model()
+    # calls ensure_set_column() at startup — that is ALL it does.
+    store.ensure_set_column("keys", str)
+
+    assert _ids(store, ["a", "z"]) == before, (
+        "pre-existing rows vanished: the && fast path went live against a column "
+        "that is still NULL for every row written before the annotation"
+    )
+
+
+def test_pre_existing_and_new_rows_are_both_visible_after_annotating():
+    """The dangerous shape of the bug: the query keeps *working* on new rows.
+
+    It does not raise or return nothing — it silently returns a SUBSET, so
+    nothing looks wrong.
+    """
+    store = get_meta_store("postgres")
+    _seed(store)
+    store.ensure_set_column("keys", str)
+
+    m = _meta("4", ["a", "q"])
+    store[m.resource_id] = m
+
+    assert _ids(store, ["a", "z"]) == ["1", "4"]
+
+
+def test_the_fast_path_is_still_taken_after_the_fix():
+    """The fix must not silently disable the optimisation to buy correctness."""
+    from specstar.query_types import DataSearchCondition, DataSearchOperator
+
+    store = get_meta_store("postgres")
+    _seed(store)
+    store.ensure_set_column("keys", str)
+
+    sql, _ = store._build_condition(
+        DataSearchCondition(
+            field_path="keys",
+            operator=DataSearchOperator.contains_any,
+            value=["a", "b"],
+        )
+    )
+    assert "&&" in sql and "set_keys" in sql
+
+
+def test_ensure_set_column_is_idempotent_across_restarts():
+    """``ensure_set_column`` runs on every add_model, i.e. every process start."""
+    store = get_meta_store("postgres")
+    _seed(store)
+    store.ensure_set_column("keys", str)
+    store.ensure_set_column("keys", str)  # "restart"
+    store.ensure_set_column("keys", str)  # and again
+    assert _ids(store, ["a", "z"]) == ["1"]
+
+
+def test_rows_whose_field_is_absent_or_not_an_array_do_not_match():
+    """A row with no ``keys`` at all must stay out of contains_any results."""
+    store = get_meta_store("postgres")
+    _seed(store)
+    m = _meta("5", [])
+    m.indexed_data = {"id": "5"}  # field absent entirely
+    store[m.resource_id] = m
+    store.ensure_set_column("keys", str)
+
+    assert _ids(store, ["a", "z"]) == ["1"]
+
+
+@pytest.mark.parametrize(
+    ("elem_type", "seed", "probe", "expected"),
+    [
+        pytest.param(str, {"1": ["a"], "2": ["b"]}, ["a"], ["1"], id="list[str]"),
+        pytest.param(int, {"1": [1, 2], "2": [3]}, [3], ["2"], id="list[int]"),
+        pytest.param(float, {"1": [1.5], "2": [2.5]}, [2.5], ["2"], id="list[float]"),
+    ],
+)
+def test_backfill_covers_every_supported_element_type(elem_type, seed, probe, expected):
+    """SetIndex infers text / bigint / double precision from the annotation."""
+    store = get_meta_store("postgres")
+    _seed(store, seed)
+    store.ensure_set_column("keys", elem_type)
+    assert _ids(store, probe) == expected


### PR DESCRIPTION
Fixes #417.

Declaring `Annotated[list[str], SetIndex()]` on a model whose table **already held rows** made every pre-existing row silently invisible to `contains_any`.

## The bug

`ensure_set_column` runs from `add_model` — i.e. on every process start. It added the column (NULL for every existing row), created the GIN, and registered the field in `_set_columns`, which is exactly what switches the query builder onto `"set_f" && %s::text[]`. `NULL && anything` is NULL, never true. Backfilling was a separate **manual CLI** (`specstar backfill set-columns`), so the window between "deploy" and "a human remembers" was a silent-wrong-results window:

```
BEFORE annotating:         contains_any(['a','z']) -> ['1']
AFTER  annotating:         contains_any(['a','z']) -> []
new row written after:                             -> ['4']
after the manual CLI:                              -> ['1', '4']
```

**The third line is the dangerous one.** The query does not break — it keeps returning newly-written rows, so nothing looks wrong. It silently returns a *subset*. Anything built on `contains_any` (a permission filter, a dashboard, a retrieval path) degrades invisibly.

## Why the tests didn't catch it

Every existing test creates the column **before** seeding, so the write path fills it:

```python
store.ensure_set_column("keys", str)   # column first
_seed(store, {...})                    # rows second
```

Real deployments do the opposite: the data exists, then the annotation ships. `tests/meta_store/test_set_index_backfill_window.py` pins that order — the order that actually matters.

## The fix

Backfill inside `ensure_set_column`, **before** registering the field, so the fast path is never live over an unpopulated column. Order is the whole fix.

Restarts stay cheap: the startup backfill only touches rows still missing a value (`only_missing=True`), while `backfill_set_column` keeps forcing a full re-derivation for the CLI. This mirrors `_migrate_existing_records`, which already backfills `indexed_data` at startup in this same file.

## An existing test pinned the bug as intended — and why that reasoning was wrong

```python
# The schema-change gap: rows created before the shadow column existed have
# a NULL shadow column, so && misses them until a backfill (mirrors how
# Vector fields need backfill_vectors for pre-existing rows).
assert _ids(store, ["a"]) == []  # NULL shadow column → && misses
```

The Vector analogy is what went wrong. `backfill_vectors` cannot run implicitly because it must **re-embed** — expensive, external, model-dependent. The SetIndex column is, per `backfill_set_column`'s own docstring, *"a pure derivation of `indexed_data` (no re-encoding needed), so it runs entirely in SQL"*. There was nothing to defer to an operator; the analogy imported a constraint that doesn't exist here.

The suite also contradicted itself: `test_set_index.py`'s own module docstring states **"Declaring SetIndex must NOT change results — only how fast they come back"**. That invariant now holds.

## Residual, deliberately not fixed here

During a **mixed-version rollout**, an old pod writes rows without populating the column, and a new pod misses them until it restarts. That is inherent to a shadow **column** — state the application must maintain. #418's expression-index approach removes it structurally: an index is derived metadata that Postgres maintains, so no such window can exist. Flagged in the code and in #417.

## Testing

- `tests/meta_store/test_set_index_backfill_window.py` — **new**, 8 tests: the repro order, the subset-not-empty shape, fast-path-still-taken (the fix must not buy correctness by silently disabling the optimisation), restart idempotency, absent/non-array fields, and all three supported element types (`list[str]` / `list[int]` / `list[float]`).
- `tests/meta_store/test_set_index.py` — updated, with the reasoning above.
- CI lane (`-m "not integration and not benchmark and not slow"`): **3274 passed, 0 failed**.
- `tests/meta_store/` vs pristine master, like-for-like (`-k "not s3"`, since minio isn't running locally): **27 failed / 141 errors on both** — all pre-existing (redis not up) — and `+8 passed` = exactly the new tests. **Zero regressions.**