### PR TITLE
fix: SetIndex/SortIndex over the whole lifecycle, and when pods boot together

### DIFF
--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -250,12 +250,14 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         backends serve ``contains_any`` from the shared path and need no
         shadow column, so this is Postgres-only native acceleration.
 
-        Called from ``add_model``, i.e. on every process start. The freshly
-        added column is NULL for every row written before it existed, so the
-        rows are backfilled BEFORE the field is registered — registering is what
-        switches ``contains_any`` onto the ``&&`` fast path, and a fast path over
-        a NULL column silently returns no rows rather than failing (#417).
-        Restarts are cheap: the backfill only touches rows still missing a value.
+        Called from ``add_model``, i.e. on every process start. The column is
+        reconciled against ``indexed_data`` BEFORE the field is registered —
+        registering is what switches ``contains_any`` onto the ``&&`` fast path,
+        and that fast path over a column which is NULL (never filled) or stale
+        (filled, then the row changed while the annotation was absent) silently
+        returns wrong rows rather than failing (#417). Reconciling, rather than
+        filling the blanks, is what makes re-adding a removed annotation safe;
+        it is also idempotent, so a restart on a clean table costs zero writes.
         """
         pg_elem = self._SET_ELEM_TYPES.get(elem_type, "text")
         col = self._set_col_name(field_path)
@@ -278,7 +280,7 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             conn.close()
         # Order matters: populate first, register second. Mirrors the startup
         # backfill _migrate_existing_records already does for indexed_data.
-        self._run_set_backfill(field_path, pg_elem, only_missing=True)
+        self._run_set_backfill(field_path, pg_elem)
         self._set_columns[field_path] = pg_elem
 
     def _sort_idx_name(self, field_path: str) -> str:
@@ -303,20 +305,73 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         succeeded, and the build itself fails on legacy data. jsonb extraction is
         total, and jsonb orders numbers numerically, so this form cannot fail.
 
-        Idempotent; safe to call from ``add_model`` on every process start.
+        Idempotent; safe to call from ``add_model`` on every process start, and
+        from several pods at once (see :meth:`_build_sort_index_ddl`).
+        """
+        # Register FIRST, and never conditionally. The emitted SQL must follow the
+        # ANNOTATION — identical code on every pod — not the outcome of the DDL
+        # below. If registration could be skipped by a lost race or a raised DDL,
+        # pods would emit different SQL for the same query; on a string field the
+        # two forms do not merely differ in speed, the numeric-cast one raises.
+        # Whether the index exists only ever decides Seq Scan vs Index Scan.
+        self._sort_indexes.add(field_path)
+        self._build_sort_index_ddl(field_path)
+
+    def _build_sort_index_ddl(self, field_path: str) -> None:
+        """Best-effort: get the index built, without fighting the other pods.
+
+        Postgres permits only ONE concurrent index build per table at a time, so
+        N pods reaching ``CREATE INDEX CONCURRENTLY`` together deadlock each other
+        (measured: 4 of 6 pods died with DeadlockDetected — a CrashLoopBackOff on
+        the first rollout after the annotation ships). An advisory lock elects one
+        builder; the losers simply skip, which is safe precisely because a missing
+        index costs speed and nothing else. The index lives in Postgres, not in
+        the pod, so once the winner is done every pod's next query uses it — no
+        restart, no reconnect.
+
+        A build killed mid-flight leaves an INVALID index behind, and
+        ``IF NOT EXISTS`` matches BY NAME, so it would skip the repair forever
+        while the planner ignores the index — the annotation silently dead. Drop
+        it first when we find one.
         """
         idx_name = self._sort_idx_name(field_path)
+        # Stable across pods, distinct per (table, field), and fits in bigint.
+        lock_key = self._advisory_key(f"sort_index:{self.table_name}:{field_path}")
         conn = psycopg2.connect(self._pg_dsn)
-        conn.autocommit = True
+        conn.autocommit = True  # CONCURRENTLY cannot run inside a transaction
         try:
             with conn.cursor() as cur:
-                cur.execute(
-                    f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{idx_name}" '
-                    f"ON \"{self.table_name}\" ((indexed_data->'{field_path}'))"
-                )
+                cur.execute("SELECT pg_try_advisory_lock(%s)", [lock_key])
+                if not cur.fetchone()[0]:
+                    return  # another pod is on it; ours would only deadlock
+                try:
+                    cur.execute(
+                        "SELECT indisvalid FROM pg_index "
+                        "WHERE indexrelid = to_regclass(%s)",
+                        [idx_name],
+                    )
+                    row = cur.fetchone()
+                    if row is not None and not row[0]:
+                        cur.execute(f'DROP INDEX CONCURRENTLY IF EXISTS "{idx_name}"')
+                    cur.execute(
+                        f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{idx_name}" '
+                        f"ON \"{self.table_name}\" ((indexed_data->'{field_path}'))"
+                    )
+                finally:
+                    cur.execute("SELECT pg_advisory_unlock(%s)", [lock_key])
         finally:
             conn.close()
-        self._sort_indexes.add(field_path)
+
+    @staticmethod
+    def _advisory_key(name: str) -> int:
+        """A stable signed-bigint key for pg_advisory_lock.
+
+        Must not depend on PYTHONHASHSEED: pods have to agree.
+        """
+        import hashlib
+
+        digest = hashlib.blake2b(name.encode(), digest_size=8).digest()
+        return int.from_bytes(digest, "big", signed=True)
 
     def _extract_set_value(self, meta: ResourceMeta, field_path: str) -> "list | None":
         """The list value for a SetIndex column, copied from indexed_data."""
@@ -325,18 +380,22 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         v = meta.indexed_data.get(field_path)
         return v if isinstance(v, list) else None
 
-    def _run_set_backfill(
-        self, field_path: str, pg_elem: str, *, only_missing: bool
-    ) -> int:
-        """The backfill ``UPDATE`` itself, without the ``_set_columns`` guard.
+    def _run_set_backfill(self, field_path: str, pg_elem: str) -> int:
+        """Reconcile the shadow column with ``indexed_data``. Returns rows fixed.
 
-        ``ensure_set_column`` must be able to run this BEFORE registering the
-        field, so the ``&&`` fast path is never live against an unpopulated
-        column (#417).
+        Kept separate from :meth:`backfill_set_column` so ``ensure_set_column``
+        can run it BEFORE registering the field, i.e. before the ``&&`` fast path
+        can read the column (#417).
 
-        ``only_missing`` restricts the rewrite to rows the column has no value
-        for. Startup passes True, so a restart is a no-op rather than a full
-        table rewrite; the CLI passes False to force a complete re-derivation.
+        The predicate is ``IS DISTINCT FROM``, not ``IS NULL``. "Has this row been
+        filled in?" is the wrong question — writes populate the column from
+        ``_set_columns``, so a row written while the annotation was absent keeps
+        whatever the column held before (``ON CONFLICT DO UPDATE`` never names it).
+        Such a row is non-NULL and WRONG, and an ``IS NULL`` predicate skips it: the
+        fast path then answers from stale data, which unlike a NULL column also
+        returns rows that do not match. The right question is "does this row still
+        agree with the source of truth?", which also makes the pass idempotent —
+        a clean table costs zero writes, so running it on every boot is cheap.
         """
         col = self._set_col_name(field_path)
         extract = "jsonb_array_elements_text(indexed_data->%s)"
@@ -347,33 +406,29 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         )
         sql = (
             f'UPDATE "{self.table_name}" SET "{col}" = {arr} '
-            f"WHERE jsonb_typeof(indexed_data->%s) = 'array'"
+            f"WHERE jsonb_typeof(indexed_data->%s) = 'array' "
+            f'AND "{col}" IS DISTINCT FROM {arr}'
         )
-        if only_missing:
-            sql += f' AND "{col}" IS NULL'
         with self.transaction() as cur:
-            cur.execute(sql, [field_path, field_path])
+            cur.execute(sql, [field_path, field_path, field_path])
             return cur.rowcount
 
     def backfill_set_column(self, field_path: str) -> int:
-        """Repopulate the SetIndex shadow column for *field_path* from
-        ``indexed_data`` across all existing rows — for rows written before the
-        column was added (it defaults to NULL there). One pushed-down ``UPDATE``;
-        returns rows touched. No-op when the field has no shadow column.
+        """Reconcile the SetIndex shadow column for *field_path* against
+        ``indexed_data``. One pushed-down ``UPDATE``; returns rows fixed. No-op
+        when the field has no shadow column.
 
         Analogous to :func:`backfill_vectors` for Vector fields, but the value
         is a pure derivation of ``indexed_data`` (no re-encoding needed), so it
         runs entirely in SQL.
 
-        Since #417 ``ensure_set_column`` backfills on its own, so this is no
-        longer required to make a newly-declared SetIndex field correct. It
-        remains as the way to force a full re-derivation.
+        Since #417 ``ensure_set_column`` reconciles on its own, so this is not
+        required to make a newly-declared SetIndex field correct. It remains as
+        an explicit repair for a column suspected of drift.
         """
         if field_path not in self._set_columns:
             return 0
-        return self._run_set_backfill(
-            field_path, self._set_columns[field_path], only_missing=False
-        )
+        return self._run_set_backfill(field_path, self._set_columns[field_path])
 
     def _build_vector_condition(
         self, condition: "VectorDistanceCondition"

--- a/tests/meta_store/test_set_index.py
+++ b/tests/meta_store/test_set_index.py
@@ -161,8 +161,11 @@ def test_backfill_populates_set_column_for_rows_written_before_it_existed():
     store.ensure_set_column("keys", str)
     assert _ids(store, ["a"]) == ["1"]  # visible immediately, no manual step
     assert _ids(store, ["c"]) == ["2"]
-    # backfill_set_column stays, as the way to force a full re-derivation.
-    assert store.backfill_set_column("keys") == 2
+    # backfill_set_column reconciles rather than rewrites, so once
+    # ensure_set_column has run there is nothing left to repair. The count is
+    # rows FIXED, and zero is the honest answer here — see
+    # test_set_index_lifecycle.py for the cases where it is not.
+    assert store.backfill_set_column("keys") == 0
     assert _ids(store, ["a"]) == ["1"]
 
 
@@ -199,10 +202,30 @@ def test_backfill_set_columns_script_runs_via_resource_manager():
     rm.create(Foo(keys=["a", "b"]))
     rm.create(Foo(keys=["c"]))
 
+    # These rows were written WITH the annotation live, so the write path already
+    # kept the column consistent: the script reports zero rows repaired, which is
+    # a stronger statement than "it rewrote 2".
     summary = backfill_set_columns(rm, field_name="keys")
-    assert summary.encoded == 2
-    # still queryable after backfill
+    assert summary.encoded == 0
     assert len(rm.list_resources(QB["keys"].contains_any(["a"]).build())) == 1
+
+
+def test_backfill_set_columns_script_repairs_a_drifted_column():
+    """What the script is actually FOR: reconciling a column that disagrees."""
+    from specstar.resource_manager.backfill import backfill_set_columns
+
+    sp, rm, Foo = _pg_spec_with_foo()
+    rm.create(Foo(keys=["a", "b"]))
+    store = sp.get_resource_manager(Foo).storage.meta_store
+
+    with store.transaction() as cur:
+        cur.execute(f'UPDATE "{store.table_name}" SET set_keys = %s', [["stale"]])
+    assert len(rm.list_resources(QB["keys"].contains_any(["a"]).build())) == 0
+
+    summary = backfill_set_columns(rm, field_name="keys")
+    assert summary.encoded == 1
+    assert len(rm.list_resources(QB["keys"].contains_any(["a"]).build())) == 1
+    assert len(rm.list_resources(QB["keys"].contains_any(["stale"]).build())) == 0
 
 
 def test_multiple_set_index_fields_each_get_their_own_column():

--- a/tests/meta_store/test_set_index_lifecycle.py
+++ b/tests/meta_store/test_set_index_lifecycle.py
@@ -1,0 +1,145 @@
+"""SetIndex over its whole lifecycle, not just "someone added the annotation".
+
+#417 fixed the ADD case: backfill before enabling the fast path. It backfilled
+only rows whose column was NULL, which is not the same question. A row can hold a
+STALE value — writes populate the shadow column from ``_set_columns``, so while the
+annotation is absent the column is not maintained, and ``ON CONFLICT DO UPDATE``
+never touches it. Such a row is non-NULL and wrong, so an ``IS NULL`` backfill
+skips it and the fast path answers from stale data.
+
+That failure is worse in kind than the one #417 fixed: a NULL column only ever
+loses rows, but a stale column also RETURNS rows that do not match.
+
+The invariant these tests pin: the shadow column is a derivation of
+``indexed_data``, so after ``ensure_set_column`` it must agree with it — whatever
+happened in between.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from specstar.query import QB
+from specstar.types import ResourceMeta
+
+
+def _meta(rid: str, keys: list) -> ResourceMeta:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=f"id-{rid}",
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, "keys": keys},
+    )
+
+
+def _ids(store, values) -> list[str]:
+    q = QB["keys"].contains_any(values).build()
+    return sorted(m.indexed_data["id"] for m in store.iter_search(q))
+
+
+def _boot(table: str):
+    """A pod starting up WITHOUT the annotation."""
+    from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+
+    store = PostgresMetaStore(
+        pg_dsn="postgresql://admin:password@localhost:5432/your_database",
+        table_name=table,
+    )
+    store.register_list_field("keys")
+    return store
+
+
+def _table() -> str:
+    return "lifecycle_" + uuid.uuid4().hex[:8]
+
+
+def test_removing_the_annotation_falls_back_to_correct_results():
+    """No shadow column in play → the shared containment path answers."""
+    t = _table()
+    a = _boot(t)
+    a["id-1"] = _meta("1", ["a"])
+    a["id-2"] = _meta("2", ["b"])
+    a.ensure_set_column("keys", str)
+    assert _ids(a, ["a"]) == ["1"]
+
+    b = _boot(t)  # annotation removed → ensure_set_column is never called
+    assert _ids(b, ["a"]) == ["1"]
+
+
+def test_readding_the_annotation_after_rows_changed_does_not_serve_stale_data():
+    """remove → write → re-add. The write went unmirrored; the column is stale.
+
+    ``IS NULL`` skips it (it is not NULL, just wrong), so the fast path returns a
+    row that no longer matches AND misses the value it now has.
+    """
+    t = _table()
+    a = _boot(t)
+    a["id-1"] = _meta("1", ["a"])
+    a.ensure_set_column("keys", str)
+    assert _ids(a, ["a"]) == ["1"]
+
+    b = _boot(t)  # annotation removed
+    b["id-1"] = _meta("1", ["zzz"])  # the row's keys CHANGE while unannotated
+    assert _ids(b, ["zzz"]) == ["1"]
+    assert _ids(b, ["a"]) == []
+
+    c = _boot(t)  # annotation re-added
+    c.ensure_set_column("keys", str)
+
+    assert _ids(c, ["zzz"]) == ["1"], "re-adding the annotation lost a real match"
+    assert _ids(c, ["a"]) == [], (
+        "re-adding the annotation resurrected a stale match — the shadow column "
+        "still holds the pre-removal value"
+    )
+
+
+def test_backfill_repairs_a_column_that_disagrees_with_indexed_data():
+    """The public CLI entry point must fix stale values, not just missing ones."""
+    t = _table()
+    a = _boot(t)
+    a["id-1"] = _meta("1", ["a"])
+    a.ensure_set_column("keys", str)
+
+    # corrupt the shadow column behind the store's back (what an unannotated
+    # deployment effectively does)
+    with a.transaction() as cur:
+        cur.execute(
+            f'UPDATE "{t}" SET set_keys = %s WHERE resource_id = %s',
+            [["wrong"], "id-1"],
+        )
+    assert _ids(a, ["a"]) == []  # proves the column is what answers
+
+    assert a.backfill_set_column("keys") == 1
+    assert _ids(a, ["a"]) == ["1"]
+    assert _ids(a, ["wrong"]) == []
+
+
+def test_backfill_is_a_noop_when_the_column_already_agrees():
+    """Startup runs this on every boot; a clean table must cost zero writes."""
+    t = _table()
+    a = _boot(t)
+    for i in range(20):
+        a[f"id-{i}"] = _meta(str(i), [f"k{i}"])
+    a.ensure_set_column("keys", str)
+
+    assert a.backfill_set_column("keys") == 0
+
+
+def test_rows_added_while_unannotated_are_picked_up_on_re_add():
+    """A brand-new row written with no annotation has a NULL column."""
+    t = _table()
+    a = _boot(t)
+    a["id-1"] = _meta("1", ["a"])
+    a.ensure_set_column("keys", str)
+
+    b = _boot(t)  # annotation removed
+    b["id-2"] = _meta("2", ["a"])  # NEW row, shadow column never populated
+
+    c = _boot(t)  # annotation re-added
+    c.ensure_set_column("keys", str)
+    assert _ids(c, ["a"]) == ["1", "2"]

--- a/tests/meta_store/test_sort_index_multipod.py
+++ b/tests/meta_store/test_sort_index_multipod.py
@@ -1,0 +1,187 @@
+"""SortIndex when several pods boot at once — the normal case in production.
+
+``ensure_sort_index`` runs from ``add_model``, i.e. on every process start, and
+Postgres permits only ONE concurrent index build per table at a time. N pods
+racing to ``CREATE INDEX CONCURRENTLY`` deadlock each other, which on Kubernetes
+is a CrashLoopBackOff on the first rollout after the annotation ships — the worst
+possible moment.
+
+The escape is #418's own premise: an index's absence costs only speed, never
+correctness. So a pod that loses the race can simply not build it. What it must
+NOT do is behave differently: the emitted SQL is decided by the ANNOTATION, which
+is identical code on every pod, and never by whether this pod won the race or the
+DDL even succeeded. Otherwise pods disagree — and on a string field the two forms
+do not merely differ in speed, one of them raises.
+"""
+
+import threading
+import uuid
+
+import pytest
+
+from specstar.query import QB
+from specstar.query_types import DataSearchCondition, DataSearchOperator
+from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+from specstar.types import ResourceMeta
+
+DSN = "postgresql://admin:password@localhost:5432/your_database"
+N_PODS = 6
+
+
+def _meta(rid: str, score) -> ResourceMeta:
+    from datetime import UTC, datetime
+
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=f"id-{rid}",
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, "score": score},
+    )
+
+
+@pytest.fixture
+def table():
+    t = "multipod_" + uuid.uuid4().hex[:8]
+    seed = PostgresMetaStore(pg_dsn=DSN, table_name=t)
+    for i in range(400):
+        seed[f"id-{i}"] = _meta(str(i), i)
+    yield t
+    with seed.transaction() as cur:
+        cur.execute(f'DROP TABLE IF EXISTS "{t}" CASCADE')
+
+
+def _hits(store: PostgresMetaStore, cond) -> list[str]:
+    out = []
+    for m in store.iter_search(cond.build()):
+        assert isinstance(m.indexed_data, dict)  # narrow dict | UnsetType for ty
+        out.append(m.indexed_data["id"])
+    return sorted(out)
+
+
+def _boot_pods(table: str, n: int = N_PODS):
+    """n pods calling ensure_sort_index simultaneously, as add_model does."""
+    results: list = []
+
+    def pod(i):
+        try:
+            s = PostgresMetaStore(pg_dsn=DSN, table_name=table)
+            s.ensure_sort_index("score")
+            results.append((i, "OK", _hits(s, QB["score"] > 396), s))
+        except Exception as e:  # noqa: BLE001
+            results.append((i, f"{type(e).__name__}: {e}", None, None))
+
+    threads = [threading.Thread(target=pod, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return results
+
+
+def test_concurrent_boot_does_not_deadlock(table):
+    """Postgres allows one concurrent build per table; N pods must not fight."""
+    results = _boot_pods(table)
+    failures = [(i, err) for i, err, _, _ in results if err != "OK"]
+    assert not failures, f"pods crashed on boot: {failures}"
+
+
+def test_every_pod_answers_identically_regardless_of_who_built_the_index(table):
+    """The index lives in Postgres, not in the pod: whoever builds it, all pods
+    see it. Until then they all seq-scan — slow, never wrong."""
+    results = _boot_pods(table)
+    answers = {tuple(hits) for _, err, hits, _ in results if err == "OK"}
+    assert len(answers) == 1, f"pods disagreed: {answers}"
+    assert answers.pop() == ("397", "398", "399")
+
+
+def test_every_pod_emits_identical_sql(table):
+    """The SQL form must follow the annotation, not the DDL outcome."""
+    results = _boot_pods(table)
+    cond = DataSearchCondition(
+        field_path="score", operator=DataSearchOperator.greater_than, value=396
+    )
+    sqls = {s._build_condition(cond)[0] for _, err, _, s in results if err == "OK"}
+    assert len(sqls) == 1, f"pods emitted different SQL: {sqls}"
+
+
+def test_the_index_ends_up_valid_after_a_concurrent_boot(table):
+    _boot_pods(table)
+    s = PostgresMetaStore(pg_dsn=DSN, table_name=table)
+    with s.transaction() as cur:
+        cur.execute(
+            "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(%s)",
+            [s._sort_idx_name("score")],
+        )
+        row = cur.fetchone()
+    assert row is not None and row[0], "no valid index after all pods booted"
+
+
+def test_an_invalid_index_left_by_a_failed_build_is_repaired(table):
+    """A build killed mid-flight (OOM, eviction) leaves an INVALID index behind.
+
+    ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` then matches it BY NAME and skips
+    forever, and the planner ignores invalid indexes — so the annotation would be
+    silently dead for good.
+    """
+    s = PostgresMetaStore(pg_dsn=DSN, table_name=table)
+    idx = s._sort_idx_name("score")
+
+    # Force a failed build the way Postgres documents: a unique violation.
+    # (psycopg2 raises UniqueViolation, a subclass — named by its stubbed parent.)
+    import psycopg2
+
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'ALTER TABLE "{table}" ADD COLUMN dup int DEFAULT 1')
+            with pytest.raises(psycopg2.IntegrityError):
+                cur.execute(
+                    f'CREATE UNIQUE INDEX CONCURRENTLY "{idx}" ON "{table}" (dup)'
+                )
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(%s)",
+                [idx],
+            )
+            assert cur.fetchone()[0] is False, (
+                "expected an invalid index to squat on the name"
+            )
+    finally:
+        conn.close()
+
+    s.ensure_sort_index("score")
+
+    with s.transaction() as cur:
+        cur.execute(
+            "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(%s)", [idx]
+        )
+        row = cur.fetchone()
+    assert row is not None and row[0], "the invalid index was not repaired"
+
+
+def test_results_are_correct_even_if_the_ddl_cannot_run(table, monkeypatch):
+    """A pod that cannot build the index must still answer correctly.
+
+    This is the whole premise: registration follows the annotation, the DDL is
+    best effort.
+    """
+    s = PostgresMetaStore(pg_dsn=DSN, table_name=table)
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated: DDL unavailable")
+
+    monkeypatch.setattr(s, "_build_sort_index_ddl", boom, raising=False)
+    try:
+        s.ensure_sort_index("score")
+    except RuntimeError:
+        pass  # even if it propagates, registration must already have happened
+
+    assert "score" in s._sort_indexes
+    assert _hits(s, QB["score"] > 396) == ["397", "398", "399"]


### PR DESCRIPTION
Follow-up to #417 and #418. Both were tested for one scenario — *someone adds the annotation* — and both break outside it. Same blind spot, two symptoms.

## 1. SetIndex served STALE data after an annotation was removed and re-added

#417 backfilled rows whose column was `NULL`, but that is the wrong question. The write path populates the shadow column from `_set_columns`, so while the annotation is absent the column is **not maintained** and `ON CONFLICT DO UPDATE` never names it — the row keeps whatever the column held before. That row is non-`NULL` and **wrong**, so an `IS NULL` predicate skips it:

```
annotate:                    contains_any(['a'])   -> ['1']
remove, row changes to zzz:  contains_any(['zzz']) -> ['1']
re-add:                      contains_any(['zzz']) -> []      <- lost a real match
                             contains_any(['a'])   -> ['1']   <- resurrected a stale one
```

The last line is **worse in kind** than the bug #417 fixed: a NULL column only ever *loses* rows; a stale one also **returns rows that do not match**.

The predicate is now `IS DISTINCT FROM` the value derived from `indexed_data` — *"does this row still agree with the source of truth?"* rather than *"has this row been filled in?"*. That also makes the pass idempotent, so **`only_missing` is gone entirely**: a clean table costs zero writes (which is what made the flag worth having), and reconciling a row that already agrees is a no-op by definition. One code path, sound, still cheap on every boot.

`backfill_set_column` now returns rows **repaired**, not rows rewritten. Two tests asserted the old count; `0` is the honest answer there and a *stronger* statement (the write path had kept the column consistent), so they say that now — plus a new test for what the script is actually for: repairing a column that drifted.

## 2. SortIndex deadlocked every rollout with more than one pod

Postgres permits only **one** concurrent index build per table at a time, and `ensure_sort_index` runs from `add_model` — every process start. Measured with 6 pods booting together: **4 died with `DeadlockDetected`**. On Kubernetes that is a CrashLoopBackOff on the first rollout after the annotation ships — the worst possible moment.

An advisory lock keyed on `(table, field)` elects one builder; the losers skip. Skipping is safe for exactly the reason #418 exists: **an index's absence costs speed and nothing else.** The index lives in Postgres, not in the pod, so once the winner is done *every* pod's next query uses it — no restart, no reconnect:

| | before | after |
|---|---|---|
| 6 pods booting | 4× `DeadlockDetected` | 1 builder **131 ms**, 5 skips **10 ms**, zero deadlocks |

Verified separately: one long-lived connection flips `SeqScan` → `Bitmap` the moment *another session* builds the index, and back to `SeqScan` on drop — with the row count never changing. That is the whole premise made concrete.

A build killed mid-flight leaves an **INVALID** index, and `IF NOT EXISTS` matches **by name** — so it would skip the repair forever while the planner ignores the index, leaving the annotation silently dead. `indisvalid` is now checked and a broken index dropped before rebuilding.

## 3. Registration must not branch on the DDL

`_sort_indexes.add()` now happens **first and unconditionally**. The emitted SQL is decided by the **annotation** — identical code on every pod — never by who won the race or whether the DDL raised. Otherwise pods disagree, and on a string field the two forms don't merely differ in speed:

```
jsonb form (registered pod):    5554 rows
cast  form (unregistered pod):  InvalidTextRepresentation: invalid input syntax for numeric: "n1"
```

"Sometimes right, sometimes not" is worse than uniformly slow.

## Not fixed here (pre-existing, needs its own decision)

Changing a SetIndex element type (`list[str]` → `list[int]`) leaves the column at its old type, because `ADD COLUMN IF NOT EXISTS` matches by name — every `contains_any` then fails with `operator does not exist: text[] && bigint[]`. It fails **loudly** rather than silently, and repairing it needs an `ALTER` + full rebuild: a deploy-time table rewrite that deserves its own decision.

## Testing

- `tests/meta_store/test_set_index_lifecycle.py` — **new**, 5 tests: remove → fallback correct; remove → write → re-add → no stale false positive; the CLI repairs drift; a clean table costs zero writes; rows added while unannotated are picked up.
- `tests/meta_store/test_sort_index_multipod.py` — **new**, 6 tests: 6 pods boot concurrently without deadlock; every pod answers identically; **every pod emits identical SQL**; the index ends up valid; an invalid index is repaired; results stay correct even when the DDL cannot run at all.
- `tests/meta_store/test_set_index.py` — two count assertions updated to the reconcile semantics, plus a new drift-repair test.
- `tests/meta_store/` vs master, compared as **failure-ID sets** (not counts — the suite is flaky at ±3 with redis down): **182 = 182, identical, zero regressions**.
- `ruff check` clean on the touched files. `ty`: **238 on both** master and this branch — none added.