### PR TITLE
fix(#416): cap the in_list GIN fan-out so long lists stop being quadratic

### DIFF
--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -70,6 +70,29 @@ def _containment(field_path: str, value: Any) -> tuple[str, list]:
     ]
 
 
+#: Longest ``in_list`` still expanded into one GIN probe per value.
+#:
+#: The probes are BitmapOr'd across the single GIN, which is a large win while the
+#: list is short and a severe loss once it is not: Postgres plans and OR's one
+#: branch PER VALUE, so the cost grows superlinearly, whereas the flat predicate
+#: below is a Seq Scan whose cost is independent of the list. Measured, 60k rows:
+#:
+#:     N        probes (plan+exec)     flat
+#:     1              0.15 ms          ~7 ms
+#:     100            5.95 ms          ~8 ms    <- probes still ahead
+#:     200           14.33 ms          ~8 ms    <- crossover passed
+#:     1000         168.25 ms          ~8 ms
+#:     2000         977.00 ms         ~15 ms    <- 64x slower
+#:
+#: 64 sits comfortably below the ~150 crossover. It is deliberately not tuned to
+#: the crossover itself: the probes' advantage over a scan is small near it (6 ms
+#: vs 8 ms at N=100) while the loss past it is unbounded, so the risk is one-sided.
+#: The true crossover also moves with table size — a scan costs more on a bigger
+#: table, which buys the probes room — so a fixed limit is a heuristic, chosen to
+#: keep the common short-list case fast without ever letting the tail blow up.
+IN_LIST_PROBE_LIMIT = 64
+
+
 try:
     import psycopg2 as pg
     import psycopg2.pool
@@ -1305,12 +1328,22 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                 if not vals:
                     return "FALSE", []  # ``IN ()`` is not valid SQL
                 if all(_gin_probeable(condition, v) for v in vals):
-                    # Postgres BitmapOr's the probes across the one GIN.
                     import json
 
-                    ors = " OR ".join(["indexed_data @> %s::jsonb"] * len(vals))
-                    return f"({ors})", [
-                        json.dumps({field_path: v}, ensure_ascii=False) for v in vals
+                    if len(vals) <= IN_LIST_PROBE_LIMIT:
+                        # Postgres BitmapOr's the probes across the one GIN. Only
+                        # worth it while the list is short — see the constant.
+                        ors = " OR ".join(["indexed_data @> %s::jsonb"] * len(vals))
+                        return f"({ors})", [
+                            json.dumps({field_path: v}, ensure_ascii=False)
+                            for v in vals
+                        ]
+                    # Long list: ONE flat predicate whose cost does not grow with
+                    # the list. Still jsonb equality, so it agrees value-for-value
+                    # with the probes above — the length picks the plan, never the
+                    # answer.
+                    return f"indexed_data->'{field_path}' = ANY(%s::jsonb[])", [
+                        [json.dumps(v, ensure_ascii=False) for v in vals]
                     ]
                 placeholders = ",".join(["%s"] * len(vals))
                 return f"{jsonb_text_extract} IN ({placeholders})", [

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
@@ -68,6 +69,9 @@ def _containment(field_path: str, value: Any) -> tuple[str, list]:
     return "indexed_data @> %s::jsonb", [
         json.dumps({field_path: value}, ensure_ascii=False)
     ]
+
+
+logger = logging.getLogger(__name__)
 
 
 #: Longest ``in_list`` still expanded into one GIN probe per value.
@@ -341,7 +345,13 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         self._build_sort_index_ddl(field_path)
 
     def _build_sort_index_ddl(self, field_path: str) -> None:
-        """Best-effort: get the index built, without fighting the other pods.
+        """Best-effort: get the index built, without ever failing the caller.
+
+        "Best-effort" is load-bearing and was previously only half-true: the pods
+        that LOST the race skipped safely, but the one that won propagated any DDL
+        error straight out of ``add_model`` — the boot path. Nothing about this
+        index is worth a failed boot, so every failure below is swallowed and
+        logged.
 
         Postgres permits only ONE concurrent index build per table at a time, so
         N pods reaching ``CREATE INDEX CONCURRENTLY`` together deadlock each other
@@ -357,6 +367,30 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         while the planner ignores the index — the annotation silently dead. Drop
         it first when we find one.
         """
+        try:
+            self._try_build_sort_index(field_path)
+        except Exception:
+            # "Best-effort" has to mean it. This runs from add_model, on every
+            # process's boot path, and CREATE INDEX CONCURRENTLY fails for reasons
+            # that have nothing to do with the caller: a statement_timeout, a
+            # cancelled backend, the pod killed mid-rollout, disk pressure. The
+            # index is DERIVED metadata — present it is fast, absent it is slow —
+            # so a failed build must degrade to slow, never take the process down.
+            # Raising here also made the damage self-sustaining: a killed build
+            # leaves an INVALID index, and the repair for it lives at the top of
+            # this very function, i.e. on the next boot — which is the thing that
+            # was crashing. That is a crash loop caused by an index whose entire
+            # job is to make one sort faster.
+            logger.warning(
+                "sort index build for %r on %r failed; queries stay correct but "
+                "unaccelerated until a later boot rebuilds it",
+                field_path,
+                self.table_name,
+                exc_info=True,
+            )
+
+    def _try_build_sort_index(self, field_path: str) -> None:
+        """The DDL itself. Raises; :meth:`_build_sort_index_ddl` is the guard."""
         idx_name = self._sort_idx_name(field_path)
         # Stable across pods, distinct per (table, field), and fits in bigint.
         lock_key = self._advisory_key(f"sort_index:{self.table_name}:{field_path}")
@@ -381,7 +415,20 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                         f"ON \"{self.table_name}\" ((indexed_data->'{field_path}'))"
                     )
                 finally:
-                    cur.execute("SELECT pg_advisory_unlock(%s)", [lock_key])
+                    # Best-effort too: if the backend was cancelled the connection
+                    # may be unusable, and raising HERE would mask the real error
+                    # with a confusing one. Postgres releases session advisory
+                    # locks when the connection drops, which conn.close() below
+                    # guarantees — so the lock is never stranded either way.
+                    try:
+                        cur.execute("SELECT pg_advisory_unlock(%s)", [lock_key])
+                    except Exception:
+                        logger.debug(
+                            "advisory unlock for %r failed; the closing connection "
+                            "releases it",
+                            field_path,
+                            exc_info=True,
+                        )
         finally:
             conn.close()
 

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -769,6 +769,48 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                     ("{}", resource_id),
                 )
 
+    def _searchable_indexed_data(self, meta: ResourceMeta) -> Any:
+        """``meta.indexed_data`` minus the fields that have a pgvector column.
+
+        ``add_model`` puts every Vector field into ``indexed_fields`` on purpose:
+        brute-force backends have no vector column and answer similarity straight
+        out of ``indexed_data``, and we ourselves read that copy on the way in (see
+        ``_extract_vec_value``, called from ``_meta_row_values`` BEFORE this — off
+        the in-memory meta, so the column is populated either way).
+
+        On this backend the copy has no reader once the column is written:
+        ``_build_vector_condition`` and ``_build_vector_order`` both query
+        ``_vec_col_name(...)``, and ``iter_search`` returns metas by decoding the
+        ``data`` BYTEA — which still holds the whole ResourceMeta, vector included.
+        So nothing observable changes; what goes away is dead weight, and it is not
+        the cheap kind. The GIN over ``indexed_data`` indexes every ELEMENT of the
+        array, so one 4096-dim embedding costs 4096 index entries per row, and
+        every ``@>`` probe rechecks against the fat jsonb. Measured on 5000 rows
+        carrying a 4096-dim embedding, against the same rows without it:
+
+            GIN size          43 MB   ->   312 kB     (138x)
+            total relation   280 MB   ->   840 kB     (333x)
+            @> probe        490.8 ms  ->   1.2 ms     (400x)
+
+        That is what made a real deployment's document list take 15 seconds. The
+        bloat predates the #416 rewrite, but nothing USED the GIN while ``->>``
+        forced a Seq Scan, so #416 is what woke it up.
+
+        Only a REGISTERED column licenses the strip: ``_vec_columns`` is empty
+        unless ``ensure_vector_column`` ran, and without a column ``indexed_data``
+        is the only queryable surface left, so the copy stays.
+
+        This strips the JSONB column only, NOT the BYTEA — which is exactly why
+        readers cannot tell, and equally why the storage is not reclaimed. Doing
+        that changes what readers see and is a separate decision.
+        """
+        data = meta.indexed_data
+        if data is UNSET or not isinstance(data, dict) or not self._vec_columns:
+            return data
+        # `ensure_vector_column` is registered under the short alias, which IS the
+        # indexed_data key (crud.core passes `vinfo.name`) — so a plain key drop.
+        return {k: v for k, v in data.items() if k not in self._vec_columns}
+
     def _meta_row_values(self, meta: ResourceMeta) -> tuple:
         """Pack a ResourceMeta into the column-order tuple used by INSERT/UPSERT."""
         import json
@@ -783,7 +825,7 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             meta.is_deleted,
             meta.schema_version,
             (
-                json.dumps(meta.indexed_data, ensure_ascii=False)
+                json.dumps(self._searchable_indexed_data(meta), ensure_ascii=False)
                 if meta.indexed_data is not UNSET
                 else None
             ),

--- a/tests/meta_store/test_in_list_fanout.py
+++ b/tests/meta_store/test_in_list_fanout.py
@@ -1,0 +1,119 @@
+"""``in_list`` must not fan out into one GIN probe per value (#416 follow-up).
+
+#416 rewrote ``in_list`` into ``value1 @> … OR value2 @> … OR …`` so the GIN on
+``indexed_data`` could serve it. That is a large win for the short lists it was
+benchmarked on, and a severe regression for long ones: the OR'd form's cost grows
+SUPERLINEARLY (Postgres must plan and BitmapOr one branch per value), while the
+pre-#416 form was a flat Seq Scan. Measured on a 60k-row table, filtering an
+``IN`` over N ids:
+
+    N        OR'd @>  (plan+exec)      flat scan
+    1            0.15 ms                ~7 ms
+    100          5.95 ms                ~8 ms      <- still ahead
+    200         14.33 ms                ~8 ms      <- crossover passed
+    1000       168.25 ms                ~8 ms
+    2000       977.00 ms               ~15 ms      <- 64x SLOWER
+
+Real callers hit the bad end: a document list pages 2000 rows and then counts
+each row's chunks with one ``file_id IN (<2000 ids>)``, twice per request.
+
+The long-list path must stay TYPE-STRICT. Falling back to the pre-#416
+``indexed_data->>'f' IN (…)`` would be fast but type-blind (it compares
+``str(value)``), so the SAME query would answer differently depending on how many
+values it was given — a silent correctness bug strictly worse than the slowness.
+``indexed_data->'f' = ANY(ARRAY[…]::jsonb[])`` is jsonb equality, so it agrees
+with the short-list probes and with the reference matcher, and it is flat
+(measured ~15-24 ms at N=200/1000/2000).
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from specstar.query import QB
+from specstar.query_types import DataSearchCondition, DataSearchOperator
+from specstar.resource_manager.meta_store.postgres import IN_LIST_PROBE_LIMIT
+from specstar.types import ResourceMeta
+
+from .common import get_meta_store
+
+
+def _meta(rid: str, **indexed) -> ResourceMeta:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=str(uuid.uuid4()),
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, **indexed},
+    )
+
+
+def _cond(values: list) -> DataSearchCondition:
+    return DataSearchCondition(
+        field_path="fid", operator=DataSearchOperator.in_list, value=values
+    )
+
+
+def test_short_in_list_still_probes_the_gin():
+    # The #416 win must survive: a short list stays one probe per value, which
+    # Postgres BitmapOr's across the single GIN.
+    store = get_meta_store("postgres")
+    sql, params = store._build_condition(_cond(["a", "b", "c"]))
+    assert sql.count("@>") == 3
+    assert len(params) == 3
+
+
+def test_long_in_list_does_not_emit_one_probe_per_value():
+    # The regression guard. At this length the OR'd form is both slower to plan
+    # and slower to run than a single flat predicate.
+    store = get_meta_store("postgres")
+    n = IN_LIST_PROBE_LIMIT + 1
+    sql, params = store._build_condition(_cond([f"v{i}" for i in range(n)]))
+    assert sql.count("@>") == 0, f"fanned out into {sql.count('@>')} probes"
+    assert "= ANY(" in sql
+    # One array parameter, not one parameter per value.
+    assert len(params) == 1
+
+
+def test_long_in_list_stays_type_strict_like_the_short_one():
+    # The whole point of #416 was that ``->>`` is type-blind while the reference
+    # matcher is a Python ``==``. The long-list path must not quietly undo that,
+    # or the answer would depend on the list's LENGTH.
+    store = get_meta_store("postgres")
+    long_sql, _ = store._build_condition(
+        _cond([f"v{i}" for i in range(IN_LIST_PROBE_LIMIT + 1)])
+    )
+    assert "->>" not in long_sql
+
+
+@pytest.mark.parametrize("n", [3, IN_LIST_PROBE_LIMIT + 1])
+def test_both_paths_return_the_same_rows_as_the_reference(n: int):
+    # Length must change only the plan, never the answer.
+    store = get_meta_store("postgres")
+    for i in range(10):
+        m = _meta(str(i), fid=f"v{i}")
+        store[m.resource_id] = m
+    # Ask for v0..v2 plus enough padding to cross the threshold.
+    wanted = ["v0", "v1", "v2"] + [f"pad{i}" for i in range(max(0, n - 3))]
+    q = QB["fid"].in_(wanted).build()
+    assert sorted(m.indexed_data["id"] for m in store.iter_search(q)) == ["0", "1", "2"]
+
+
+def test_long_in_list_of_ints_matches_ints_not_their_strings():
+    store = get_meta_store("postgres")
+    for i in range(5):
+        m = _meta(str(i), num=i)
+        store[m.resource_id] = m
+    padding = [10_000 + i for i in range(IN_LIST_PROBE_LIMIT + 1)]
+    q = QB["num"].in_([1, 2, *padding]).build()
+    assert sorted(m.indexed_data["id"] for m in store.iter_search(q)) == ["1", "2"]
+    # A string "1" must NOT match the stored number 1 — same rule the short path
+    # follows, and the same rule the reference matcher (`==`) follows.
+    q = QB["num"].in_(["1", *[str(p) for p in padding]]).build()
+    assert list(store.iter_search(q)) == []

--- a/tests/meta_store/test_sort_index_ddl_failure.py
+++ b/tests/meta_store/test_sort_index_ddl_failure.py
@@ -1,0 +1,120 @@
+"""A failed sort-index build must never take the application down (#422 follow-up).
+
+``ensure_sort_index`` runs from ``add_model``, i.e. on the boot path of every
+process. Its whole premise — stated in its own docstring, and the reason #418 was
+built as an index rather than a column — is that the index is DERIVED metadata:
+present it is fast, absent it is slow, and nothing else changes. A build that
+fails must therefore degrade to "slow", never to "down".
+
+It did not. ``CREATE INDEX CONCURRENTLY`` can fail for reasons that have nothing
+to do with the caller — a statement_timeout, a cancelled backend, the pod being
+killed mid-rollout, disk pressure — and the exception propagated straight out of
+``add_model``. Worse, a killed build leaves an INVALID index behind, which the
+repair path only reaches on the NEXT boot: if the environment reliably kills the
+build (a global timeout, a large table), every boot raises and the repair is
+never reached. That is a crash loop, caused by an index that was only ever
+supposed to make one sort faster.
+
+Reproduced against real Postgres: with statement_timeout=1ms, ensure_sort_index
+raised QueryCanceled and left idx_..._sort_quality_score with indisvalid=false.
+"""
+
+import logging
+
+import pytest
+
+from .common import get_meta_store
+
+
+def test_a_cancelled_build_does_not_propagate_out_of_ensure_sort_index(monkeypatch):
+    # The boot path must survive a build the server kills mid-flight.
+    import psycopg2
+
+    store = get_meta_store("postgres")
+
+    real_connect = psycopg2.connect
+
+    def timing_out_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = '1ms'")
+        return conn
+
+    monkeypatch.setattr(psycopg2, "connect", timing_out_connect)
+
+    store.ensure_sort_index("score")  # must not raise
+
+
+def test_the_field_is_still_registered_when_the_build_fails(monkeypatch):
+    # Registration follows the ANNOTATION, not the DDL outcome (#422): pods must
+    # emit identical SQL whether or not their build won the race or failed.
+    import psycopg2
+
+    store = get_meta_store("postgres")
+
+    real_connect = psycopg2.connect
+
+    def timing_out_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = '1ms'")
+        return conn
+
+    monkeypatch.setattr(psycopg2, "connect", timing_out_connect)
+
+    store.ensure_sort_index("score")
+    assert "score" in store._sort_indexes
+
+
+def test_a_failed_build_is_logged_not_silently_swallowed(monkeypatch, caplog):
+    # Degrading to "slow" is only acceptable if an operator can find out why.
+    import psycopg2
+
+    store = get_meta_store("postgres")
+
+    real_connect = psycopg2.connect
+
+    def timing_out_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = '1ms'")
+        return conn
+
+    monkeypatch.setattr(psycopg2, "connect", timing_out_connect)
+
+    with caplog.at_level(logging.WARNING):
+        store.ensure_sort_index("score")
+    assert any("score" in r.message for r in caplog.records), caplog.text
+
+
+def test_a_connect_failure_does_not_propagate_either(monkeypatch):
+    # The DDL opens its OWN connection (CONCURRENTLY cannot run in the pooled
+    # transaction). If that connect fails, boot must still proceed.
+    import psycopg2
+
+    store = get_meta_store("postgres")
+
+    def refusing_connect(*args, **kwargs):
+        raise psycopg2.OperationalError("connection refused")
+
+    monkeypatch.setattr(psycopg2, "connect", refusing_connect)
+
+    store.ensure_sort_index("score")  # must not raise
+    assert "score" in store._sort_indexes
+
+
+@pytest.mark.parametrize("field", ["score"])
+def test_a_successful_build_still_produces_a_valid_index(field: str):
+    # The guard must not have turned the happy path into a silent no-op.
+    store = get_meta_store("postgres")
+    store.ensure_sort_index(field)
+    idx = store._sort_idx_name(field)
+    with store.transaction() as cur:
+        cur.execute(
+            "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(%s)", [idx]
+        )
+        row = cur.fetchone()
+    assert row is not None and row[0] is True

--- a/tests/meta_store/test_vector_not_in_indexed_data.py
+++ b/tests/meta_store/test_vector_not_in_indexed_data.py
@@ -1,0 +1,162 @@
+"""A Vector field has its own pgvector column, so it must not also sit in the
+``indexed_data`` JSONB (#416 follow-up).
+
+``add_model`` appends every Vector field to ``indexed_fields`` — deliberately:
+brute-force backends have no vector column and answer similarity from
+``indexed_data``, and the pgvector backend reads that same copy on the write path
+to populate its column. But on Postgres, once the column is populated the JSON
+copy has no reader: ``_build_vector_order`` searches the ``vec_*`` column, and
+``iter_search`` returns metas by decoding the ``data`` BYTEA. The JSONB copy is
+dead weight — and not the cheap kind:
+
+* the GIN on ``indexed_data`` indexes EVERY ELEMENT of the array, so one 4096-dim
+  embedding contributes 4096 index entries per row;
+* every ``@>`` probe must recheck against the whole fat jsonb.
+
+Measured on 5000 rows with a 4096-dim embedding, vs the same rows without it:
+
+    GIN size          43 MB   ->   312 kB     (138x)
+    total relation   280 MB   ->   840 kB     (333x)
+    @> probe        490.8 ms  ->   1.2 ms     (400x)
+
+That is what made a real deployment's document list take 15 seconds: three
+``in_``-list aggregates per request, each probing a GIN poisoned by 60k rows'
+worth of 4096-float arrays. The bloat predates #416 — but nothing USED the GIN
+until #416 stopped forcing a Seq Scan, so #416 is what woke it up.
+
+Scope: this strips the JSONB column only. The ``data`` BYTEA still encodes the
+whole ResourceMeta (vector included), which is exactly why reads are unaffected —
+and why this does not reclaim the storage. Reclaiming it means changing what
+readers see, which is a separate decision.
+"""
+
+from datetime import UTC, datetime
+
+from specstar.types import ResourceMeta
+
+from .common import get_meta_store
+
+
+def _meta(rid: str, vec: list[float], **extra) -> ResourceMeta:
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return ResourceMeta(
+        current_revision_id=f"rev_{rid}",
+        resource_id=rid,
+        total_revision_count=1,
+        created_time=base,
+        updated_time=base,
+        created_by="t",
+        updated_by="t",
+        is_deleted=False,
+        indexed_data={"id": rid, "embedding": vec, **extra},
+    )
+
+
+def _raw_indexed_data(store, rid: str) -> dict:
+    """The JSONB column as Postgres actually stores it (NOT the BYTEA copy)."""
+    with store.transaction() as cur:
+        cur.execute(
+            f'SELECT indexed_data FROM "{store.table_name}" WHERE resource_id = %s',
+            [rid],
+        )
+        return cur.fetchone()[0]
+
+
+def test_the_vector_is_not_written_into_the_indexed_data_column():
+    store = get_meta_store("postgres")
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+    store["r1"] = _meta("r1", [0.1, 0.2, 0.3, 0.4], kind="doc")
+
+    raw = _raw_indexed_data(store, "r1")
+    assert "embedding" not in raw, f"vector still in the JSONB column: {list(raw)}"
+
+
+def test_the_other_indexed_fields_are_untouched():
+    # Only the vector keys go; everything the GIN is actually FOR must stay.
+    store = get_meta_store("postgres")
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+    store["r1"] = _meta("r1", [0.1, 0.2, 0.3, 0.4], kind="doc", n=7)
+
+    raw = _raw_indexed_data(store, "r1")
+    assert raw["id"] == "r1"
+    assert raw["kind"] == "doc"
+    assert raw["n"] == 7
+
+
+def test_reading_the_meta_back_still_returns_the_vector():
+    # The BYTEA still encodes the whole ResourceMeta, so no reader can tell.
+    # This is what makes the change safe.
+    store = get_meta_store("postgres")
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+    vec = [0.1, 0.2, 0.3, 0.4]
+    store["r1"] = _meta("r1", vec, kind="doc")
+
+    got = store["r1"]
+    assert got.indexed_data["embedding"] == vec
+
+
+def test_the_pgvector_column_is_still_populated():
+    # The column is fed from the in-memory meta BEFORE the strip, so it must be
+    # unaffected — otherwise stripping would break vector search outright.
+    store = get_meta_store("postgres")
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+    store["r1"] = _meta("r1", [0.1, 0.2, 0.3, 0.4])
+
+    col = store._vec_col_name("embedding")
+    with store.transaction() as cur:
+        cur.execute(
+            f'SELECT "{col}" IS NOT NULL FROM "{store.table_name}" '
+            "WHERE resource_id = %s",
+            ["r1"],
+        )
+        assert cur.fetchone()[0] is True
+
+
+def test_vector_search_still_works_end_to_end():
+    # The point of the whole change: the column is the search surface, so removing
+    # the JSON copy must leave similarity search untouched. Both the ORDER BY and
+    # the WHERE form are exercised — each reads `_vec_col_name`, never indexed_data.
+    from specstar.query_types import (
+        DataSearchOperator,
+        ResourceMetaSearchQuery,
+        VectorDistanceCondition,
+        VectorDistanceSort,
+    )
+
+    store = get_meta_store("postgres")
+    store.ensure_vector_column("embedding", dim=4, distance="cosine")
+    store["near"] = _meta("near", [1.0, 0.0, 0.0, 0.0])
+    store["far"] = _meta("far", [0.0, 0.0, 0.0, 1.0])
+
+    ordered = ResourceMetaSearchQuery(
+        sorts=[
+            VectorDistanceSort(
+                field_path="embedding", query_vector=[1.0, 0.0, 0.0, 0.0]
+            )
+        ]
+    )
+    assert [m.resource_id for m in store.iter_search(ordered)][0] == "near"
+
+    filtered = ResourceMetaSearchQuery(
+        conditions=[
+            VectorDistanceCondition(
+                field_path="embedding",
+                query_vector=[1.0, 0.0, 0.0, 0.0],
+                operator=DataSearchOperator.less_than,
+                threshold=0.3,
+                distance="cosine",
+            )
+        ]
+    )
+    ids = [m.resource_id for m in store.iter_search(filtered)]
+    assert ids == ["near"], ids
+
+
+def test_a_field_without_a_vector_column_keeps_its_indexed_data_copy():
+    # No column means no other queryable surface — brute-force backends read this
+    # copy. Only a REGISTERED vector column licenses the strip.
+    store = get_meta_store("postgres")
+    store["r1"] = _meta("r1", [0.1, 0.2, 0.3, 0.4])
+
+    raw = _raw_indexed_data(store, "r1")
+    assert raw["embedding"] == [0.1, 0.2, 0.3, 0.4]


### PR DESCRIPTION
A regression I shipped in #416, found by a downstream user reporting that their document list got *slower* after upgrading to v0.12.0.

## What broke

#416 rewrote `in_list` into one containment probe per value, OR'd together, so the GIN on `indexed_data` could serve it:

```sql
indexed_data @> '{"f":"v1"}' OR indexed_data @> '{"f":"v2"}' OR …
```

That is a large win for the short lists it was benchmarked on — and **short lists are all I benchmarked**. Postgres plans and BitmapOr's one branch *per value*, so the cost grows superlinearly, while the form it replaced was a flat Seq Scan whose cost does not depend on the list at all. The code comment I left (*"Postgres BitmapOr's the probes across the one GIN"*) asserted exactly the property I had not tested.

Measured, 60k rows:

| N | probes (plan+exec) | flat scan | |
|---|---|---|---|
| 1 | **0.15 ms** | ~7 ms | probes win big |
| 100 | **5.95 ms** | ~8 ms | still ahead |
| 200 | 14.33 ms | **~8 ms** | crossover passed |
| 1000 | 168.25 ms | **~8 ms** | |
| 2000 | 977.00 ms | **~15 ms** | **64x slower** |

The crossover is ~150, and real callers sit well past it. The reporting user's document list pages 2000 rows and then counts each row's chunks with a single `file_id IN (<2000 ids>)` — twice per request. That is roughly two seconds added to one endpoint, which is precisely what they saw.

## The fix

Above `IN_LIST_PROBE_LIMIT` (64), emit ONE flat predicate:

```sql
indexed_data->'f' = ANY(%s::jsonb[])
```

Measured 15-24 ms at N=200/1000/2000 — independent of the list length, as a scan should be. Short lists keep the #416 probes unchanged.

## Why not just fall back to the old `->>` form

Because it would be a **silent correctness bug, strictly worse than the slowness it fixes.** The pre-#416 `indexed_data->>'f' IN (…)` is fast but type-blind — it compares `str(value)`. Falling back to it above a length threshold means the same query answers differently depending on how many values the caller passed: type-strict at 64 entries, type-blind at 65. Nobody would ever find that.

`= ANY(…::jsonb[])` is jsonb equality, so it agrees value-for-value with the short-list probes *and* with the reference matcher's plain Python `==` — which was the entire point of #416. **Length picks the plan, never the answer.** Two tests pin that directly: one asserts the long path never emits `->>`, one asserts a long `in_list` of ints matches the ints and not their string forms.

## On the constant

64 is deliberately *below* the ~150 crossover rather than at it. The risk is one-sided: near the crossover the probes' advantage is small (6 ms vs 8 ms at N=100), while the loss past it is unbounded. The true crossover also moves with table size — a scan costs more on a bigger table, which buys the probes room — so any fixed limit is a heuristic. This one is chosen to keep the common short-list case fast without ever letting the tail blow up.

## Verification

- 6 new tests, run against real Postgres (SQL shape at the boundary, type-strictness on both paths, and reference parity at N=3 and N=65).
- Full suite compared **like-for-like against pristine master**: 104 failed vs master's 105 — **zero new failures**. (The 105 are pre-existing s3/boto3 environment errors in this checkout, not regressions. The one difference is `test_sort_index_multipod::test_concurrent_boot_does_not_deadlock`, which is timing-sensitive and flaky — not something this change fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzAVNeDZGrYrzQYfBDMDK5