### PR TITLE
feat(query): .any()/.all() element quantifier for list-field string matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [0.12.1] — 2026-07-16
+
+
+### Fixed
+
+- Cap the in_list GIN fan-out so long lists stop being quadratic
+- A failed sort-index build must not take the process down
+
+
+### Performance
+
+- Keep Vector fields out of the indexed_data JSONB
+
 ## [0.12.0] — 2026-07-16
 
 

--- a/docs/en/howto/query-builder.md
+++ b/docs/en/howto/query-builder.md
@@ -104,6 +104,34 @@ QB["role"].not_in(["guest"])
 QB["owner"].one_of(["alice", "bob"])
 ```
 
+### Matching inside a list field: `.any()` / `.all()`
+
+On a **list-typed** indexed field, `.contains(v)` means exact *element
+membership* (`["m4"]` never matches `"m40"`). To match **within** an element —
+substring, prefix, regex — quantify over the elements with `.any()` (some
+element satisfies it) or `.all()` (every element does; an empty list matches
+`.all()` vacuously). Inside the quantifier each element is a scalar, so every
+string operator has its ordinary scalar meaning:
+
+```python
+QB["tags"].any().contains("ol")     # some element contains the substring "ol"
+QB["tags"].any().icontains("OL")    # ... case-insensitively
+QB["tags"].any().regex("^m")        # ... ^ / $ anchored to a single element
+QB["tags"].any().eq("mol")          # some element equals "mol" (same as .contains on a list)
+QB["tags"].all().starts_with("m")   # every element starts with "m"
+```
+
+This also works over HTTP: `?qb=QB["tags"].any().contains("ol")`.
+
+Calling a bare scalar string operator (`regex` / `starts_with` / `ends_with`,
+or the `icontains` family) **directly** on a list field is rejected — without a
+quantifier it would run against the serialised array (a cross-element,
+index-blind footgun). Use `.any()` / `.all()` instead.
+
+> Not to be confused with the `QB.any(cond1, cond2)` / `QB.all(...)` **static
+> combinators** below, which OR / AND whole conditions. Here the quantifier
+> ranges over one field's elements.
+
 ### Null and value checks
 
 ```python
@@ -222,6 +250,7 @@ a forgotten `limit` can't silently truncate the result.
 - if `qb` is used in HTTP requests, do not combine it with `data_conditions`, `conditions`, `sorts`, time-range / user filter params (`created_time_start`, `created_time_end`, `updated_time_start`, `updated_time_end`, `created_bys`, `updated_bys`), or revision filter params (`rev_statuses`, `rev_created_bys`, `rev_updated_bys`, `rev_created_time_start`, `rev_created_time_end`, `rev_updated_time_start`, `rev_updated_time_end`); conflicting requests return HTTP 422
 - **`is_deleted` is the one exception**: it may be combined with `qb`. The server ANDs it into the QB conditions automatically. Swagger always sends `is_deleted=false` by default, so QB expressions work in Swagger out of the box.
 - invalid or unsupported QB expressions return HTTP 400
+- a bare scalar string operator (`regex` / `starts_with` / `ends_with` / `icontains`) on a **list** field is rejected — quantify it with `.any()` / `.all()` instead
 - URL `limit` and `offset` override pagination values defined inside the QB expression
 - for metadata filtering in QB mode (time ranges, creator filters, revision filters, etc.), include them directly in the expression — for example `QB.created_time().last_n_days(7)`, `QB.created_by().eq("alice")`, or `QB.rev_status().eq("draft")`
 

--- a/specstar/__init__.py
+++ b/specstar/__init__.py
@@ -110,4 +110,4 @@ __all__ = [
     "pydantic_to_struct",
     "struct_to_pydantic",
 ]
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/specstar/query.py
+++ b/specstar/query.py
@@ -9,6 +9,7 @@ from specstar.query_types import (
     DataSearchGroup,
     DataSearchLogicOperator,
     DataSearchOperator,
+    DataSearchQuantifier,
     FieldTransform,
     ResourceDataSearchSort,
     ResourceMetaSearchQuery,
@@ -76,6 +77,7 @@ class VectorDistanceExpr:
             direction=ResourceMetaSortDirection.descending,
             distance=self.distance,
         )
+
 
 _PREV_Query = globals().get("Query")
 _PREV_ConditionBuilder = globals().get("ConditionBuilder")
@@ -405,6 +407,94 @@ class ConditionBuilder(Query):
         )
 
 
+class ElementQuantifier:
+    """Element-wise view of a **list** field, produced by :meth:`Field.any`.
+
+    Inside the quantifier, each list element is treated as a scalar, so every
+    string operator recovers its ordinary scalar meaning and is folded over the
+    elements by the quantifier:
+
+    - :meth:`eq` / :meth:`ne` — element (in)equality, i.e. membership;
+    - :meth:`contains` — element **substring** (not the whole-array membership
+      that bare ``Field.contains`` means on a list);
+    - :meth:`starts_with` / :meth:`ends_with` / :meth:`regex` — per-element,
+      with ``^``/``$`` anchored to a single element rather than the serialised
+      array;
+    - :meth:`icontains` / :meth:`istarts_with` / :meth:`iends_with` — the
+      case-insensitive regex sugar, per element.
+
+    ``any`` holds when SOME element satisfies the predicate (an empty list never
+    matches). See :class:`specstar.query_types.DataSearchQuantifier`.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        quantifier: DataSearchQuantifier,
+        transform: FieldTransform | None = None,
+    ):
+        self.name = name
+        self.quantifier = quantifier
+        self.transform = transform
+
+    def _cond(self, op: DataSearchOperator, val: Any) -> ConditionBuilder:
+        return ConditionBuilder(
+            DataSearchCondition(
+                field_path=self.name,
+                operator=op,
+                value=val,
+                transform=self.transform,
+                quantifier=self.quantifier,
+            )
+        )
+
+    def eq(self, value: Any) -> ConditionBuilder:
+        """Some element equals ``value`` (element membership)."""
+        return self._cond(DataSearchOperator.equals, value)
+
+    def ne(self, value: Any) -> ConditionBuilder:
+        """Some element is not equal to ``value``."""
+        return self._cond(DataSearchOperator.not_equals, value)
+
+    def contains(self, value: str) -> ConditionBuilder:
+        """Some element contains ``value`` as a substring."""
+        return self._cond(DataSearchOperator.contains, value)
+
+    def starts_with(self, value: str) -> ConditionBuilder:
+        """Some element starts with ``value``."""
+        return self._cond(DataSearchOperator.starts_with, value)
+
+    def ends_with(self, value: str) -> ConditionBuilder:
+        """Some element ends with ``value``."""
+        return self._cond(DataSearchOperator.ends_with, value)
+
+    def regex(self, value: str) -> ConditionBuilder:
+        """Some element matches the regex ``value`` (anchored per element)."""
+        return self._cond(DataSearchOperator.regex, value)
+
+    def match(self, value: str) -> ConditionBuilder:
+        """Alias for :meth:`regex`."""
+        return self.regex(value)
+
+    def icontains(self, value: str) -> ConditionBuilder:
+        """Some element case-insensitively contains ``value``."""
+        import re
+
+        return self.regex(f"(?i){re.escape(value)}")
+
+    def istarts_with(self, value: str) -> ConditionBuilder:
+        """Some element case-insensitively starts with ``value``."""
+        import re
+
+        return self.regex(f"(?i)^{re.escape(value)}")
+
+    def iends_with(self, value: str) -> ConditionBuilder:
+        """Some element case-insensitively ends with ``value``."""
+        import re
+
+        return self.regex(f"(?i){re.escape(value)}$")
+
+
 class Field(ConditionBuilder):
     def __init__(
         self,
@@ -631,6 +721,40 @@ class Field(ConditionBuilder):
         :meth:`contains` (single-element membership). On a scalar field it
         degrades to membership (``field in value``)."""
         return self._cond(DataSearchOperator.contains_any, value)
+
+    def any(self) -> "ElementQuantifier":
+        """Quantify a string predicate existentially over a **list** field's
+        elements: the row matches when SOME element satisfies it.
+
+        Each element is treated as a scalar, so the chained operator has its
+        ordinary scalar meaning — the composable, index-friendly way to ask
+        "does any element *contain* / *match* this?", which bare
+        :meth:`contains` (exact membership) deliberately does not::
+
+            QB["norm_keys"].any().contains("ol")  # some element has substring "ol"
+            QB["norm_keys"].any().icontains("OL")  # ... case-insensitively
+            QB["norm_keys"].any().regex("^m")  # ... ^ anchored per element
+            QB["norm_keys"].any().eq("mol")  # some element == "mol" (membership)
+
+        An empty list never matches. The bare per-element string operators
+        (``regex``/``starts_with``/``ends_with`` and case-insensitive sugar) are
+        only valid *through* ``any()`` — calling them directly on a list field
+        raises, because they would otherwise run against the serialised array.
+        """
+        return ElementQuantifier(self.name, DataSearchQuantifier.any, self.transform)
+
+    def all(self) -> "ElementQuantifier":
+        """Universal sibling of :meth:`any`: the row matches when EVERY element
+        of the list satisfies the chained predicate. An empty list matches
+        vacuously (there is no element that fails)::
+
+            QB["norm_keys"].all().starts_with("m")  # every element starts "m"
+
+        Note this is unrelated to the ``QB.all(c1, c2)`` static combinator, which
+        ANDs whole conditions — here the quantifier ranges over one field's
+        elements.
+        """
+        return ElementQuantifier(self.name, DataSearchQuantifier.all, self.transform)
 
     def not_in(self, value: list[Any]) -> ConditionBuilder:
         return self._cond(DataSearchOperator.not_in_list, value)

--- a/specstar/query_types.py
+++ b/specstar/query_types.py
@@ -34,11 +34,34 @@ class FieldTransform(StrEnum):
     length = "len"  # Get length of string, list, dict, etc.
 
 
+class DataSearchQuantifier(StrEnum):
+    """Existential/universal quantifier over the elements of a list field.
+
+    When set on a :class:`DataSearchCondition`, the ``operator`` is applied to
+    *each element* of the list field (treated as a scalar) rather than to the
+    field as a whole, and the condition holds when:
+
+    - ``any`` — SOME element satisfies the predicate (existential; empty list
+      never matches);
+    - ``all`` — EVERY element satisfies it (universal; empty list matches
+      vacuously).
+
+    This is what powers ``QB["keys"].any().contains("ol")`` — per-element
+    substring / regex / prefix matching, with anchors bound to a single element
+    instead of the serialised array. See :meth:`specstar.query.Field.any`.
+    """
+
+    any = "any"
+    all = "all"
+
+
 class DataSearchCondition(Struct, kw_only=True, tag=True):
     field_path: str
     operator: DataSearchOperator
     value: Any
     transform: FieldTransform | None = None  # Optional field transformation
+    quantifier: DataSearchQuantifier | None = None
+    """Apply ``operator`` element-wise over a list field (``any``/``all``)."""
 
 
 class DataSearchLogicOperator(StrEnum):
@@ -287,6 +310,7 @@ __all__ = [
     "DataSearchGroup",
     "DataSearchLogicOperator",
     "DataSearchOperator",
+    "DataSearchQuantifier",
     "FieldTransform",
     "ResourceDataSearchSort",
     "ResourceMetaSearchQuery",

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -18,6 +18,7 @@ from specstar.query_types import (
     DataSearchGroup,
     DataSearchLogicOperator,
     DataSearchOperator,
+    DataSearchQuantifier,
     ResourceDataSearchSort,
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
@@ -223,6 +224,51 @@ def _match_data_condition(
     return result is True
 
 
+def _scalar_op(op: DataSearchOperator, element: Any, compare_value: Any) -> bool:
+    """Apply a *scalar* string/comparison operator to a single list element.
+
+    This is the per-element predicate behind the ``any``/``all`` quantifier: the
+    element is a scalar, so ``contains`` is substring (not the whole-array
+    membership that :data:`DataSearchOperator.contains` means on a list) and
+    ``regex`` anchors ``^``/``$`` to this one element. It mirrors the scalar
+    branches of :func:`_evaluate_trivalent`, kept in sync with them.
+    """
+    if op == DataSearchOperator.equals:
+        return element == compare_value
+    if op == DataSearchOperator.not_equals:
+        return element != compare_value
+    if op == DataSearchOperator.contains:
+        return str(compare_value) in str(element)
+    if op == DataSearchOperator.starts_with:
+        return str(element).startswith(str(compare_value))
+    if op == DataSearchOperator.ends_with:
+        return str(element).endswith(str(compare_value))
+    if op == DataSearchOperator.regex:
+        return re.search(str(compare_value), str(element)) is not None
+    # ElementQuantifier never emits any other operator; be conservative.
+    return False
+
+
+def _match_quantified(
+    quantifier: DataSearchQuantifier,
+    op: DataSearchOperator,
+    field_value: Any,
+    compare_value: Any,
+) -> bool | None:
+    """Fold a per-element scalar predicate with an ``any``/``all`` quantifier.
+
+    ``any`` is existential (empty list -> ``False``); ``all`` is universal
+    (empty list -> vacuously ``True``). A non-list value is Unknown (``None``)
+    — quantifying over a scalar is a category error.
+    """
+    if not isinstance(field_value, list):
+        return None
+    results = [_scalar_op(op, el, compare_value) for el in field_value]
+    if quantifier == DataSearchQuantifier.any:
+        return any(results)
+    return all(results)
+
+
 def _evaluate_trivalent(
     data: dict[str, Any] | ResourceMeta,
     condition: DataSearchCondition | DataSearchGroup | VectorDistanceCondition,
@@ -355,6 +401,13 @@ def _evaluate_trivalent(
         )
     else:
         compare_value = condition.value
+
+    # Element-wise quantifier (``QB[...].any().<op>(...)``): apply the operator
+    # to each list element as a scalar and fold with any/all.
+    if condition.quantifier is not None:
+        return _match_quantified(
+            condition.quantifier, condition.operator, field_value, compare_value
+        )
 
     if condition.operator == DataSearchOperator.equals:
         return field_value == compare_value

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -269,6 +269,63 @@ def _match_quantified(
     return all(results)
 
 
+# Bare scalar-string operators that are meaningless on a list field: without a
+# quantifier they would run against the whole serialised array (a cross-element,
+# backend-divergent, index-blind footgun), so they must go through .any()/.all().
+# ``contains`` stays valid on a list (exact element membership, #362) and is not
+# listed here.
+_LIST_SCALAR_ONLY_OPS = frozenset(
+    {
+        DataSearchOperator.regex,
+        DataSearchOperator.starts_with,
+        DataSearchOperator.ends_with,
+    }
+)
+
+
+def bad_list_string_op(field_path: str, operator: DataSearchOperator) -> ValueError:
+    """The error raised when a bare scalar string op targets a list field."""
+    return ValueError(
+        f"{operator.value!r} on the list field {field_path!r} is not allowed: a "
+        f"scalar string operator would run against the whole serialised array. "
+        f"Quantify over the elements instead, e.g. "
+        f"QB[{field_path!r}].any().{operator.value}(...) "
+        f"(or .all(), or .icontains/.istarts_with/.iends_with through .any())."
+    )
+
+
+def reject_unquantified_list_string_ops(
+    query: ResourceMetaSearchQuery, list_fields: Iterable[str]
+) -> None:
+    """Raise :func:`bad_list_string_op` if *query* applies a bare scalar string
+    operator to a registered list field without ``.any()``/``.all()``.
+
+    A side-effect-free validation the reference (pure-Python) backends run once
+    per query, before iterating — so an empty store rejects a bad query just
+    like the SQL backends, which raise the same error from ``_build_condition``.
+    """
+    fields = set(list_fields)
+    if not fields:
+        return
+
+    def _walk(cond: object) -> None:
+        if isinstance(cond, DataSearchGroup):
+            for sub in cond.conditions:
+                _walk(sub)
+        elif isinstance(cond, DataSearchCondition):
+            if (
+                cond.quantifier is None
+                and cond.operator in _LIST_SCALAR_ONLY_OPS
+                and cond.field_path in fields
+            ):
+                raise bad_list_string_op(cond.field_path, cond.operator)
+
+    for bucket in (query.conditions, query.data_conditions):
+        if bucket is not UNSET:
+            for c in bucket:
+                _walk(c)
+
+
 def _evaluate_trivalent(
     data: dict[str, Any] | ResourceMeta,
     condition: DataSearchCondition | DataSearchGroup | VectorDistanceCondition,
@@ -596,6 +653,25 @@ class IMetaStore(MutableMapping[str, ResourceMeta]):
 
     See: https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping
     """
+
+    def register_list_field(self, field_path: str) -> None:
+        """Declare *field_path* as a list-typed indexed field (see #362).
+
+        Base default: record the name so a bare scalar string operator on it is
+        rejected in favour of ``.any()``/``.all()`` (see
+        :func:`reject_unquantified_list_string_ops`). SQL stores override this to
+        *also* route ``contains`` through element membership. Idempotent — safe
+        to call from ``add_model`` on every registration.
+        """
+        try:
+            self._list_fields.add(field_path)  # ty: ignore[unresolved-attribute]
+        except AttributeError:
+            self._list_fields = {field_path}
+
+    def _registered_list_fields(self) -> "set[str] | frozenset[str]":
+        """Names declared list-typed via :meth:`register_list_field` (empty when
+        none were, e.g. a store built directly in a test)."""
+        return getattr(self, "_list_fields", frozenset())
 
     @abstractmethod
     def __getitem__(self, pk: str) -> ResourceMeta:

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -24,11 +24,13 @@ from specstar.query_types import (
 )
 from specstar.resource_manager import _pg_pool
 from specstar.resource_manager.basic import (
+    _LIST_SCALAR_ONLY_OPS,
     Encoding,
     IMetaWithAgg,
     IMetaWithCount,
     ISlowMetaStore,
     MsgspecSerializer,
+    bad_list_string_op,
 )
 from specstar.types import ResourceMeta
 
@@ -1391,6 +1393,12 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                     return f"{column_name} IS NOT NULL", []
 
             return "", []
+
+        # A bare scalar string op on a registered list field would run against
+        # the serialised array — reject it, directing to .any()/.all(). (The
+        # quantified form already returned above; ``contains`` stays @> membership.)
+        if field_path in self._list_fields and operator in _LIST_SCALAR_ONLY_OPS:
+            raise bad_list_string_op(field_path, operator)
 
         # PostgreSQL JSONB 提取語法: indexed_data->>'field_path'
         # 對於數字比較，使用 (indexed_data->>'field_path')::numeric

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -14,6 +14,7 @@ from specstar.query_types import (
     DataSearchGroup,
     DataSearchLogicOperator,
     DataSearchOperator,
+    DataSearchQuantifier,
     FieldTransform,
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
@@ -1202,6 +1203,62 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             base = f"(indexed_data->>'{ref.name}')::numeric"
         return f"{a.op.upper()}({base})"
 
+    def _scalar_element_sql(
+        self, operator: DataSearchOperator, value: Any
+    ) -> tuple[str | None, list]:
+        """Per-element scalar predicate over a ``jsonb_array_elements_text``
+        alias ``val``.
+
+        Case-sensitive (matching the pure-Python reference) and injection-free —
+        ``strpos``/``starts_with``/``right`` instead of splicing user text into a
+        ``LIKE`` pattern. Returns ``(None, [])`` for an operator the quantifier
+        never emits.
+        """
+        if operator == DataSearchOperator.equals:
+            return "val = %s", [value]
+        if operator == DataSearchOperator.not_equals:
+            return "val <> %s", [value]
+        if operator == DataSearchOperator.contains:
+            return "strpos(val, %s) > 0", [value]
+        if operator == DataSearchOperator.starts_with:
+            return "starts_with(val, %s)", [value]
+        if operator == DataSearchOperator.ends_with:
+            return "right(val, length(%s)) = %s", [value, value]
+        if operator == DataSearchOperator.regex:
+            return "val ~ %s", [value]
+        return None, []
+
+    def _build_quantified(
+        self,
+        field_path: str,
+        operator: DataSearchOperator,
+        value: Any,
+        quantifier: DataSearchQuantifier,
+    ) -> tuple[str, list]:
+        """``any``/``all`` over a list field via ``EXISTS
+        (jsonb_array_elements_text …)``.
+
+        The ``CASE WHEN jsonb_typeof = 'array'`` around the extraction keeps a
+        scalar / missing value from raising "cannot extract elements from a
+        scalar" (it degrades to an empty array). ``any`` then never matches such
+        a row; ``all`` additionally gates on the outer ``= 'array'`` so a
+        non-array is a non-match rather than vacuously true (a present empty
+        array still satisfies ``all``) — aligning every edge with the reference.
+        """
+        pred, params = self._scalar_element_sql(operator, value)
+        if pred is None:
+            return "", []
+        ptr = f"indexed_data->'{field_path}'"
+        arr = f"CASE WHEN jsonb_typeof({ptr}) = 'array' THEN {ptr} ELSE '[]'::jsonb END"
+        elems = f"jsonb_array_elements_text({arr}) AS e(val)"
+        if quantifier == DataSearchQuantifier.any:
+            return f"EXISTS (SELECT 1 FROM {elems} WHERE {pred})", params
+        return (
+            f"(jsonb_typeof({ptr}) = 'array' AND "
+            f"NOT EXISTS (SELECT 1 FROM {elems} WHERE NOT ({pred})))",
+            params,
+        )
+
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 PostgreSQL 查詢條件 (支援 Meta 欄位與 JSONB 欄位)"""
         if isinstance(condition, DataSearchGroup):
@@ -1235,6 +1292,13 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         elif isinstance(value, (list, tuple, set)):
             # Handle Enum in lists (for in_list/not_in_list operators)
             value = [v.value if isinstance(v, EnumType) else v for v in value]
+
+        # Element quantifier (``QB[...].any()/.all()``): apply the operator to
+        # each array element and fold existentially / universally.
+        if condition.quantifier is not None:
+            return self._build_quantified(
+                field_path, operator, value, condition.quantifier
+            )
 
         # 判斷是否為 Meta 欄位
         meta_fields = {

--- a/specstar/resource_manager/meta_store/simple.py
+++ b/specstar/resource_manager/meta_store/simple.py
@@ -14,6 +14,7 @@ from specstar.resource_manager.basic import (
     MsgspecSerializer,
     get_sort_fn,
     is_match_query,
+    reject_unquantified_list_string_ops,
 )
 from specstar.types import ResourceMeta
 from specstar.util.fanout import (
@@ -52,6 +53,7 @@ class MemoryMetaStore(IFastMetaStore):
         return len(self._store)
 
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+        reject_unquantified_list_string_ops(query, self._registered_list_fields())
         results: list[ResourceMeta] = []
         # Snapshot the values: a concurrent write mid-search must not raise
         # "dictionary changed size during iteration".
@@ -152,9 +154,7 @@ class DiskMetaStore(IFastMetaStore):
         # write leaves only the temp file (excluded by the ``*.data`` glob and
         # never decoded), so it is invisible to the loader instead of crashing
         # boot.
-        fd, tmp = tempfile.mkstemp(
-            dir=path.parent, prefix=f"{pk}.", suffix=".data.tmp"
-        )
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f"{pk}.", suffix=".data.tmp")
         try:
             with os.fdopen(fd, "wb") as f:
                 f.write(data)
@@ -192,6 +192,7 @@ class DiskMetaStore(IFastMetaStore):
         return sum(1 for _ in self._iter_data_files())
 
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+        reject_unquantified_list_string_ops(query, self._registered_list_fields())
         results: list[ResourceMeta] = []
         for file in self._iter_data_files():
 

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -8,7 +8,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from msgspec import UNSET
 
@@ -16,6 +16,8 @@ from specstar.query_types import (
     AggKeyRef,
     AggSpec,
     DataSearchFilter,
+    DataSearchOperator,
+    DataSearchQuantifier,
     ResourceMetaSearchQuery,
     ResourceMetaSearchSort,
     ResourceMetaSortDirection,
@@ -503,6 +505,59 @@ class SqliteMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             val = f"json_extract(indexed_data, '$.\"{ref.name}\"')"
         return f"{a.op.upper()}({val})"
 
+    def _scalar_element_sql(
+        self, operator: DataSearchOperator, value: Any
+    ) -> tuple[str | None, list]:
+        """Per-element scalar predicate over ``json_each``'s ``value`` column.
+
+        Case-sensitive (binary) — matching the pure-Python reference — via
+        ``instr``/``substr`` rather than the case-insensitive ``LIKE``, and
+        injection-free (no user text spliced into a LIKE/GLOB pattern). Returns
+        ``(None, [])`` for an operator the quantifier never emits.
+        """
+        if operator == DataSearchOperator.equals:
+            return "value = ?", [value]
+        if operator == DataSearchOperator.not_equals:
+            return "value != ?", [value]
+        if operator == DataSearchOperator.contains:
+            return "instr(value, ?) > 0", [value]
+        if operator == DataSearchOperator.starts_with:
+            return "substr(value, 1, length(?)) = ?", [value, value]
+        if operator == DataSearchOperator.ends_with:
+            return "substr(value, -length(?)) = ?", [value, value]
+        if operator == DataSearchOperator.regex:
+            return "value REGEXP ?", [value]
+        return None, []
+
+    def _build_quantified(
+        self,
+        field_path: str,
+        operator: DataSearchOperator,
+        value: Any,
+        quantifier: DataSearchQuantifier,
+    ) -> tuple[str, list]:
+        """``any``/``all`` over a list field via ``EXISTS (json_each …)``.
+
+        The ``json_type = 'array'`` guard makes a missing / null / scalar value
+        a non-match for both quantifiers (a present empty array still satisfies
+        ``all`` vacuously), aligning every edge with the reference backend.
+        """
+        pred, params = self._scalar_element_sql(operator, value)
+        if pred is None:
+            return "", []
+        each = f"json_each(indexed_data, '$.\"{field_path}\"')"
+        is_array = f"json_type(indexed_data, '$.\"{field_path}\"') = 'array'"
+        if quantifier == DataSearchQuantifier.any:
+            return (
+                f"({is_array} AND EXISTS (SELECT 1 FROM {each} WHERE {pred}))",
+                params,
+            )
+        # all: array present and no element fails the predicate (empty -> vacuous)
+        return (
+            f"({is_array} AND NOT EXISTS (SELECT 1 FROM {each} WHERE NOT ({pred})))",
+            params,
+        )
+
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 SQLite 查詢條件 (支援 Meta 欄位與 JSON 欄位)"""
         from specstar.query_types import (
@@ -543,6 +598,13 @@ class SqliteMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         elif isinstance(value, (list, tuple, set)):
             # Handle Enum in lists (for in_list/not_in_list operators)
             value = [v.value if isinstance(v, EnumType) else v for v in value]
+
+        # Element quantifier (``QB[...].any()/.all()``): apply the operator to
+        # each array element and fold existentially / universally.
+        if condition.quantifier is not None:
+            return self._build_quantified(
+                field_path, operator, value, condition.quantifier
+            )
 
         # 判斷是否為 Meta 欄位
         meta_fields = {

--- a/specstar/resource_manager/meta_store/sqlite3.py
+++ b/specstar/resource_manager/meta_store/sqlite3.py
@@ -23,11 +23,13 @@ from specstar.query_types import (
     ResourceMetaSortDirection,
 )
 from specstar.resource_manager.basic import (
+    _LIST_SCALAR_ONLY_OPS,
     Encoding,
     IMetaWithAgg,
     IMetaWithCount,
     ISlowMetaStore,
     MsgspecSerializer,
+    bad_list_string_op,
 )
 from specstar.types import ResourceMeta
 
@@ -697,6 +699,12 @@ class SqliteMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
 
             # Fallback or unsupported operator for meta fields
             return "", []
+
+        # A bare scalar string op on a registered list field would run against
+        # the serialised array — reject it, directing to .any()/.all(). (The
+        # quantified form already returned above; ``contains`` stays membership.)
+        if field_path in self._list_fields and operator in _LIST_SCALAR_ONLY_OPS:
+            raise bad_list_string_op(field_path, operator)
 
         # SQLite JSON 提取語法: json_extract(indexed_data, '$.field_path')
         json_extract = f"json_extract(indexed_data, '$.\"{field_path}\"')"

--- a/tests/meta_store/test_any_quantifier_parity.py
+++ b/tests/meta_store/test_any_quantifier_parity.py
@@ -109,3 +109,56 @@ class TestAnyQuantifierParity:
 
     def test_all_empty_list_matches_vacuously(self):
         assert self._ids(QB["keys"].all().contains("zzz")) == ["4"]
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestBareListStringOpRejected:
+    """A bare scalar string op on a *registered* list field is rejected — it
+    would otherwise run against the serialised array — and directed to
+    ``.any()``/``.all()``. ``contains`` (membership) and the quantified forms
+    stay valid. Fires the same way on every backend (SQL from
+    ``_build_condition``, reference from ``iter_search``)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self.meta_store = get_meta_store(meta_store_type, my_tmpdir)
+        self.meta_store.register_list_field("keys")
+        base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        self.meta_store[str(uuid.uuid4())] = ResourceMeta(
+            current_revision_id="rev",
+            resource_id=str(uuid.uuid4()),
+            total_revision_count=1,
+            created_time=base,
+            updated_time=base,
+            created_by="t",
+            updated_by="t",
+            is_deleted=False,
+            indexed_data={"id": "1", "keys": ["mol", "capping"]},
+        )
+
+    def _run(self, builder) -> list:
+        return list(self.meta_store.iter_search(builder.build()))
+
+    @pytest.mark.parametrize(
+        "builder_name",
+        ["regex", "starts_with", "ends_with", "icontains", "istarts_with"],
+    )
+    def test_bare_scalar_string_op_on_list_raises(self, builder_name):
+        builder = getattr(QB["keys"], builder_name)("ol")
+        with pytest.raises(ValueError, match="any"):
+            self._run(builder)
+
+    def test_quantified_form_is_allowed(self):
+        # the sanctioned replacement must NOT raise
+        assert self._run(QB["keys"].any().regex("^mol$")) != [] or True
+        self._run(QB["keys"].any().starts_with("m"))
+        self._run(QB["keys"].all().icontains("x"))
+
+    def test_membership_ops_still_allowed(self):
+        # contains = exact element membership; contains_any = overlap — both fine
+        self._run(QB["keys"].contains("mol"))
+        self._run(QB["keys"].contains_any(["mol"]))
+
+    def test_unregistered_field_not_rejected(self):
+        # a scalar (non-list) field keeps ordinary substring/regex semantics
+        self._run(QB["other"].regex("x"))

--- a/tests/meta_store/test_any_quantifier_parity.py
+++ b/tests/meta_store/test_any_quantifier_parity.py
@@ -1,0 +1,111 @@
+"""Cross-backend parity for the ``.any()`` / ``.all()`` element quantifier.
+
+``QB["keys"].any().<op>(...)`` applies a scalar string predicate to each element
+of a list field and folds the per-element results existentially (``any``) or
+universally (``all``). Every metastore MUST agree — memory is the pure-Python
+reference; SQLite / Postgres push it down to ``json_each`` /
+``jsonb_array_elements_text`` wrapped in ``EXISTS``.
+
+Same semantics as ``tests/test_any_quantifier.py`` (which pins them on the
+reference backend); here they run over ``ALL_META_STORE_TYPES``.
+"""
+
+import tempfile
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from specstar.query import QB
+from specstar.types import ResourceMeta
+
+from .common import ALL_META_STORE_TYPES, get_meta_store
+
+
+@pytest.fixture
+def my_tmpdir():
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestAnyQuantifierParity:
+    # id -> keys (a list[str] indexed field)
+    DATA = {
+        "1": ["mol", "capping"],
+        "2": ["m4", "m40"],
+        "3": ["ol"],
+        "4": [],  # empty list
+        "5": ["中文", "モル"],  # unicode
+        "6": ["MOL"],  # uppercase
+    }
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self.meta_store = get_meta_store(meta_store_type, my_tmpdir)
+        base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        for rid, keys in self.DATA.items():
+            meta = ResourceMeta(
+                current_revision_id=f"rev_{rid}",
+                resource_id=str(uuid.uuid4()),
+                total_revision_count=1,
+                created_time=base,
+                updated_time=base,
+                created_by="t",
+                updated_by="t",
+                is_deleted=False,
+                indexed_data={"id": rid, "keys": keys},
+            )
+            self.meta_store[meta.resource_id] = meta
+
+    def _ids(self, builder) -> list[str]:
+        q = builder.build()
+        return sorted(m.indexed_data["id"] for m in self.meta_store.iter_search(q))
+
+    # --- any() ---------------------------------------------------------------
+
+    def test_any_contains_is_substring(self):
+        assert self._ids(QB["keys"].any().contains("ol")) == ["1", "3"]
+
+    def test_any_eq_is_membership(self):
+        assert self._ids(QB["keys"].any().eq("ol")) == ["3"]
+
+    def test_any_contains_vs_eq_diverge_on_partial(self):
+        assert self._ids(QB["keys"].any().contains("4")) == ["2"]
+        assert self._ids(QB["keys"].any().eq("4")) == []
+
+    def test_any_icontains_case_insensitive(self):
+        assert self._ids(QB["keys"].any().icontains("OL")) == ["1", "3", "6"]
+
+    def test_any_starts_with(self):
+        assert self._ids(QB["keys"].any().starts_with("m")) == ["1", "2"]
+
+    def test_any_ends_with(self):
+        # "mol"/"ol" end with "ol"; "モル" ends with "ル" not "ol".
+        assert self._ids(QB["keys"].any().ends_with("ol")) == ["1", "3"]
+
+    def test_any_regex_anchored_per_element(self):
+        assert self._ids(QB["keys"].any().regex("^ol$")) == ["3"]
+
+    def test_any_regex_suffix(self):
+        assert self._ids(QB["keys"].any().regex("ol$")) == ["1", "3"]
+
+    def test_any_unicode_substring(self):
+        assert self._ids(QB["keys"].any().contains("中")) == ["5"]
+
+    def test_any_empty_list_never_matches(self):
+        for b in (
+            QB["keys"].any().contains("ol"),
+            QB["keys"].any().regex(".*"),
+        ):
+            assert "4" not in self._ids(b)
+
+    # --- all() ---------------------------------------------------------------
+
+    def test_all_is_universal(self):
+        # every element starts "m": row 2; row 4 (empty) vacuously.
+        assert self._ids(QB["keys"].all().starts_with("m")) == ["2", "4"]
+
+    def test_all_empty_list_matches_vacuously(self):
+        assert self._ids(QB["keys"].all().contains("zzz")) == ["4"]

--- a/tests/routes/test_qb_search_integration.py
+++ b/tests/routes/test_qb_search_integration.py
@@ -885,3 +885,61 @@ def test_qb_with_is_deleted_filter(client: TestClient, sample_users: list[str]) 
     )
     assert response.status_code == 200
     assert len(response.json()) == 0
+
+
+class Doc(Struct):
+    title: str
+    tags: list[str] = []
+
+
+@pytest.fixture
+def doc_client() -> TestClient:
+    """A client over a model with a list[str] indexed field."""
+    app: FastAPI = FastAPI()
+    router: APIRouter = APIRouter()
+    spec: SpecStar = SpecStar()
+    spec.add_model(Doc, indexed_fields=["title", "tags"])
+    spec.apply(router)
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_docs(doc_client: TestClient) -> None:
+    for doc in (
+        {"title": "1", "tags": ["mol", "capping"]},
+        {"title": "2", "tags": ["m4", "m40"]},
+        {"title": "3", "tags": ["ol"]},
+        {"title": "6", "tags": ["MOL"]},
+    ):
+        assert doc_client.post("/doc", json=doc).status_code == 200
+
+
+def test_qb_any_element_substring_over_http(
+    doc_client: TestClient, sample_docs: None
+) -> None:
+    """?qb=QB['tags'].any().contains('ol') matches per element over HTTP."""
+    response = doc_client.get(
+        "/doc/data", params={"qb": "QB['tags'].any().contains('ol')"}
+    )
+    assert response.status_code == 200
+    titles = sorted(d["title"] for d in response.json())
+    assert titles == ["1", "3"]  # mol, ol — not the uppercase MOL
+
+
+def test_qb_any_icontains_over_http(doc_client: TestClient, sample_docs: None) -> None:
+    """The case-insensitive sugar also works through ?qb=."""
+    response = doc_client.get(
+        "/doc/data", params={"qb": "QB['tags'].any().icontains('OL')"}
+    )
+    assert response.status_code == 200
+    titles = sorted(d["title"] for d in response.json())
+    assert titles == ["1", "3", "6"]
+
+
+def test_qb_bare_regex_on_list_rejected_over_http(
+    doc_client: TestClient, sample_docs: None
+) -> None:
+    """A bare scalar string op on the list field is rejected, not silently wrong."""
+    response = doc_client.get("/doc/data", params={"qb": "QB['tags'].regex('ol')"})
+    assert response.status_code >= 400

--- a/tests/test_any_quantifier.py
+++ b/tests/test_any_quantifier.py
@@ -1,0 +1,123 @@
+"""Reference semantics for the ``.any()`` element quantifier on a list field.
+
+``QB["keys"].any()`` drops into "for SOME element, treated as a scalar string"
+land, where every string operator recovers its ordinary scalar meaning:
+
+- ``.any().eq("ol")``        -> some element **equals** "ol"      (membership)
+- ``.any().contains("ol")``  -> some element **substring**-contains "ol"
+- ``.any().regex("^ol$")``   -> some element matches, ``^``/``$`` anchored to
+                                the single element (not the serialised array)
+
+This is the composable, index-friendly answer to "find the card whose
+``norm_keys`` has an element containing this substring", which the bare
+``contains`` (exact membership) deliberately does NOT do.
+
+This file pins the semantics on the pure-Python reference backends (memory /
+disk). Cross-backend parity (sqlite / postgres push-down) lives in
+``tests/meta_store/test_any_quantifier_parity.py``.
+"""
+
+import tempfile
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from specstar.query import QB
+from specstar.types import ResourceMeta
+
+from tests.meta_store.common import get_meta_store
+
+
+@pytest.fixture
+def my_tmpdir():
+    with tempfile.TemporaryDirectory(dir="./") as d:
+        yield Path(d)
+
+
+@pytest.mark.parametrize("meta_store_type", ["memory", "disk"])
+class TestAnyQuantifier:
+    # id -> keys (a list[str] indexed field)
+    DATA = {
+        "1": ["mol", "capping"],
+        "2": ["m4", "m40"],
+        "3": ["ol"],
+        "4": [],  # empty list: never satisfies an existential
+        "5": ["中文", "モル"],  # unicode parity
+        "6": ["MOL"],  # uppercase, to separate contains from icontains
+    }
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self.meta_store = get_meta_store(meta_store_type, my_tmpdir)
+        base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        for rid, keys in self.DATA.items():
+            meta = ResourceMeta(
+                current_revision_id=f"rev_{rid}",
+                resource_id=str(uuid.uuid4()),
+                total_revision_count=1,
+                created_time=base,
+                updated_time=base,
+                created_by="t",
+                updated_by="t",
+                is_deleted=False,
+                indexed_data={"id": rid, "keys": keys},
+            )
+            self.meta_store[meta.resource_id] = meta
+
+    def _ids(self, builder) -> list[str]:
+        q = builder.build()
+        return sorted(m.indexed_data["id"] for m in self.meta_store.iter_search(q))
+
+    def test_contains_is_substring_over_elements(self):
+        # "ol" is a substring of "mol" and of "ol" itself; "MOL" is uppercase so
+        # a case-sensitive contains misses it.
+        assert self._ids(QB["keys"].any().contains("ol")) == ["1", "3"]
+
+    def test_eq_is_exact_membership_not_substring(self):
+        # eq stays exact-element membership: only the literal "ol" element, NOT
+        # "mol". This is the distinction bare .contains() already guarantees.
+        assert self._ids(QB["keys"].any().eq("ol")) == ["3"]
+
+    def test_contains_vs_eq_diverge_on_a_partial(self):
+        # "4" is a substring of "m4"/"m40" but is no element on its own.
+        assert self._ids(QB["keys"].any().contains("4")) == ["2"]
+        assert self._ids(QB["keys"].any().eq("4")) == []
+
+    def test_icontains_is_case_insensitive_substring(self):
+        # adds the uppercase "MOL" row over the case-sensitive contains result.
+        assert self._ids(QB["keys"].any().icontains("OL")) == ["1", "3", "6"]
+
+    def test_starts_with_over_elements(self):
+        # case-sensitive prefix: "mol", "m4", "m40" — not "MOL", not "モル".
+        assert self._ids(QB["keys"].any().starts_with("m")) == ["1", "2"]
+
+    def test_regex_is_anchored_per_element(self):
+        # ^ol$ matches the element "ol" only — "mol" is NOT the whole element,
+        # proving the anchors bind to a single element, not the array text.
+        assert self._ids(QB["keys"].any().regex("^ol$")) == ["3"]
+
+    def test_regex_suffix_over_elements(self):
+        assert self._ids(QB["keys"].any().regex("ol$")) == ["1", "3"]
+
+    def test_unicode_element_substring(self):
+        assert self._ids(QB["keys"].any().contains("中")) == ["5"]
+
+    def test_empty_list_never_matches(self):
+        # row "4" (empty list) appears in no existential result.
+        for b in (
+            QB["keys"].any().contains("ol"),
+            QB["keys"].any().eq("ol"),
+            QB["keys"].any().regex(".*"),
+        ):
+            assert "4" not in self._ids(b)
+
+    def test_all_is_universal_over_elements(self):
+        # every element starts with "m": row 2 (m4, m40); row 4 (empty) matches
+        # vacuously. Row 1 fails on "capping", row 6 on the uppercase "MOL".
+        assert self._ids(QB["keys"].all().starts_with("m")) == ["2", "4"]
+
+    def test_all_empty_list_matches_vacuously(self):
+        # nothing satisfies "zzz", yet the empty-list row still matches all().
+        assert self._ids(QB["keys"].all().contains("zzz")) == ["4"]

--- a/tests/test_any_quantifier.py
+++ b/tests/test_any_quantifier.py
@@ -26,7 +26,6 @@ import pytest
 
 from specstar.query import QB
 from specstar.types import ResourceMeta
-
 from tests.meta_store.common import get_meta_store
 
 

--- a/tests/test_qb_parser.py
+++ b/tests/test_qb_parser.py
@@ -184,6 +184,36 @@ class TestSafeQBParser:
         cond = query.conditions[0]  # ty:ignore[not-subscriptable]
         assert cond.field_path == expected_field  # ty:ignore[unresolved-attribute]
 
+    def test_any_quantifier_parses(self):
+        """QB['keys'].any().contains('ol') is accepted and carries quantifier=any."""
+        from specstar.query_types import DataSearchOperator, DataSearchQuantifier
+
+        parser = SafeQBParser()
+        result = parser.parse("QB['keys'].any().contains('ol')")
+        cond = result.build().conditions[0]  # ty:ignore[not-subscriptable]
+        assert cond.field_path == "keys"  # ty:ignore[unresolved-attribute]
+        assert cond.operator == DataSearchOperator.contains  # ty:ignore[unresolved-attribute]
+        assert cond.quantifier == DataSearchQuantifier.any  # ty:ignore[unresolved-attribute]
+
+    def test_all_quantifier_parses(self):
+        """QB['keys'].all().starts_with('m') is accepted and carries quantifier=all."""
+        from specstar.query_types import DataSearchQuantifier
+
+        parser = SafeQBParser()
+        result = parser.parse("QB['keys'].all().starts_with('m')")
+        cond = result.build().conditions[0]  # ty:ignore[not-subscriptable]
+        assert cond.quantifier == DataSearchQuantifier.all  # ty:ignore[unresolved-attribute]
+
+    def test_any_icontains_parses(self):
+        """The i* regex sugar works through .any() over ?qb= too."""
+        from specstar.query_types import DataSearchOperator, DataSearchQuantifier
+
+        parser = SafeQBParser()
+        result = parser.parse("QB['keys'].any().icontains('OL')")
+        cond = result.build().conditions[0]  # ty:ignore[not-subscriptable]
+        assert cond.operator == DataSearchOperator.regex  # ty:ignore[unresolved-attribute]
+        assert cond.quantifier == DataSearchQuantifier.any  # ty:ignore[unresolved-attribute]
+
     def test_datetime_integration(self):
         """測試 datetime 整合"""
         parser = SafeQBParser()


### PR DESCRIPTION
## What

Adds a `.any()` / `.all()` **element quantifier** to the query builder so a
`list`-typed indexed field can be matched **inside** its elements — substring,
prefix, regex — instead of only by exact membership.

```python
QB["tags"].any().contains("ol")     # some element contains the substring "ol"
QB["tags"].any().icontains("OL")    # ... case-insensitively
QB["tags"].any().regex("^m")        # ^ / $ anchored to a single element
QB["tags"].any().eq("mol")          # some element equals "mol" (== bare .contains on a list)
QB["tags"].all().starts_with("m")   # every element starts with "m"
```

## Why

On a list field, `.contains(v)` is **exact element membership** (`["m4"]` never
matches `"m40"`, per #362). There was **no first-class way** to ask "some
element *contains* this substring". Worse, calling a scalar string operator
(`regex` / `starts_with` / `ends_with` / the `icontains` family) **directly** on
a list field **silently ran against the serialised array text** — a
cross-element, backend-divergent (Python `repr` vs PG/SQLite JSON), `^`/`$`-
meaningless, index-blind footgun.

`.any()` / `.all()` fixes both: inside the quantifier each element is a scalar,
so every string operator recovers its ordinary scalar meaning. The bare
list-string footgun is now a **hard error** that points at `.any()` / `.all()`.

## Design

A single orthogonal modifier `DataSearchCondition.quantifier: any | all | None`
(mirroring the existing `transform` modifier) — the operator set is unchanged.
Each backend, on seeing a quantifier, wraps the per-element predicate in an
existential/universal over the array:

- **memory / disk** (pure-Python reference): fold `_scalar_op` over the list
  (`any=False` / `all=True` vacuous on the empty list).
- **SQLite**: `EXISTS(SELECT 1 FROM json_each(...) WHERE <scalar pred>)` with a
  `json_type='array'` guard; case-sensitive `instr`/`substr` (no LIKE-wildcard
  injection).
- **Postgres**: `EXISTS(... jsonb_array_elements_text(...) AS e(val) WHERE ...)`
  with a `jsonb_typeof='array'` guard; `strpos` / `starts_with` / `right` / `~`.

`.any().eq()` is exact membership (can route to `@>`); `.any().contains()` is
substring; `.any().regex("^m")` anchors per element. `.all()` is symmetric
(empty list matches vacuously).

## Phases

- **P1** — `types` + `Field.any()/.all()` + `ElementQuantifier` + pure-Python
  reference (`_scalar_op` / `_match_quantified`) + memory/disk tests.
- **P2** — SQL push-down to SQLite + Postgres, with `array`-type guards so
  missing / scalar / empty-list boundaries match the reference; cross-backend
  parity tests.
- **P3** — bare scalar string ops on a **registered** list field raise
  `ValueError` directing to `.any()`; `IMetaStore.register_list_field` base
  wiring so memory/disk honour it too.
- **P4** — HTTP `?qb=` surface (no parser change — `any`/`all` were already in
  the allow-list); parser + route end-to-end tests (bare regex → HTTP 400).
- **P5** — docs (`docs/en/howto/query-builder.md`).

## Tests

Targeted suites green (P1 reference 22, cross-backend parity 80 incl.
rejection, parser + route 135); the **fast unit suite passes** (the sole failure
was a pre-existing worktree-venv missing `python-magic`, unrelated to this
branch).

## Follow-up

This is the **foundation** for a stacked PR that makes `.any().contains()`
index-backed and adds fuzzy search — an opt-in `TrigramIndex` annotation
(pg_trgm GIN, Postgres-only, pure derivation like `SortIndex`), a `.fuzzy()`
word-similarity predicate, a `.similarity().desc()` ranking sort, and the
`.any().eq()` → `@>` optimization. Kept separate so this correct-but-scan
baseline can land and be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
