### PR TITLE
fix(query): dispatch fuzzy/vector conditions nested inside a group

### DIFF
--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -375,7 +375,10 @@ def reject_unquantified_list_string_ops(
 
 def _evaluate_trivalent(
     data: dict[str, Any] | ResourceMeta,
-    condition: DataSearchCondition | DataSearchGroup | VectorDistanceCondition,
+    condition: DataSearchCondition
+    | DataSearchGroup
+    | VectorDistanceCondition
+    | TrigramFuzzyCondition,
 ) -> bool | None:
     """
     Evaluate condition using SQL-like trivalent logic (True, False, Unknown/None).
@@ -395,6 +398,23 @@ def _evaluate_trivalent(
             wrapper = _Wrap()
             wrapper.indexed_data = data  # type: ignore[attr-defined]
             return _match_vector_condition(wrapper, condition)  # type: ignore[arg-type]
+        return None
+
+    if isinstance(condition, TrigramFuzzyCondition):
+        # Like vector conditions, a fuzzy condition can be AND/OR-combined with
+        # other filters (``QB[...] == v) & QB[...].fuzzy(q)``), so it must be
+        # evaluated when reached INSIDE a group too — not only at the top level.
+        # It reads the same indexed_data; wrap a bare dict when nested.
+        if isinstance(data, ResourceMeta):
+            return _match_fuzzy_condition(data, condition)
+        if isinstance(data, dict):
+
+            class _Wrap:
+                pass
+
+            wrapper = _Wrap()
+            wrapper.indexed_data = data  # type: ignore[attr-defined]
+            return _match_fuzzy_condition(wrapper, condition)  # type: ignore[arg-type]
         return None
 
     if isinstance(condition, DataSearchGroup):

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -1489,6 +1489,15 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
 
     def _build_condition(self, condition: DataSearchFilter) -> tuple[str, list]:
         """構建 PostgreSQL 查詢條件 (支援 Meta 欄位與 JSONB 欄位)"""
+        # Vector / fuzzy conditions carry no ``operator``/``value``, so they must be
+        # dispatched to their own builders BEFORE the scalar path — not only at the
+        # top level (``_build_where``) but also when reached recursively INSIDE a
+        # group, i.e. AND/OR-combined with another filter.
+        if isinstance(condition, VectorDistanceCondition):
+            return self._build_vector_condition(condition)
+        if isinstance(condition, TrigramFuzzyCondition):
+            return self._build_fuzzy_condition(condition)
+
         if isinstance(condition, DataSearchGroup):
             sub_conditions = []
             sub_params = []

--- a/tests/meta_store/test_trigram_index.py
+++ b/tests/meta_store/test_trigram_index.py
@@ -292,6 +292,20 @@ def test_similarity_sort_ranks_the_best_match_first(store):
     assert _ordered_ids(store, asc) == ["3", "1"]
 
 
+def test_fuzzy_combined_with_a_filter_in_a_group(store):
+    """Regression: ``.fuzzy()`` AND/OR-combined with another filter nests inside a
+    DataSearchGroup, so the group SQL builder must dispatch it to word_similarity —
+    not the scalar path, which reads ``.operator`` (absent on a fuzzy condition)."""
+    store.ensure_trigram_index("title")
+    # AND: title contains "biology" AND fuzzy-matches "molecular" -> only row 1
+    # ("molecular biology"), NOT row 3 ("small molecule") which fuzzy alone matches.
+    q_and = QB["title"].contains("biology") & QB["title"].fuzzy("molecular")
+    assert _ids(store, q_and) == ["1"]
+    # OR: title contains "polymer" OR fuzzy-matches "molecular" -> rows 1, 2, 3
+    q_or = QB["title"].contains("polymer") | QB["title"].fuzzy("molecular")
+    assert _ids(store, q_or) == ["1", "2", "3"]
+
+
 # --- Reference-backend parity: the Python port must match live Postgres --------
 
 

--- a/tests/test_trigram_fuzzy_reference.py
+++ b/tests/test_trigram_fuzzy_reference.py
@@ -92,6 +92,29 @@ def test_fuzzy_filter_returns_same_rows_on_every_backend(tmp, make_query, expect
         assert got == expected
 
 
+def test_fuzzy_and_or_combined_with_a_filter_on_every_backend(tmp):
+    """The essential 'scope + fuzzy' query — a fuzzy condition AND/OR-combined
+    with another filter. It nests inside a DataSearchGroup, which every backend
+    must dispatch to the fuzzy path rather than treat as a plain scalar condition
+    (regression: it used to raise ``'TrigramFuzzyCondition' has no attribute
+    'operator'/'transform'`` on Postgres / memory)."""
+    for store in _stores(tmp):
+        _load(
+            store,
+            [
+                _meta("1", coll="a", title="molecular biology"),
+                _meta("2", coll="a", title="capping protein"),
+                _meta("3", coll="b", title="molecular biology"),
+            ],
+        )
+        # AND: collection "a" AND fuzzy-matches "mol" -> only row 1
+        q_and = ((QB["coll"] == "a") & QB["title"].fuzzy("mol")).build()
+        assert {m.indexed_data["id"] for m in store.iter_search(q_and)} == {"1"}
+        # OR: collection "b" OR fuzzy-matches "mol" -> row 1 (fuzzy) + row 3 (coll b)
+        q_or = ((QB["coll"] == "b") | QB["title"].fuzzy("mol")).build()
+        assert {m.indexed_data["id"] for m in store.iter_search(q_or)} == {"1", "3"}
+
+
 # ── List-field fuzzy filter (any element may match) ──────────────────────────
 
 _TAGGED = [


### PR DESCRIPTION
## What

A `TrigramFuzzyCondition` / `VectorDistanceCondition` **AND/OR-combined with another filter** — the essential *scope-then-fuzzy* query, e.g. `(QB["collection_id"] == c) & QB["norm_keys"].fuzzy(q)` — nests inside a `DataSearchGroup`. Both were only dispatched at the **top level**, so combining them raised:

- memory/disk: `'TrigramFuzzyCondition' object has no attribute 'transform'` (`_evaluate_trivalent` handled vector but not fuzzy).
- Postgres: `_build_condition` (group recursion) dispatched **neither** → hit `condition.operator`/`.value` (absent). Latent for vector too.
- sqlite was already correct (it recurses `_build_condition`, which handles fuzzy at the top).

## Fix

Dispatch both special conditions where a group is actually walked: a `TrigramFuzzyCondition` branch in `_evaluate_trivalent` (mirroring vector), and vector/fuzzy dispatch at the top of Postgres `_build_condition`.

## Why it escaped 0.12.2

The 0.12.2 tests only exercised `.fuzzy()` **standalone**, never `&`/`|`-combined — so 100% line coverage held while the combined path was never run (a path/input gap, invisible to line coverage). Regression tests added: fuzzy AND/OR + filter across memory/disk/sqlite and on live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)