### PR TITLE
feat(query): Python fallback for .fuzzy()/.similarity() when pg_trgm is absent

### DIFF
--- a/docs/en/howto/query-builder.md
+++ b/docs/en/howto/query-builder.md
@@ -183,6 +183,13 @@ The same index also accelerates an exact substring `.contains()` /
 > runs as a scan); the other backends have no such index and compute by scan,
 > which is fine at their scale. The default cutoff is pg_trgm's
 > `word_similarity_threshold` (0.6).
+>
+> On Postgres **without** the `pg_trgm` extension installed, `.fuzzy()` /
+> `.similarity()` don't error — they degrade to the same Python computation (with
+> a one-time `SpecStarWarning`), pushing every other condition down to SQL first
+> so only the survivors are scored in Python. Correct, just unaccelerated. Install
+> it with `CREATE EXTENSION pg_trgm;` (annotating any field with `TrigramIndex`
+> also installs it) to get the GIN-served path.
 
 ### Null and value checks
 

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -1,12 +1,15 @@
 import logging
 import time
+import warnings
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from enum import Enum as EnumType
 from typing import Any
 
+import msgspec
 from msgspec import UNSET
 
+from specstar.errors import SpecStarWarning
 from specstar.query_types import (
     AggKeyRef,
     AggSpec,
@@ -33,6 +36,8 @@ from specstar.resource_manager.basic import (
     ISlowMetaStore,
     MsgspecSerializer,
     bad_list_string_op,
+    get_sort_fn,
+    is_match_query,
 )
 from specstar.types import ResourceMeta
 
@@ -113,6 +118,26 @@ _TRGM_COARSE_OPS = frozenset(
 
 
 logger = logging.getLogger(__name__)
+
+
+def _condition_has_trigram(cond: object) -> bool:
+    """Whether *cond* is (or, for a group, contains) a ``TrigramFuzzyCondition``."""
+    if isinstance(cond, TrigramFuzzyCondition):
+        return True
+    if isinstance(cond, DataSearchGroup):
+        return any(_condition_has_trigram(sub) for sub in cond.conditions)
+    return False
+
+
+def _query_uses_trigram(query: ResourceMetaSearchQuery) -> bool:
+    """Whether *query* filters with ``.fuzzy()`` or sorts by ``.similarity()`` —
+    the pg_trgm-backed operators. Used to route to the Python fallback when the
+    Postgres extension is absent."""
+    conds = query.conditions if query.conditions is not UNSET else []
+    if any(_condition_has_trigram(c) for c in conds):
+        return True
+    sorts = query.sorts if query.sorts is not UNSET else []
+    return any(isinstance(s, TrigramSimilaritySort) for s in sorts)
 
 
 #: Longest ``in_list`` still expanded into one GIN probe per value.
@@ -1244,7 +1269,56 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             where_clause = "WHERE " + " AND ".join(conditions)
         return where_clause, params
 
+    def _warn_no_pg_trgm(self) -> None:
+        """Warn once (per store) that a trigram query is running unaccelerated."""
+        if getattr(self, "_warned_no_pg_trgm", False):
+            return
+        self._warned_no_pg_trgm = True
+        warnings.warn(
+            "pg_trgm is not installed, so .fuzzy() / .similarity() are computed in "
+            "Python (correct, but a full scan — no GIN). Run "
+            "`CREATE EXTENSION pg_trgm;` (or annotate a field with TrigramIndex) to "
+            "accelerate them on Postgres.",
+            SpecStarWarning,
+            stacklevel=3,
+        )
+
+    def _trigram_fallback_search(
+        self, query: ResourceMetaSearchQuery
+    ) -> Generator[ResourceMeta]:
+        """Evaluate a ``.fuzzy()`` / ``.similarity()`` query WITHOUT pg_trgm.
+
+        Push every trigram-FREE top-level condition down to SQL (they are ANDed, so
+        a subset is a correct pre-filter that bounds the candidate set), then apply
+        the FULL predicate + sorts + pagination in Python with the same reference
+        helpers the memory backend uses — so the answer is identical to native
+        pg_trgm, only slower.
+        """
+        self._warn_no_pg_trgm()
+        conds = query.conditions if query.conditions is not UNSET else []
+        pushable = [c for c in conds if not _condition_has_trigram(c)]
+        # Fetch candidates: trigram-free conditions only, no sorts, unbounded — the
+        # trigram filter/sort/pagination all happen in Python below. With no trigram
+        # left, this recursion takes the ordinary SQL path (no re-entry here).
+        candidate_query = msgspec.structs.replace(
+            query,
+            conditions=pushable,
+            sorts=UNSET,
+            limit=2**63 - 1,
+            offset=0,
+        )
+        candidates = list(self.iter_search(candidate_query))
+        survivors = [m for m in candidates if is_match_query(m, query)]
+        survivors.sort(key=get_sort_fn([] if query.sorts is UNSET else query.sorts))
+        # offset/offset+limit — same pagination the memory backend applies; a query
+        # reaching a store always carries both (QB.build() fills the defaults).
+        yield from survivors[query.offset : query.offset + query.limit]
+
     def iter_search(self, query: ResourceMetaSearchQuery) -> Generator[ResourceMeta]:
+        if not self._has_pg_trgm and _query_uses_trigram(query):
+            yield from self._trigram_fallback_search(query)
+            return
+
         where_clause, params = self._build_where(query)
 
         # 构建排序子句
@@ -1301,6 +1375,10 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         SIZE of a limited window does not depend on the order its rows come back
         in, so sorting for a count is pure waste (``iter_search`` pays it today).
         """
+        if not self._has_pg_trgm and _query_uses_trigram(query):
+            # No pushdown for the fuzzy count — honour the contract by counting the
+            # Python-fallback window directly.
+            return sum(1 for _ in self.iter_search(query))
         where_clause, params = self._build_where(query)
         sql = (
             f'SELECT COUNT(*) AS n FROM (SELECT 1 FROM "{self.table_name}" '

--- a/tests/meta_store/test_trigram_fallback.py
+++ b/tests/meta_store/test_trigram_fallback.py
@@ -1,0 +1,90 @@
+"""When pg_trgm is absent, Postgres .fuzzy()/.similarity() degrade to a Python
+computation (the specstar.util.trigram port), not a cryptic operator error.
+
+Unlike pgvector (declared by a Vector annotation, so a missing extension can fail
+at boot), .fuzzy() can be sent over ?qb= against ANY field with no annotation —
+you cannot know at boot who will use it. So the reference-correct behaviour is
+reactive: at query time, if the extension is missing, warn once and compute the
+same word_similarity in Python. Correct everywhere, only slower — the same
+"absence costs speed, never correctness" contract as the GIN.
+
+Simulated by forcing ``_has_pg_trgm = False`` on a live-Postgres store (the test
+DB really has pg_trgm, so the fallback path — not the raw error — is what we pin).
+"""
+
+import pytest
+
+from specstar.errors import SpecStarWarning
+from specstar.query import QB
+
+from .common import get_meta_store
+from .test_trigram_index import _ids, _ordered_ids, _seed
+
+
+@pytest.fixture
+def no_trgm_store():
+    store = _seed(get_meta_store("postgres"))
+    store._has_pg_trgm = False  # simulate a database without the pg_trgm extension
+    return store
+
+
+def test_fuzzy_scoped_by_a_pushdown_filter_falls_back_to_python(no_trgm_store):
+    """The common query: a fuzzy match AND a filter that CAN be pushed to SQL.
+    The filter bounds the candidate set; the fuzzy is applied in Python."""
+    store = no_trgm_store
+    with pytest.warns(SpecStarWarning, match="pg_trgm"):
+        # title contains "biology" (SQL) AND fuzzy-matches "molecular" (Python)
+        got = _ids(
+            store, QB["title"].contains("biology") & QB["title"].fuzzy("molecular")
+        )
+    assert got == ["1"]  # "molecular biology" — not row 3 "small molecule"
+
+
+def test_bare_fuzzy_falls_back_to_python(no_trgm_store):
+    """No pushdown filter → a full scan in Python, but still correct + warned."""
+    store = no_trgm_store
+    with pytest.warns(SpecStarWarning, match="pg_trgm"):
+        got = _ids(store, QB["title"].fuzzy("molecular"))
+    assert got == ["1", "3"]  # matches "molecular biology" and "small molecule"
+
+
+def test_custom_threshold_fuzzy_falls_back_to_python(no_trgm_store):
+    store = no_trgm_store
+    with pytest.warns(SpecStarWarning, match="pg_trgm"):
+        loose = _ids(store, QB["title"].fuzzy("molec", threshold=0.5))
+        tight = _ids(store, QB["title"].fuzzy("molec", threshold=0.99))
+    assert loose == ["1", "3"]
+    assert tight == []
+
+
+def test_similarity_sort_falls_back_to_python(no_trgm_store):
+    """The ranking sort computes word_similarity in Python and orders by it."""
+    store = no_trgm_store
+    with pytest.warns(SpecStarWarning, match="pg_trgm"):
+        desc = (
+            QB["title"]
+            .fuzzy("molecular")
+            .sort(QB["title"].similarity("molecular").desc())
+        )
+        order = _ordered_ids(store, desc)
+    assert order == ["1", "3"]  # exact word (1.0) before partial (0.7)
+
+
+def test_fallback_matches_the_native_pg_trgm_answer(no_trgm_store):
+    """The Python fallback returns exactly what native pg_trgm would — same rows."""
+    native = _seed(get_meta_store("postgres"))  # _has_pg_trgm stays True
+    for cond in [
+        QB["title"].fuzzy("molecular"),
+        QB["title"].fuzzy("polymer"),
+        QB["title"].fuzzy("zzznope"),
+        QB["keys"].fuzzy("capp"),
+        QB["title"].contains("biology") & QB["title"].fuzzy("molecular"),
+    ]:
+        assert _ids(no_trgm_store, cond) == _ids(native, cond)
+
+
+def test_count_falls_back_when_pg_trgm_absent(no_trgm_store):
+    store = no_trgm_store
+    with pytest.warns(SpecStarWarning, match="pg_trgm"):
+        n = store.count(QB["title"].fuzzy("molecular").build())
+    assert n == 2


### PR DESCRIPTION
## What

On Postgres, `.fuzzy()`/`.similarity()` emit pg_trgm's `<%` / `word_similarity()`. Without the extension installed they used to fail with a cryptic `operator/function does not exist`. Now they **degrade gracefully to a Python computation** (one-time `SpecStarWarning`), returning the same rows — never an error.

## Why not fail loud like pgvector?

`pgvector` is declared by a `Vector(...)` annotation, so a missing extension can fail at `add_model`. But `.fuzzy()` can be sent over `?qb=` against **any** field with **no annotation** — you can't know at boot who will use it (h/t the reviewer for this point). So the reference-correct behaviour is *reactive + graceful*, matching the "absence costs speed, never correctness" contract already used for the GIN.

## How

When `_has_pg_trgm` is false and a query uses `.fuzzy()`/`.similarity()`:
- push every **trigram-free top-level condition** down to SQL (they're ANDed → a subset is a correct pre-filter that bounds the candidate set),
- apply the full predicate + similarity sort + pagination in Python with the same helpers the memory backend uses (`is_match_query`, `get_sort_fn`, `specstar.util.trigram`).

Same rows as native pg_trgm, only slower. The guard short-circuits on `not _has_pg_trgm`, so it's a **strict no-op when the extension is present** (zero added work for every existing query). `iter_search` + `count` both fall back.

## Tests

Live-Postgres integration (`_has_pg_trgm` forced false): scoped / bare / custom-threshold fuzzy, similarity sort, count, and **equality with the native pg_trgm answer**. New code is unit-covered (only the normal-path fall-through branch is covered by the rest of the suite). Native trigram tests (34) still green → normal path unaffected.

> Note: specstar CI runs `-m "not integration"`, so the fallback tests (integration) run in the full local suite, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)