### PR TITLE
feat(aggregates): composite group-by (by = list of Fields → tuple key) (#430)

### DIFF
--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -2734,14 +2734,20 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         )
         from specstar.query import Field as _Field
 
-        # 0) ``by`` must be a QB Field — no string-by-convention guessing.
-        if not isinstance(by, _Field):
+        # 0) ``by`` must be a QB Field, or a non-empty list/tuple of Fields for a
+        #    COMPOSITE group-by — no string-by-convention guessing. A composite
+        #    ``by`` yields a TUPLE group key (in field order); a single Field keeps
+        #    the scalar key (backward compatible).
+        by_fields = list(by) if isinstance(by, (list, tuple)) else [by]
+        if not by_fields or not all(isinstance(f, _Field) for f in by_fields):
             raise TypeError(
-                "exp_aggregate_by: ``by`` must be a QB Field "
-                '(e.g. QB["source_doc_id"] for indexed data or '
-                "QB.resource_id() / QB.created_by() for ResourceMeta); "
+                "exp_aggregate_by: ``by`` must be a QB Field, or a non-empty "
+                "list of QB Fields for a composite group-by "
+                '(e.g. QB["source_doc_id"], or [QB["metric"], QB["period"]]); '
                 f"got {type(by).__name__}."
             )
+        is_composite = len(by_fields) > 1
+        by = by_fields[0]  # single-field paths (per-row mode / push) use this
 
         # 0b) Parse the #412 group order + guard the page bounds up front. The
         #     negative-bound check MUST be here: on the pushed path a negative
@@ -2782,7 +2788,9 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             a.field for a in self_aggs.values() if isinstance(a, (Sum, Min, Max, Avg))
         ]
         bad = [
-            f.name for f in (by, *agg_field_specs) if not self._is_field_queryable(f)
+            f.name
+            for f in (*by_fields, *agg_field_specs)
+            if not self._is_field_queryable(f)
         ]
         if bad:
             from specstar.types import OnUnindexedQuery, UnindexedQueryError
@@ -2843,7 +2851,9 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         #    bucket per key.
         groups: dict[object, dict[str, object]] = {}
         resource_by_key: dict[object, object] = {}
-        per_row_mode = by.name == "resource_id" and by.source == "meta"
+        per_row_mode = (
+            not is_composite and by.name == "resource_id" and by.source == "meta"
+        )
         # Set only when the store's engine did the group ORDER BY / LIMIT /
         # OFFSET (#412) — then step 6 returns ``out`` as-is instead of
         # re-ordering + re-slicing it (which would double-apply the offset).
@@ -2875,6 +2885,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             pushable = bool(
                 self_aggs
                 and not foreign_aggs
+                and not is_composite  # composite group-by: Python reduce (pushdown TODO)
                 and by.source in ("meta", "data")
                 and isinstance(ms, IMetaWithAgg)
             )
@@ -2939,7 +2950,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 }
             else:
                 for meta in self.iter_all(query):
-                    key = self._read_field(meta, by)
+                    key = (
+                        tuple(self._read_field(meta, f) for f in by_fields)
+                        if is_composite
+                        else self._read_field(meta, by)
+                    )
                     state = groups.get(key)
                     if state is None:
                         state = groups[key] = {

--- a/tests/meta_store/test_aggregate_by.py
+++ b/tests/meta_store/test_aggregate_by.py
@@ -540,6 +540,75 @@ class TestAggregateByOrderAndPaginate:
             mgr.exp_aggregate_by(QB["bucket"], {"n": Count()}, limit=-1)
 
 
+class Sale(msgspec.Struct):
+    region: str
+    period: str
+    amount: int
+
+
+@pytest.mark.parametrize("meta_store_type", ALL_META_STORE_TYPES)
+class TestAggregateByCompositeGroupByParity:
+    """Composite group-by (``by`` = a list of Fields → tuple key), identical
+    across backends."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, meta_store_type, my_tmpdir):
+        self._meta_store_type = meta_store_type
+        self._tmpdir = my_tmpdir
+        yield
+
+    def _mgr(self):
+        meta_store = get_meta_store(self._meta_store_type, tmpdir=self._tmpdir)
+        storage = SimpleStorage(
+            meta_store=meta_store,
+            resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+        )
+        return ResourceManager(
+            Sale,
+            storage=storage,
+            name="sale",
+            default_user="t",
+            indexed_fields=[
+                IndexableField(field_path="region", field_type=str),
+                IndexableField(field_path="period", field_type=str),
+                IndexableField(field_path="amount", field_type=int),
+            ],
+        )
+
+    def _seed(self, mgr, rows):
+        for region, period, amount in rows:
+            mgr.create(Sale(region=region, period=period, amount=amount))
+
+    def test_composite_key_is_a_tuple_in_field_order(self):
+        mgr = self._mgr()
+        self._seed(
+            mgr,
+            [("US", "Q3", 10), ("US", "Q3", 20), ("US", "Q4", 5), ("EU", "Q3", 7)],
+        )
+        rows = mgr.exp_aggregate_by([QB["region"], QB["period"]], {"n": Count()})
+        assert {r.key: r.n for r in rows} == {
+            ("US", "Q3"): 2,
+            ("US", "Q4"): 1,
+            ("EU", "Q3"): 1,
+        }
+
+    def test_composite_group_by_with_a_value_aggregate(self):
+        from specstar.aggregates import Sum
+
+        mgr = self._mgr()
+        self._seed(mgr, [("US", "Q3", 10), ("US", "Q3", 20), ("EU", "Q3", 7)])
+        rows = mgr.exp_aggregate_by(
+            [QB["region"], QB["period"]], {"total": Sum(QB["amount"])}
+        )
+        assert {r.key: r.total for r in rows} == {("US", "Q3"): 30, ("EU", "Q3"): 7}
+
+    def test_single_field_keeps_a_scalar_key(self):
+        mgr = self._mgr()
+        self._seed(mgr, [("US", "Q3", 1), ("EU", "Q3", 1)])
+        rows = mgr.exp_aggregate_by(QB["region"], {"n": Count()})
+        assert {r.key: r.n for r in rows} == {"US": 1, "EU": 1}  # scalar, not 1-tuple
+
+
 @pytest.fixture
 def my_tmpdir():
     import tempfile


### PR DESCRIPTION
Closes #430.

`exp_aggregate_by`'s `by` now accepts a **list of Fields** — a native composite `GROUP BY k1, k2, …`. `GroupRow.key` becomes a **tuple** in field order; a single `Field` keeps the scalar key (backward compatible). No more denormalised composite-string key just to group by multiple logical columns.

```python
rows = rm.exp_aggregate_by([QB["region"], QB["period"]], {"total": Sum(QB["amount"])})
# GroupRow.key == ("US", "Q3")
```

### Status
- The Python reduction buckets by the tuple key — parity-tested across memory / disk / SQLite / Postgres; single-field behaviour and all existing aggregate tests unchanged (163 passed).
- **Follow-up:** pushing a multi-column `GROUP BY` down to Postgres/SQLite (a composite `by` currently reduces in-memory — correct, not yet pushed). Single-field pushdown is unchanged.

A previous draft also bundled a `CountDistinct` aggregate; that was **dropped** — it's a bad contradiction detector (counts distinct *strings*, so "1.2M" vs "1,200,000" reads as a false conflict) and single-purpose, so it doesn't belong in a general library. Only this general composite group-by primitive lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)