### PR TITLE
feat: patch_many — bulk patch under a memory budget (#434)

### DIFF
--- a/docs/en/guides/performance.md
+++ b/docs/en/guides/performance.md
@@ -27,6 +27,59 @@ For large datasets:
 - avoid returning huge payloads in one request
 - prefer querying fields that are indexed
 
+## Updating many rows at once
+
+Pushing one change across many rows — mirroring a collection's visibility onto
+every document in it, say — is not a job for a loop of `update()`. Each
+iteration costs a meta read, a payload read, an encode and two writes, and on a
+remote backend every one of those is a round-trip. Use `patch_many` instead:
+
+```python
+result = rm.patch_many(
+    (QB["collection_id"] == collection_id).build(),
+    MergePatch({"visibility": "public"}),
+)
+print(result.patched, result.unchanged, result.conflicts, result.failures)
+```
+
+You describe the fields that change and never touch the data. That is what
+makes the batching possible: once the read belongs to SpecStar, it can fetch a
+whole batch in one query (`octet_length` + one `SELECT` on Postgres, concurrent
+`head_object` + `GET` on S3) and write the batch back through `save_*_bulk`.
+Handing the manager `(resource_id, full_data)` pairs instead would keep the read
+on your side, one round-trip at a time.
+
+What it does **not** change:
+
+- **Events, and therefore permission checks, still fire per row.** Write ACLs
+  are per-row policies; authorizing a batch is not the same as authorizing its
+  rows.
+- **A row whose revision moved since it was selected is reported as a
+  conflict**, not overwritten — a patch rewrites the whole body, so writing
+  anyway would discard a concurrent edit entirely. Re-run to pick conflicts up.
+- **A no-op patch creates no revision**, so re-running a fan-out is cheap and
+  you do not need to pre-filter rows that already hold the target value.
+
+Failures are collected rather than raised, so one unwritable row does not
+strand the rest; they come back in `result.failures` as `(resource_id, reason)`.
+
+### Memory
+
+`max_bytes` (default 256 MiB) caps how much row data is held at once. The
+budget is in bytes rather than a row count on purpose: row size varies by
+orders of magnitude between models, so a batch size that suits a flat derived
+table will exhaust memory on documents that carry their whole extracted text.
+Rows are read in budget-sized batches; a row larger than the entire budget is
+still processed, on its own.
+
+### Watch the count
+
+`patch_many` patches exactly what the query selects — **including its
+`limit`**, which carries a process-wide default that a deployment can configure
+via `SPECSTAR_DEFAULT_QUERY_LIMIT`. `result.total` reports how many rows were
+selected, so compare it against what you expected rather than assuming the
+fan-out covered everything.
+
 ## Backup / restore
 
 `dump()` and `load()` are streaming-based (msgpack archive). For large backups:

--- a/specstar/aggregates.py
+++ b/specstar/aggregates.py
@@ -38,13 +38,15 @@ class _FieldAggregate(Aggregate):
         if not isinstance(field, Field):
             raise TypeError(
                 f"{type(self).__name__} requires a QB Field "
-                f"(e.g. QB[\"size\"] or QB.created_time()); "
+                f'(e.g. QB["size"] or QB.created_time()); '
                 f"got {type(field).__name__}."
             )
         self.field = field
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.field.name!r}, source={self.field.source!r})"
+        return (
+            f"{type(self).__name__}({self.field.name!r}, source={self.field.source!r})"
+        )
 
 
 class Sum(_FieldAggregate):
@@ -100,7 +102,7 @@ class ForeignAggregate:
         if not isinstance(link, Field):
             raise TypeError(
                 f"ForeignAggregate.link must be a QB Field "
-                f"(e.g. QB[\"source_doc_id\"]); got {type(link).__name__}."
+                f'(e.g. QB["source_doc_id"]); got {type(link).__name__}.'
             )
         if not isinstance(aggregate, Aggregate):
             raise TypeError(
@@ -129,9 +131,7 @@ class GroupRow:
 
     __slots__ = ("key", "resource", "_aggregates")
 
-    def __init__(
-        self, key: Any, *, resource: Any = None, **aggregates: Any
-    ) -> None:
+    def __init__(self, key: Any, *, resource: Any = None, **aggregates: Any) -> None:
         self.key = key
         self.resource = resource
         self._aggregates = aggregates

--- a/specstar/crud/ref_manager.py
+++ b/specstar/crud/ref_manager.py
@@ -172,9 +172,7 @@ def _make_ref_existence_validator(
                     missing.append((ref_info.source_field, rid))
         if missing:
             details = ", ".join(f"{field}={rid!r}" for field, rid in missing)
-            raise ValidationError(
-                f"Reference target(s) not found: {details}"
-            )
+            raise ValidationError(f"Reference target(s) not found: {details}")
 
     return _check
 

--- a/specstar/crud/route_templates/basic.py
+++ b/specstar/crud/route_templates/basic.py
@@ -135,9 +135,7 @@ def reject_resource_id_in_patch(body) -> None:
         return
     for op in body:
         if isinstance(op, dict) and op.get("path") == "/resource_id":
-            raise HTTPException(
-                status_code=422, detail=RESOURCE_ID_IN_BODY_DETAIL
-            )
+            raise HTTPException(status_code=422, detail=RESOURCE_ID_IN_BODY_DETAIL)
 
 
 class IRouteTemplate(ABC):

--- a/specstar/locks.py
+++ b/specstar/locks.py
@@ -147,9 +147,7 @@ class InMemoryLockBackend:
                 raise LockNotOwnedError(handle.key)
             expires_at = time.monotonic() + ttl
             self._held[handle.key] = (handle.token, expires_at)
-            return LockHandle(
-                key=handle.key, token=handle.token, expires_at=expires_at
-            )
+            return LockHandle(key=handle.key, token=handle.token, expires_at=expires_at)
 
 
 __all__ = [

--- a/specstar/resource_manager/backfill.py
+++ b/specstar/resource_manager/backfill.py
@@ -53,12 +53,8 @@ def backfill_vectors(
         if emb is None:
             summary.skipped += 1
             continue
-        needs_encode = (
-            emb.vector is UNSET
-            or (
-                current_encoder_id is not None
-                and emb.encoder_id != current_encoder_id
-            )
+        needs_encode = emb.vector is UNSET or (
+            current_encoder_id is not None and emb.encoder_id != current_encoder_id
         )
         if not needs_encode:
             summary.skipped += 1

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -2203,6 +2203,33 @@ class IStorage(ABC):
         store's :meth:`IResourceStore.save_many`.
         """
 
+    @abstractmethod
+    def read_metas_bulk(
+        self, resource_ids: "Sequence[str]"
+    ) -> "dict[str, ResourceMeta]":
+        """Bulk read resource metadata (#434).
+
+        The read-side counterpart of :meth:`save_metas_bulk`; implementations
+        should delegate to :meth:`IMetaStore.get_many`. Ids with no row are
+        omitted rather than raising — a bulk caller needs to see which members
+        of its set have gone.
+        """
+
+    @abstractmethod
+    def read_revisions_bulk(
+        self,
+        items: "Sequence[tuple[str, str, str | None]]",
+        *,
+        max_bytes: int,
+    ) -> "tuple[dict[str, bytes], int]":
+        """Bulk read revision payloads under a memory budget (#434).
+
+        The read-side counterpart of :meth:`save_revisions_bulk`; implementations
+        should delegate to :meth:`IResourceStore.read_many`, whose docstring
+        carries the budget contract — bytes rather than rows, at least one row
+        always consumed, missing rows omitted.
+        """
+
 
 # Data Search Related Classes
 

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -1616,6 +1616,13 @@ class IResourceStore(ABC):
     # resources, bounded by how much memory the caller can spare. That is
     # what ``read_many`` is for.
 
+    #: How a store signals "this payload is gone". Backends disagree
+    #: (``KeyError`` for the keyed stores, ``FileNotFoundError`` for the
+    #: filesystem one) and a bulk read has to treat them alike: a row can be
+    #: deleted between being selected and being read, and one dead row must
+    #: not take the whole batch down. See :meth:`read_many`.
+    MISSING_PAYLOAD: "tuple[type[BaseException], ...]" = (KeyError, FileNotFoundError)
+
     def payload_sizes(
         self, items: "Sequence[tuple[str, str, str | None]]"
     ) -> "list[int] | None":
@@ -1641,11 +1648,19 @@ class IResourceStore(ABC):
         *items* holds ``(resource_id, revision_id, schema_version)`` triples,
         at most one per ``resource_id``. The default reads them one by one;
         backends with concurrent or set-based fetches override it.
+
+        Items whose payload has gone missing are **omitted** rather than
+        raised — see :attr:`MISSING_PAYLOAD`.
         """
         out: dict[str, bytes] = {}
         for resource_id, revision_id, schema_version in items:
-            with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
-                out[resource_id] = fh.read()
+            try:
+                with self.get_data_bytes(
+                    resource_id, revision_id, schema_version
+                ) as fh:
+                    out[resource_id] = fh.read()
+            except self.MISSING_PAYLOAD:
+                continue
         return out
 
     def read_many(
@@ -1672,6 +1687,10 @@ class IResourceStore(ABC):
         When :meth:`payload_sizes` cannot size cheaply the fallback measures
         payloads as it reads them, so it may overshoot the budget by at most
         one entry — the one that crossed the line has already been fetched.
+
+        Entries whose payload vanished between selection and read are counted
+        as consumed but absent from the returned mapping; a long fan-out has
+        to survive a row being deleted underneath it.
         """
         items = list(items)
         if not items:
@@ -1694,11 +1713,16 @@ class IResourceStore(ABC):
         total = 0
         consumed = 0
         for resource_id, revision_id, schema_version in items:
-            with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
-                raw = fh.read()
+            consumed += 1
+            try:
+                with self.get_data_bytes(
+                    resource_id, revision_id, schema_version
+                ) as fh:
+                    raw = fh.read()
+            except self.MISSING_PAYLOAD:
+                continue
             out[resource_id] = raw
             total += len(raw)
-            consumed += 1
             if total >= max_bytes:
                 break
         return out, consumed

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -2,7 +2,7 @@ import datetime as dt
 import functools
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator, Iterable, MutableMapping
+from collections.abc import Callable, Generator, Iterable, MutableMapping, Sequence
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from enum import Flag, StrEnum
@@ -1607,6 +1607,101 @@ class IResourceStore(ABC):
         for info, raw in items:
             stream = _io.BytesIO(raw) if isinstance(raw, (bytes, bytearray)) else raw
             self.save(info, stream)
+
+    # -- Bulk read (#434) -------------------------------------------------
+    #
+    # ``dump_all_revisions`` below is an *export* primitive: it pulls every
+    # revision of every resource. A read-modify-write fan-out needs the
+    # opposite shape — the *current* revision only, for a named set of
+    # resources, bounded by how much memory the caller can spare. That is
+    # what ``read_many`` is for.
+
+    def payload_sizes(
+        self, items: "Sequence[tuple[str, str, str | None]]"
+    ) -> "list[int] | None":
+        """Byte size of each item's payload, *without* transferring it.
+
+        Returns ``None`` when the backend cannot answer cheaply, which makes
+        :meth:`read_many` fall back to measuring payloads as it reads them.
+
+        Size is deliberately **derived, never stored**. A ``size`` field on
+        :class:`RevisionInfo` would need a backfill, and every revision
+        written before it existed would read as ``UNSET`` — a budget that
+        silently mis-packs exactly the oldest data. ``stat`` /
+        ``octet_length`` / ``head_object`` cost a little time and are always
+        right; a missing column costs correctness and says nothing.
+        """
+        return None
+
+    def read_payloads(
+        self, items: "Sequence[tuple[str, str, str | None]]"
+    ) -> "dict[str, bytes]":
+        """Fetch every item's raw payload, keyed by ``resource_id``.
+
+        *items* holds ``(resource_id, revision_id, schema_version)`` triples,
+        at most one per ``resource_id``. The default reads them one by one;
+        backends with concurrent or set-based fetches override it.
+        """
+        out: dict[str, bytes] = {}
+        for resource_id, revision_id, schema_version in items:
+            with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
+                out[resource_id] = fh.read()
+        return out
+
+    def read_many(
+        self,
+        items: "Sequence[tuple[str, str, str | None]]",
+        *,
+        max_bytes: int,
+    ) -> "tuple[dict[str, bytes], int]":
+        """Read a prefix of *items* that fits in *max_bytes*.
+
+        Returns ``(payloads_by_resource_id, consumed)`` where *consumed* is
+        how many leading entries of *items* were read, so a caller drains the
+        set with ``items = items[consumed:]``.
+
+        The budget is in **bytes rather than rows** because row size varies by
+        orders of magnitude between models — a batch size tuned for a flat
+        derived table will exhaust memory on documents carrying their whole
+        extracted text, and vice versa.
+
+        **At least one entry is always consumed**, even if it alone exceeds
+        *max_bytes*. A row bigger than the budget must still make progress;
+        refusing it would leave the caller asking for the same prefix forever.
+
+        When :meth:`payload_sizes` cannot size cheaply the fallback measures
+        payloads as it reads them, so it may overshoot the budget by at most
+        one entry — the one that crossed the line has already been fetched.
+        """
+        items = list(items)
+        if not items:
+            return {}, 0
+
+        sizes = self.payload_sizes(items)
+        if sizes is not None:
+            total = 0
+            consumed = 0
+            for size in sizes:
+                if consumed and total + size > max_bytes:
+                    break
+                total += size
+                consumed += 1
+            return self.read_payloads(items[:consumed]), consumed
+
+        # No cheap size probe: read until the running total reaches the
+        # budget. Bounded overshoot of one entry — see the docstring.
+        out: dict[str, bytes] = {}
+        total = 0
+        consumed = 0
+        for resource_id, revision_id, schema_version in items:
+            with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
+                raw = fh.read()
+            out[resource_id] = raw
+            total += len(raw)
+            consumed += 1
+            if total >= max_bytes:
+                break
+        return out, consumed
 
     def dump_all_revisions(
         self, *, resource_ids: "frozenset[str] | None" = None

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -858,6 +858,26 @@ class IMetaStore(MutableMapping[str, ResourceMeta]):
         for m in metas:
             self[m.resource_id] = m
 
+    def get_many(self, pks: "Sequence[str]") -> "dict[str, ResourceMeta]":
+        """Optional bulk read — the read-side twin of :meth:`save_many` (#434).
+
+        A fan-out re-reads every row's meta right before writing it, both to
+        build the new revision and to notice a concurrent writer. Without a
+        bulk path that is one round-trip per row, which is exactly the cost
+        batching set out to remove.
+
+        Missing keys are **omitted** rather than raised: the caller is
+        reconciling a set and needs to see which members are gone, not to be
+        stopped by the first one.
+        """
+        out: dict[str, ResourceMeta] = {}
+        for pk in pks:
+            try:
+                out[pk] = self[pk]
+            except KeyError:
+                continue
+        return out
+
     @property
     def supports_native_vector_search(self) -> bool:
         """Whether this meta store can run vector searches natively (vs brute-force).

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -720,30 +720,7 @@ def execute_with_events(
                         else:
                             inputs_[k] = get_from_path(func_inputs, v)
                 before_ctx = contexts.before(**inputs_)
-                # Permission re-entrancy guard (#402): authorize once, at the
-                # outermost operation. The first event-emitting op in this call
-                # stack arms the flag for its whole extent; any nested op (a
-                # patch's internal get/update, a get's internal get_meta, …)
-                # observes it and skips ONLY its permission check — every other
-                # event handler still fires. ``check_permission`` is False for
-                # such nested ops.
-                check_permission = not self._perm_checked_ctx.get()
-                if check_permission:
-                    stack.enter_context(self._perm_checked_ctx.ctx(True))
-                # Read access-scope is a precondition for request-originated
-                # writes: a resource outside the caller's scope is hidden as
-                # not-found (→ 404) *before* the permission checker (→ 403) and
-                # before any current_resource load, so writes never leak
-                # existence. The remainder then runs unscoped — the resource is
-                # confirmed in-scope, and the operation's own (and nested
-                # get/get_meta) reads must not re-probe.
-                if self._maybe_assert_write_scope(before_ctx):
-                    stack.enter_context(self.apply_scope_ctx.ctx(False))
-                # current_resource is loaded solely for the permission check, so
-                # skip the extra storage read when this nested op won't check.
-                if check_permission:
-                    self._maybe_load_current_resource(before_ctx)
-                self._handle_event(before_ctx, check_permission=check_permission)
+                self._authorize_and_announce(before_ctx, stack)
                 try:
                     result = func(self, *args, **kwargs)
                     built_result = _build_result(result)
@@ -1866,6 +1843,44 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             ) as fh:
                 current.data = self._data_serializer.decode(fh.read())
         return current
+
+    def _authorize_and_announce(self, before_ctx: Any, stack: ExitStack) -> None:
+        """Authorize one operation and fire its before-context.
+
+        This is *the* permission gate, in one place. ``execute_with_events``
+        calls it for the operation it wraps; a bulk operation that has to
+        authorize row by row (:meth:`patch_many`) calls it once per row. It
+        stays a single function deliberately — a second copy of this sequence
+        would drift from the decorator, and what would drift is the
+        authorization path, which fails silently and open.
+
+        *stack* must stay open for the rest of the operation: it holds the
+        re-entrancy guard and the unscoped window opened by the write-scope
+        probe.
+
+        Permission re-entrancy guard (#402): authorize once, at the outermost
+        operation. The first event-emitting op in this call stack arms the flag
+        for its whole extent; any nested op (a patch's internal get/update, a
+        get's internal get_meta, …) observes it and skips ONLY its permission
+        check — every other event handler still fires.
+
+        Read access-scope (#398) is a precondition for request-originated
+        writes: a resource outside the caller's scope is hidden as not-found
+        (→ 404) *before* the permission checker (→ 403) and before any
+        current_resource load, so writes never leak existence. The remainder
+        then runs unscoped — the resource is confirmed in-scope, and the
+        operation's own (and nested get/get_meta) reads must not re-probe.
+        """
+        check_permission = not self._perm_checked_ctx.get()
+        if check_permission:
+            stack.enter_context(self._perm_checked_ctx.ctx(True))
+        if self._maybe_assert_write_scope(before_ctx):
+            stack.enter_context(self.apply_scope_ctx.ctx(False))
+        # current_resource is loaded solely for the permission check, so skip
+        # the extra storage read when this nested op won't check.
+        if check_permission:
+            self._maybe_load_current_resource(before_ctx)
+        self._handle_event(before_ctx, check_permission=check_permission)
 
     def _maybe_load_current_resource(self, before_ctx: Any) -> None:
         """Populate ``before_ctx.current_resource`` for a write before-context

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -128,6 +128,7 @@ from specstar.types import (
     OnDecodeError,
     OnDuplicate,
     OnUnindexedQuery,
+    PatchManyResult,
     PermissionDeniedError,
     RawResource,
     Resource,
@@ -455,6 +456,15 @@ class SimpleStorage(IStorage):
             return
         self._resource_store.save_many(items)
 
+    def read_metas_bulk(
+        self, resource_ids: "Sequence[str]"
+    ) -> "dict[str, ResourceMeta]":
+        """Bulk-read metas (#434) — the read-side twin of
+        :meth:`save_metas_bulk`. Ids with no row are omitted."""
+        if not resource_ids:
+            return {}
+        return self._meta_store.get_many(resource_ids)
+
     def read_revisions_bulk(
         self,
         items: "Sequence[tuple[str, str, str | None]]",
@@ -502,6 +512,13 @@ class _BlobEntry(Struct, kw_only=True):
 class _BuildRevInfoCreate(Struct, Generic[T]):
     data: T
     status: RevisionStatus = RevisionStatus.stable
+
+
+#: Default memory ceiling for one ``patch_many`` batch (#434). A library
+#: default has to be safe on a small machine, so it is deliberately well below
+#: what a big host could afford; a caller that knows it has the headroom raises
+#: it per call.
+DEFAULT_PATCH_MANY_MAX_BYTES = 256 * 1024 * 1024
 
 
 class _BuildRevInfoUpdate(Struct, Generic[T]):
@@ -3790,24 +3807,208 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             expected_etag=expected_etag,
         )
 
-    def _apply_patch(self, resource_id: str, patch_data: JsonPatch) -> T:
-        data = self.get(resource_id).data
+    def patch_many(
+        self,
+        query: "ResourceMetaSearchQuery | Query | None",
+        patch_data: "JsonPatch | MergePatch",
+        *,
+        max_bytes: int = DEFAULT_PATCH_MANY_MAX_BYTES,
+        status: RevisionStatus | UnsetType = UNSET,
+        user: str | UnsetType = UNSET,
+        now: dt.datetime | UnsetType = UNSET,
+    ) -> PatchManyResult:
+        """Apply one patch to every resource *query* selects (#434).
+
+        This is the shape a fan-out actually needs — pushing a derived mirror
+        onto every row of a collection, say. The caller describes the fields
+        that change and never touches the data, which is the point: once the
+        read belongs to specstar, specstar can batch it. Handing back
+        ``(resource_id, full_data)`` pairs instead would force the caller to
+        read and re-encode every row itself, one round-trip at a time.
+
+        Semantically this is **N patches whose reads and writes go through the
+        bulk path**, not a second set of rules:
+
+        * Events fire **per row**, including the permission check. Write ACLs
+          are per-row policies, so a batch-level check would authorize the
+          batch and not the rows — a way to write rows the caller may not
+          write. This is why ``patch_many`` is not itself wrapped in
+          ``execute_with_events``: that would arm the re-entrancy guard and
+          turn every row's check into a no-op.
+        * A row whose current revision moved since it was selected is reported
+          as a **conflict** and left alone. A patch rewrites the whole body, so
+          writing anyway would discard a concurrent edit entirely, not merely
+          the mirrored fields. This is the same guarantee ``patch`` gives with
+          ``expected_revision_id`` — no stronger: the compare and the write are
+          not atomic, so it narrows the window rather than closing it.
+        * A no-op patch creates no revision, so a caller need not pre-filter
+          rows that already hold the target value, and re-running is cheap.
+
+        Failures are **collected, not raised**: one unwritable row must not
+        strand the rest of a collection.
+
+        Memory is bounded by *max_bytes*, not by a row count — row size varies
+        by orders of magnitude between models, so rows are the wrong unit. Rows
+        are read in batches that fit the budget; a row larger than the whole
+        budget is still processed on its own.
+
+        Arguments:
+            query: selects the rows to patch. ``None`` selects everything.
+            patch_data: an RFC 6902 ``JsonPatch`` or RFC 7386 ``MergePatch``,
+                applied to every selected row.
+            max_bytes: ceiling on how much row data is held in memory at once.
+            status: status for the new revisions (default: stable).
+            user: the user performing the fan-out; recorded as ``updated_by``
+                on every row it writes, while each row keeps its own
+                ``created_by``.
+            now: timestamp for the write.
+
+        Returns:
+            result (PatchManyResult): counts plus the ids that conflicted or
+            failed.
+        """
+        status = self.default_status if status is UNSET else status
+        result = PatchManyResult()
+        with self._apply_context(user=user, now=now):
+            metas = self.search_resources(query)
+            pending = [
+                (m.resource_id, m.current_revision_id, m.schema_version) for m in metas
+            ]
+            while pending:
+                payloads, consumed = self.storage.read_revisions_bulk(
+                    pending, max_bytes=max_bytes
+                )
+                batch, pending = pending[:consumed], pending[consumed:]
+                self._patch_batch(batch, payloads, patch_data, status, result)
+        return result
+
+    def _patch_batch(
+        self,
+        batch: "list[tuple[str, str, str | None]]",
+        payloads: dict[str, bytes],
+        patch_data: "JsonPatch | MergePatch",
+        status: RevisionStatus,
+        result: PatchManyResult,
+    ) -> None:
+        """Authorize, patch and write one budget-sized batch of rows.
+
+        Ordering matters and is the whole reason this is not a loop over
+        ``patch()``: every row is authorized and announced **before** anything
+        is written, the batch is then written in one go, and only rows that
+        actually landed get their success event. Firing success first and
+        writing after would tell handlers a row was committed that might not
+        be.
+        """
+        fresh = self.storage.read_metas_bulk([rid for rid, _, _ in batch])
+        revisions: list[tuple[RevisionInfo, bytes]] = []
+        new_metas: list[ResourceMeta] = []
+        prepared: list[tuple[str, dict[str, Any], RevisionInfo]] = []
+
+        for resource_id, selected_revision_id, _schema_version in batch:
+            ctx_kw: dict[str, Any] = {
+                "user": self.user_or_unset,
+                "now": self.now_or_unset,
+                "resource_name": self.resource_name,
+                "resource_id": resource_id,
+                "patch_data": patch_data.patch,
+            }
+            try:
+                with ExitStack() as stack:
+                    stack.enter_context(self.id_ctx.ctx(resource_id))
+                    self._authorize_and_announce(BeforePatch(**ctx_kw), stack)
+
+                    raw = payloads.get(resource_id)
+                    prev_meta = fresh.get(resource_id)
+                    if raw is None or prev_meta is None:
+                        raise ResourceIDNotFoundError(resource_id)
+                    if prev_meta.current_revision_id != selected_revision_id:
+                        result.conflicts.append(resource_id)
+                        continue
+
+                    prev_data = self._data_serializer.decode(raw)
+                    data = self._patched(prev_data, patch_data)
+                    data = self._process_binary_fields(data)
+                    data = self._embedding_processor.process_sync(
+                        data, previous=prev_data
+                    )
+                    encoded = self.encode(data)
+                    # Both sides go through this encoder, so a difference in
+                    # how the row was stored (an older schema, say) cancels
+                    # out and only a real change counts. Comparing here also
+                    # saves a per-row read of the previous RevisionInfo just
+                    # to reach its hash.
+                    if encoded == self.encode(prev_data):
+                        result.unchanged += 1
+                        self._handle_event(AfterPatch(**ctx_kw))
+                        continue
+
+                    rev_info = self._rev_info(
+                        _BuildRevInfoUpdate(prev_meta, data, status)
+                    )
+                    revisions.append((rev_info, encoded))
+                    new_metas.append(
+                        self._res_meta(_BuildResMetaUpdate(prev_meta, rev_info, data))
+                    )
+                    prepared.append((resource_id, ctx_kw, rev_info))
+            except Exception as e:
+                self._announce_patch_failure(ctx_kw, e)
+                result.failures.append((resource_id, str(e)))
+
+        if not revisions:
+            return
+        try:
+            self.storage.save_revisions_bulk(revisions)
+            self.storage.save_metas_bulk(new_metas)
+        except Exception as e:
+            # The batch is written as a unit, so nothing here can be reported
+            # as committed. Every prepared row failed together.
+            for resource_id, ctx_kw, _ in prepared:
+                self._announce_patch_failure(ctx_kw, e)
+                result.failures.append((resource_id, str(e)))
+            return
+
+        for resource_id, ctx_kw, rev_info in prepared:
+            self._handle_event(OnSuccessPatch(**ctx_kw, revision_info=rev_info))
+            self._handle_event(AfterPatch(**ctx_kw))
+            result.patched += 1
+
+    def _announce_patch_failure(self, ctx_kw: dict[str, Any], error: Exception) -> None:
+        self._handle_event(
+            OnFailurePatch(
+                **ctx_kw,
+                error=str(error),
+                stack_trace="".join(
+                    traceback.format_exception(type(error), error, error.__traceback__)
+                ),
+            )
+        )
+        self._handle_event(AfterPatch(**ctx_kw))
+
+    def _patched(self, data: T, patch_data: "JsonPatch | MergePatch") -> T:
+        """Apply either patch flavour to data that is already decoded.
+
+        Split out of :meth:`_apply_patch` / :meth:`_apply_merge_patch` so a
+        bulk caller that has already read the row (:meth:`patch_many`) applies
+        the patch through the very same code the single-row path uses. Two
+        implementations of "what a patch means" would be one too many — they
+        would agree right up until the day they didn't.
+        """
         if isinstance(data, msgspec.Raw):
             d = json.loads(bytes(data))
         else:
             d = msgspec.to_builtins(data)
+        if isinstance(patch_data, MergePatch):
+            return msgspec.convert(_rfc7386_merge(d, patch_data), self.resource_type)
         patch_data.apply(d, in_place=True)
         return msgspec.convert(d, self.resource_type)
+
+    def _apply_patch(self, resource_id: str, patch_data: JsonPatch) -> T:
+        return self._patched(self.get(resource_id).data, patch_data)
 
     def _apply_merge_patch(self, resource_id: str, merge_patch: dict) -> T:
         """RFC 7386 analogue of :meth:`_apply_patch`: merge ``merge_patch`` into
         the current data and return the resulting full resource."""
-        data = self.get(resource_id).data
-        if isinstance(data, msgspec.Raw):
-            d = json.loads(bytes(data))
-        else:
-            d = msgspec.to_builtins(data)
-        return msgspec.convert(_rfc7386_merge(d, merge_patch), self.resource_type)
+        return self._patched(self.get(resource_id).data, MergePatch(merge_patch))
 
     @execute_with_events(
         (BeforeSwitch, AfterSwitch, OnSuccessSwitch, OnFailureSwitch),

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -455,6 +455,24 @@ class SimpleStorage(IStorage):
             return
         self._resource_store.save_many(items)
 
+    def read_revisions_bulk(
+        self,
+        items: "Sequence[tuple[str, str, str | None]]",
+        *,
+        max_bytes: int,
+    ) -> "tuple[dict[str, bytes], int]":
+        """Bulk-read revision payloads under a memory budget (#434).
+
+        The read-side counterpart of :meth:`save_revisions_bulk`. Returns
+        ``(payloads_by_resource_id, consumed)``; the caller drains a large set
+        with ``items = items[consumed:]``. See
+        :meth:`IResourceStore.read_many` for the budget contract — bytes not
+        rows, at least one row always consumed, missing rows omitted.
+        """
+        if not items:
+            return {}, 0
+        return self._resource_store.read_many(items, max_bytes=max_bytes)
+
     def collect_orphans(self) -> int:
         """Reclaim resource/blob data left by interrupted ``create()`` calls.
 

--- a/specstar/resource_manager/embedding_processor.py
+++ b/specstar/resource_manager/embedding_processor.py
@@ -37,7 +37,9 @@ class EmbeddingProcessor:
         model_overrides: dict | None = None,
     ) -> None:
         self._infos = [
-            info for info in extract_vector_field_infos(struct_type) if info.is_embedding
+            info
+            for info in extract_vector_field_infos(struct_type)
+            if info.is_embedding
         ]
         self._registry = registry
         self._model_overrides = model_overrides or {}
@@ -50,7 +52,9 @@ class EmbeddingProcessor:
                 continue
             if emb.vector is not UNSET:
                 continue
-            encoder = lookup_encoder(self._registry, field_info=info, model_overrides=self._model_overrides)
+            encoder = lookup_encoder(
+                self._registry, field_info=info, model_overrides=self._model_overrides
+            )
             if encoder is None:
                 continue
             new_hash = _content_hash(emb.content)
@@ -94,7 +98,9 @@ class EmbeddingProcessor:
                 continue
             if emb.vector is not UNSET:
                 continue
-            encoder = lookup_encoder(self._registry, field_info=info, model_overrides=self._model_overrides)
+            encoder = lookup_encoder(
+                self._registry, field_info=info, model_overrides=self._model_overrides
+            )
             if encoder is None:
                 continue
             new_hash = _content_hash(emb.content)

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import warnings
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from enum import Enum as EnumType
 from typing import Any
@@ -1136,6 +1136,27 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             if row is None:
                 raise KeyError(pk)
             return self._serializer.decode(row["data"])
+
+    def get_many(self, pks: "Sequence[str]") -> "dict[str, ResourceMeta]":
+        """Bulk read in one ``WHERE resource_id = ANY(...)`` (#434).
+
+        The inherited default loops ``__getitem__``, which on a remote
+        database is one round-trip per row — the very cost a fan-out batches
+        to avoid. Missing ids are simply absent from the result.
+        """
+        pk_list = list(pks)
+        if not pk_list:
+            return {}
+        with self.stream_cursor() as cur:
+            cur.execute(
+                f'SELECT resource_id, data FROM "{self.table_name}" '
+                f"WHERE resource_id = ANY(%s)",
+                (pk_list,),
+            )
+            return {
+                row["resource_id"]: self._serializer.decode(row["data"])
+                for row in cur.fetchall()
+            }
 
     def __setitem__(self, pk: str, meta: ResourceMeta) -> None:  # ty:ignore[invalid-method-override]
         # 直接寫入 PostgreSQL — honour caller-supplied ``pk`` even if it

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import io
 import time
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from typing import IO, Any
 
@@ -70,9 +70,7 @@ class PostgresResourceStore(IResourceStore):
 
         # Share one process-global pool per DSN (#380). The pool is owned by
         # the registry for the process lifetime; this store never closes it.
-        self._conn_pool = _pg_pool.get_pool(
-            pg_dsn, minconn=minconn, maxconn=maxconn
-        )
+        self._conn_pool = _pg_pool.get_pool(pg_dsn, minconn=minconn, maxconn=maxconn)
 
         self._data_table = f"{table_prefix}resource_data"
         self._index_table = f"{table_prefix}resource_index"
@@ -298,6 +296,56 @@ class PostgresResourceStore(IResourceStore):
                     uid,
                 ),
             )
+
+    # -- Bulk read (#434) -------------------------------------------------
+
+    def _key_tuples(
+        self, items: "Sequence[tuple[str, str, str | None]]"
+    ) -> tuple[tuple[str, str, str], ...]:
+        return tuple((rid, rev, self._sv(sv)) for rid, rev, sv in items)
+
+    def payload_sizes(
+        self, items: "Sequence[tuple[str, str, str | None]]"
+    ) -> list[int]:
+        """Size the batch with ``octet_length`` — one query, no bytes moved.
+
+        This is why the memory budget can be honoured *exactly* here rather
+        than overshooting: Postgres reports how big each payload is without
+        sending it, so the packing decision is made before the transfer.
+
+        Rows that are absent size as 0; ``read_payloads`` then omits them.
+        """
+        if not items:
+            return []
+        keys = self._key_tuples(items)
+        with self._transaction() as cur:
+            cur.execute(
+                f"SELECT i.resource_id, i.revision_id, i.schema_version, "
+                f"octet_length(d.data) "
+                f'FROM "{self._data_table}" d '
+                f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                f"WHERE (i.resource_id, i.revision_id, i.schema_version) IN %s",
+                (keys,),
+            )
+            found = {(r[0], r[1], r[2]): r[3] for r in cur.fetchall()}
+        return [found.get(key, 0) for key in keys]
+
+    def read_payloads(
+        self, items: "Sequence[tuple[str, str, str | None]]"
+    ) -> dict[str, bytes]:
+        """Fetch the whole batch in one query instead of one per row."""
+        if not items:
+            return {}
+        keys = self._key_tuples(items)
+        with self._transaction() as cur:
+            cur.execute(
+                f"SELECT i.resource_id, d.data "
+                f'FROM "{self._data_table}" d '
+                f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                f"WHERE (i.resource_id, i.revision_id, i.schema_version) IN %s",
+                (keys,),
+            )
+            return {row[0]: bytes(row[1]) for row in cur.fetchall()}
 
     def save_many(
         self, items: Iterable[tuple[RevisionInfo, bytes | IO[bytes]]]

--- a/specstar/resource_manager/resource_store/s3.py
+++ b/specstar/resource_manager/resource_store/s3.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import IO
@@ -225,6 +225,97 @@ class S3ResourceStore(IResourceStore):
             if error_code in ("NoSuchKey", "404"):
                 raise KeyError(f"Revision info not found: {uid}")
             raise
+
+    # -- Bulk read (#434) -------------------------------------------------
+
+    @staticmethod
+    def _is_missing(e: "Exception") -> bool:
+        return e.response["Error"]["Code"] in ("NoSuchKey", "404")  # ty: ignore[unresolved-attribute]
+
+    def _resolve_uid(self, item: tuple[str, str, str | None]) -> str | None:
+        """GET the uid index object; ``None`` when the revision is gone."""
+        key = self._get_resource_key(*item)
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+            return response["Body"].read().decode("utf-8")
+        except _ClientError as e:
+            if self._is_missing(e):
+                return None
+            raise
+
+    def _head_size(self, uid: str | None) -> int:
+        """``ContentLength`` without transferring the body."""
+        if uid is None:
+            return 0
+        try:
+            response = self.client.head_object(
+                Bucket=self.bucket, Key=self._get_raw_data_key(uid)
+            )
+            return response["ContentLength"]
+        except _ClientError as e:
+            if self._is_missing(e):
+                return 0
+            raise
+
+    def _get_payload(self, uid: str) -> bytes | None:
+        try:
+            response = self.client.get_object(
+                Bucket=self.bucket, Key=self._get_raw_data_key(uid)
+            )
+            return response["Body"].read()
+        except _ClientError as e:
+            if self._is_missing(e):
+                return None
+            raise
+
+    def read_many(
+        self,
+        items: "Sequence[tuple[str, str, str | None]]",
+        *,
+        max_bytes: int,
+        max_workers: int = 20,
+    ) -> "tuple[dict[str, bytes], int]":
+        """Resolve uids, size with ``head_object``, then fetch only what fits.
+
+        This overrides ``read_many`` wholesale instead of the
+        ``payload_sizes`` / ``read_payloads`` hooks because reaching a payload
+        on S3 takes two calls — GET the uid index, then GET the object — and
+        the two hooks would resolve the same uids twice.
+
+        Every stage fans out over a thread pool. That is where the win is: S3
+        cost is dominated by per-call latency, so N sequential round-trips is
+        precisely the thing worth avoiding. ``head_object`` reports the size
+        without sending the body, so the budget is packed exactly rather than
+        overshooting by a row.
+        """
+        items = list(items)
+        if not items:
+            return {}, 0
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            uids = list(pool.map(self._resolve_uid, items))
+            sizes = list(pool.map(self._head_size, uids))
+
+            total = 0
+            consumed = 0
+            for size in sizes:
+                if consumed and total + size > max_bytes:
+                    break
+                total += size
+                consumed += 1
+
+            selected = [
+                (item[0], uid)
+                for item, uid in zip(items[:consumed], uids[:consumed])
+                if uid is not None
+            ]
+            payloads = list(pool.map(lambda pair: self._get_payload(pair[1]), selected))
+
+        return {
+            resource_id: raw
+            for (resource_id, _), raw in zip(selected, payloads)
+            if raw is not None
+        }, consumed
 
     def save(self, info: RevisionInfo, data: IO[bytes]) -> None:
         # 保存實際數據和資訊到 UID-based 位置

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -111,11 +111,18 @@ class MemoryResourceStore(IResourceStore):
     def payload_sizes(
         self, items: "Sequence[tuple[ResourceID, RevisionID, SchemaVersion | None]]"
     ) -> list[int]:
-        """Sizes are free here — every payload is already in memory (#434)."""
-        return [
-            len(self._raw_data_store[self._store[rid][rev][sv]])
-            for rid, rev, sv in items
-        ]
+        """Sizes are free here — every payload is already in memory (#434).
+
+        A row that has gone missing costs nothing to skip, so it sizes as 0
+        and ``read_payloads`` simply omits it.
+        """
+        sizes: list[int] = []
+        for rid, rev, sv in items:
+            try:
+                sizes.append(len(self._raw_data_store[self._store[rid][rev][sv]]))
+            except KeyError:
+                sizes.append(0)
+        return sizes
 
     def purge_resource(self, resource_id: str) -> None:
         """Hard-delete all revision data for a resource."""
@@ -374,7 +381,12 @@ class DiskResourceStore(IResourceStore):
                 self._resolve_symdir(resource_id, revision_id, schema_version) / "data"
             )
             # Same ESTALE exposure as get_data_bytes — see #352.
-            sizes.append(retry_on_estale(data_path.stat).st_size)
+            try:
+                sizes.append(retry_on_estale(data_path.stat).st_size)
+            except FileNotFoundError:
+                # Deleted since selection — sizes as 0 and read_payloads omits
+                # it, so one dead row cannot fail the whole batch.
+                sizes.append(0)
         return sizes
 
     def save(self, info: RevisionInfo, data: DataIO) -> None:

--- a/specstar/resource_manager/resource_store/simple.py
+++ b/specstar/resource_manager/resource_store/simple.py
@@ -1,7 +1,7 @@
 import io
 import os
 import uuid as uuid_module
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import IO
@@ -107,6 +107,15 @@ class MemoryResourceStore(IResourceStore):
             )[info.schema_version] = info.uid
             self._raw_data_store[info.uid] = raw
             self._raw_info_store[info.uid] = self._info_serializer.encode(info)
+
+    def payload_sizes(
+        self, items: "Sequence[tuple[ResourceID, RevisionID, SchemaVersion | None]]"
+    ) -> list[int]:
+        """Sizes are free here — every payload is already in memory (#434)."""
+        return [
+            len(self._raw_data_store[self._store[rid][rev][sv]])
+            for rid, rev, sv in items
+        ]
 
     def purge_resource(self, resource_id: str) -> None:
         """Hard-delete all revision data for a resource."""
@@ -302,9 +311,7 @@ class DiskResourceStore(IResourceStore):
     ) -> bool:
         return any(
             c.exists()
-            for c in self._symdir_candidates(
-                resource_id, revision_id, schema_version
-            )
+            for c in self._symdir_candidates(resource_id, revision_id, schema_version)
         )
 
     def _resolve_symdir(
@@ -356,6 +363,19 @@ class DiskResourceStore(IResourceStore):
                 return f.read()
 
         return self._info_serializer.decode(retry_on_estale(_read))
+
+    def payload_sizes(
+        self, items: "Sequence[tuple[ResourceID, RevisionID, SchemaVersion | None]]"
+    ) -> list[int]:
+        """``stat`` the data file — no read, no transfer (#434)."""
+        sizes: list[int] = []
+        for resource_id, revision_id, schema_version in items:
+            data_path = (
+                self._resolve_symdir(resource_id, revision_id, schema_version) / "data"
+            )
+            # Same ESTALE exposure as get_data_bytes — see #352.
+            sizes.append(retry_on_estale(data_path.stat).st_size)
+        return sizes
 
     def save(self, info: RevisionInfo, data: DataIO) -> None:
         symd = self._get_uid_store_symdir(
@@ -569,9 +589,7 @@ class DiskResourceStore(IResourceStore):
                 rev = rev_dir.name
                 for ver_link in list(rev_dir.iterdir()):
                     ver = ver_link.name
-                    new_symdir = (
-                        sharded_dir(resource_root, rid) / rid / rev / ver
-                    )
+                    new_symdir = sharded_dir(resource_root, rid) / rid / rev / ver
                     if new_symdir.exists():
                         continue
                     # ``resolve().name`` yields the uid even if the legacy

--- a/specstar/types.py
+++ b/specstar/types.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from jsonpatch import JsonPatch
 from jsonpointer import JsonPointer
 from msgspec import UNSET, Struct, UnsetType
+from msgspec import field as _msgspec_field
 from typing_extensions import Literal
 from typing_extensions import TypeVar as TypeVarExt
 
@@ -1227,6 +1228,43 @@ class MergePatch(dict):
         return dict(self)
 
 
+class PatchManyResult(Struct):
+    """Outcome of a :meth:`IResourceManager.patch_many` fan-out (#434).
+
+    Counts, not a list of ``RevisionInfo``: a fan-out can cover a hundred
+    thousand rows, and returning one struct per row would undo the memory
+    ceiling the batching exists to hold. Only rows that went wrong are named,
+    so the report stays proportional to the trouble rather than to the work.
+
+    ``patched`` and ``unchanged`` are separate because a *re-run* of a mirror
+    fan-out is expected to be almost entirely ``unchanged`` — identical data
+    hashes to the same revision and is never written twice — while the caller
+    still wants to report how many rows it actually moved.
+    """
+
+    patched: int = 0
+    """Rows that were written; a new revision exists."""
+
+    unchanged: int = 0
+    """Rows the patch was a no-op for. No revision was created."""
+
+    conflicts: list[str] = _msgspec_field(default_factory=list)
+    """Rows whose current revision moved between selection and write.
+
+    Left untouched. Re-running the same call picks them up: a patch is
+    idempotent and a no-op costs no revision.
+    """
+
+    failures: list[tuple[str, str]] = _msgspec_field(default_factory=list)
+    """``(resource_id, reason)`` for rows that could not be patched — denied by
+    a permission checker, deleted mid-fan-out, or failed to encode."""
+
+    @property
+    def total(self) -> int:
+        """How many rows the query selected."""
+        return self.patched + self.unchanged + len(self.conflicts) + len(self.failures)
+
+
 class IResourceManager(ABC, Generic[T]):
     """Interface for managing versioned resources with full lifecycle support.
 
@@ -1827,6 +1865,53 @@ class IResourceManager(ABC, Generic[T]):
 
         This operation will fail if the resource is soft-deleted. Use restore()
         first to make soft-deleted resources accessible for patching.
+        """
+
+    @abstractmethod
+    def patch_many(
+        self,
+        query: "Any",
+        patch_data: "JsonPatch | MergePatch",
+        *,
+        max_bytes: int = ...,
+        status: "RevisionStatus | UnsetType" = UNSET,
+        user: str | UnsetType = UNSET,
+        now: dt.datetime | UnsetType = UNSET,
+    ) -> PatchManyResult:
+        """Apply one patch to every resource *query* selects (#434).
+
+        The bulk shape of :meth:`patch`, for fan-outs that push a derived value
+        onto many rows. The caller names the fields that change and never
+        handles the data — which is the point, because once the read belongs to
+        specstar it can be batched.
+
+        Semantically **N patches whose reads and writes go through the bulk
+        path**, not a second set of rules. Events (and therefore permission
+        checks) fire per row; a row whose revision moved since it was selected
+        is reported as a conflict instead of being overwritten; a no-op patch
+        creates no revision. Failures are collected, not raised, so one
+        unwritable row cannot strand the rest.
+
+        The selection is exactly what *query* returns — **including its
+        ``limit``**, which carries a process-wide default that a deployment can
+        configure. :attr:`PatchManyResult.total` reports how many rows were
+        selected so a truncated fan-out is visible rather than silent.
+
+        Args:
+            query: selects the rows to patch; ``None`` selects everything.
+            patch_data: an RFC 6902 ``JsonPatch`` or RFC 7386 ``MergePatch``.
+            max_bytes: ceiling on how much row data is held in memory at once.
+                Bytes rather than a row count because row size varies by orders
+                of magnitude between models. A row larger than the whole budget
+                is still processed, on its own.
+            status: status for the new revisions (default: stable).
+            user: recorded as ``updated_by`` on every row written; each row
+                keeps its own ``created_by``.
+            now: the timestamp for the write.
+
+        Returns:
+            result (PatchManyResult): counts, plus the ids that conflicted or
+            failed.
         """
 
     @abstractmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ INTEGRATION_FILE_PATTERNS = (
     # S3 / MinIO dependent
     "test_advanced_cached_s3.py",
     "test_cached_s3.py",
-    "test_s3_storage_factory.py",
+    "test_s3_*.py",
     "test_blob_store_s3_*.py",
     # End-to-end wizard / wizard integration
     "test_wizard_integration.py",

--- a/tests/meta_store/test_disk_crash_safety.py
+++ b/tests/meta_store/test_disk_crash_safety.py
@@ -264,9 +264,7 @@ def test_collect_orphans_removes_unreferenced_data(my_tmpdir: Path):
         assert not orphan_blob.exists()
         # The live resource is untouched and still readable.
         assert mgr.get(live.resource_id).data.name == "keep"
-        assert (
-            sharded_dir(res_dir / "store", str(live.uid)) / str(live.uid)
-        ).exists()
+        assert (sharded_dir(res_dir / "store", str(live.uid)) / str(live.uid)).exists()
 
 
 def test_collect_orphans_noop_when_clean(my_tmpdir: Path):

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -61,9 +61,11 @@ def test_bfl_cli_runs_backfill_and_prints_summary(monkeypatch) -> None:
 
     # Confirm initial state: vectors UNSET
     mgr = spec.get_resource_manager(_Doc)
-    metas = mgr.search_resources(__import__(
-        "specstar.query_types", fromlist=["ResourceMetaSearchQuery"]
-    ).ResourceMetaSearchQuery())
+    metas = mgr.search_resources(
+        __import__(
+            "specstar.query_types", fromlist=["ResourceMetaSearchQuery"]
+        ).ResourceMetaSearchQuery()
+    )
     rids = [m.resource_id for m in metas]
     for rid in rids:
         assert mgr.get(rid).data.summary.vector is UNSET

--- a/tests/test_bulk_read.py
+++ b/tests/test_bulk_read.py
@@ -124,6 +124,46 @@ def test_read_many_with_no_items_reads_nothing(store):
 
 
 # ---------------------------------------------------------------------------
+# SimpleStorage passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_storage_exposes_the_budgeted_read(tmp_path):
+    """`read_revisions_bulk` is the read-side twin of `save_revisions_bulk`.
+
+    Storage is the seam every ResourceManager talks to, so the budget has to
+    survive the trip through it rather than only existing on the store.
+    """
+    from msgspec import Struct
+
+    from specstar.crud.core import SpecStar
+
+    class Item(Struct):
+        name: str
+
+    spec = SpecStar()
+    spec.configure(default_user="tester", default_now=lambda: _NOW)
+    spec.add_model(Item)
+    rm = spec.get_resource_manager(Item)
+
+    ids = [rm.create(Item(name="n" * 50)).resource_id for _ in range(3)]
+    keys = [
+        (rid, rm.get_meta(rid).current_revision_id, rm.get_meta(rid).schema_version)
+        for rid in ids
+    ]
+
+    everything, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1_000_000)
+    assert consumed == 3
+    assert set(everything) == set(ids)
+
+    # A budget below one row's size still makes progress — exactly one row.
+    _, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1)
+    assert consumed == 1
+
+    assert rm.storage.read_revisions_bulk([], max_bytes=1_000) == ({}, 0)
+
+
+# ---------------------------------------------------------------------------
 # Backends that cannot size a payload without transferring it
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bulk_read.py
+++ b/tests/test_bulk_read.py
@@ -152,6 +152,22 @@ def test_read_many_without_a_size_probe_overshoots_by_at_most_one_row():
     assert set(data) == {"a", "b", "c"}
 
 
+def test_read_many_skips_rows_that_vanished_since_selection(store):
+    """A fan-out selects rows, then reads them — a row can die in between.
+
+    The read must not take the whole batch down with it: the surviving rows
+    are returned, the dead one is simply absent, and the caller (which is
+    collecting per-row failures anyway) decides what that means.
+    """
+    keys = _seed(store, {"a": 10, "gone": 10, "c": 10})
+    store.purge_resource("gone")
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3  # the whole prefix was accounted for
+    assert set(data) == {"a", "c"}
+
+
 def test_read_many_without_a_size_probe_still_makes_progress():
     store = _UnsizeableStore()
     keys = _seed(store, {"huge": 5_000})

--- a/tests/test_bulk_read.py
+++ b/tests/test_bulk_read.py
@@ -1,0 +1,162 @@
+"""Tests for the memory-budgeted bulk read primitive (issue #434).
+
+``IResourceStore.read_many`` is the read-side counterpart of the existing
+``save_many``: it fetches the raw payload of many revisions at once so a
+read-modify-write fan-out (``ResourceManager.patch_many``) does not pay one
+round-trip per row.
+
+The budget is expressed in **bytes**, not rows, because row size varies by
+orders of magnitude between models (a flat derived table vs a document
+carrying its whole extracted text). A row-count batch size that is right for
+one is catastrophically wrong for the other.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import uuid
+
+import pytest
+
+from specstar.resource_manager.resource_store.simple import (
+    DiskResourceStore,
+    MemoryResourceStore,
+)
+from specstar.types import RevisionInfo, RevisionStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = dt.datetime(2026, 7, 20, tzinfo=dt.timezone.utc)
+
+
+def _info(resource_id: str, revision_id: str = "r1") -> RevisionInfo:
+    return RevisionInfo(
+        uid=uuid.uuid4(),
+        resource_id=resource_id,
+        revision_id=revision_id,
+        schema_version=None,
+        status=RevisionStatus.stable,
+        created_time=_NOW,
+        updated_time=_NOW,
+        created_by="tester",
+        updated_by="tester",
+    )
+
+
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
+    """Save one revision per entry of *sizes* and return the read keys."""
+    keys: list[tuple[str, str, None]] = []
+    for rid, size in sizes.items():
+        info = _info(rid)
+        store.save(info, io.BytesIO(b"x" * size))
+        keys.append((rid, info.revision_id, info.schema_version))
+    return keys
+
+
+@pytest.fixture(params=["memory", "disk"])
+def store(request, tmp_path):
+    if request.param == "memory":
+        return MemoryResourceStore()
+    return DiskResourceStore(rootdir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Budget behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_read_many_returns_everything_when_budget_is_ample(store):
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3
+    assert data == {"a": b"x" * 10, "b": b"x" * 20, "c": b"x" * 30}
+
+
+def test_read_many_stops_at_the_budget(store):
+    # 40 bytes of budget fits "a" (10) + "b" (20) but not "c" (30).
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=40)
+
+    assert consumed == 2
+    assert set(data) == {"a", "b"}
+
+
+def test_read_many_always_reads_at_least_one_row(store):
+    """A row bigger than the whole budget must still make progress.
+
+    Otherwise a single oversized row stalls the caller forever — it would
+    ask for the same prefix again and again and never consume it.
+    """
+    keys = _seed(store, {"huge": 5_000})
+
+    data, consumed = store.read_many(keys, max_bytes=1)
+
+    assert consumed == 1
+    assert data == {"huge": b"x" * 5_000}
+
+
+def test_read_many_resumes_from_the_unconsumed_tail(store):
+    """Consuming a prefix at a time must eventually cover every row."""
+    keys = _seed(store, {"a": 30, "b": 30, "c": 30})
+
+    seen: dict[str, bytes] = {}
+    pending = list(keys)
+    rounds = 0
+    while pending:
+        data, consumed = store.read_many(pending, max_bytes=40)
+        assert consumed >= 1
+        seen.update(data)
+        pending = pending[consumed:]
+        rounds += 1
+
+    assert seen.keys() == {"a", "b", "c"}
+    assert rounds == 3  # 40 bytes fits exactly one 30-byte row at a time
+
+
+def test_read_many_with_no_items_reads_nothing(store):
+    assert store.read_many([], max_bytes=1_000) == ({}, 0)
+
+
+# ---------------------------------------------------------------------------
+# Backends that cannot size a payload without transferring it
+# ---------------------------------------------------------------------------
+
+
+class _UnsizeableStore(MemoryResourceStore):
+    """A backend with no cheap size probe — exercises the fallback path."""
+
+    def payload_sizes(self, items):
+        return None
+
+
+def test_read_many_without_a_size_probe_overshoots_by_at_most_one_row():
+    """The fallback can only measure a payload *after* fetching it.
+
+    So it stops as soon as the running total reaches the budget, which means
+    the row that crossed the line has already been read. That is a bounded,
+    documented overshoot of one row — not an unbounded one — and it is why
+    backends that *can* size cheaply override ``payload_sizes``.
+    """
+    store = _UnsizeableStore()
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=40)
+
+    assert consumed == 3  # exact packing would have stopped at 2
+    assert set(data) == {"a", "b", "c"}
+
+
+def test_read_many_without_a_size_probe_still_makes_progress():
+    store = _UnsizeableStore()
+    keys = _seed(store, {"huge": 5_000})
+
+    data, consumed = store.read_many(keys, max_bytes=1)
+
+    assert consumed == 1
+    assert data == {"huge": b"x" * 5_000}

--- a/tests/test_bulk_read.py
+++ b/tests/test_bulk_read.py
@@ -46,9 +46,9 @@ def _info(resource_id: str, revision_id: str = "r1") -> RevisionInfo:
     )
 
 
-def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, str | None]]:
     """Save one revision per entry of *sizes* and return the read keys."""
-    keys: list[tuple[str, str, None]] = []
+    keys: list[tuple[str, str, str | None]] = []
     for rid, size in sizes.items():
         info = _info(rid)
         store.save(info, io.BytesIO(b"x" * size))
@@ -201,15 +201,15 @@ def test_storage_exposes_the_budgeted_read(tmp_path):
         for rid in ids
     ]
 
-    everything, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1_000_000)
+    everything, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1_000_000)  # ty:ignore[unresolved-attribute]
     assert consumed == 3
     assert set(everything) == set(ids)
 
     # A budget below one row's size still makes progress — exactly one row.
-    _, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1)
+    _, consumed = rm.storage.read_revisions_bulk(keys, max_bytes=1)  # ty:ignore[unresolved-attribute]
     assert consumed == 1
 
-    assert rm.storage.read_revisions_bulk([], max_bytes=1_000) == ({}, 0)
+    assert rm.storage.read_revisions_bulk([], max_bytes=1_000) == ({}, 0)  # ty:ignore[unresolved-attribute]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bulk_read.py
+++ b/tests/test_bulk_read.py
@@ -124,6 +124,55 @@ def test_read_many_with_no_items_reads_nothing(store):
 
 
 # ---------------------------------------------------------------------------
+# Meta store bulk read
+# ---------------------------------------------------------------------------
+
+
+def _meta_spec():
+    from msgspec import Struct
+
+    from specstar.crud.core import SpecStar
+
+    class Item(Struct):
+        name: str
+
+    spec = SpecStar()
+    spec.configure(default_user="tester", default_now=lambda: _NOW)
+    spec.add_model(Item)
+    return spec, Item
+
+
+def test_meta_store_get_many_returns_what_it_finds():
+    spec, Item = _meta_spec()
+    rm = spec.get_resource_manager(Item)
+    ids = [rm.create(Item(name=f"n{i}")).resource_id for i in range(3)]
+
+    found = rm.storage.meta_store.get_many(ids)
+
+    assert set(found) == set(ids)
+    assert {m.resource_id for m in found.values()} == set(ids)
+
+
+def test_meta_store_get_many_omits_unknown_ids():
+    """A bulk caller is reconciling a set — it needs to see which members are
+    gone, not to be stopped by the first missing one."""
+    spec, Item = _meta_spec()
+    rm = spec.get_resource_manager(Item)
+    known = rm.create(Item(name="here")).resource_id
+
+    found = rm.storage.meta_store.get_many([known, "does-not-exist"])
+
+    assert set(found) == {known}
+
+
+def test_meta_store_get_many_with_no_ids():
+    spec, Item = _meta_spec()
+    rm = spec.get_resource_manager(Item)
+
+    assert rm.storage.meta_store.get_many([]) == {}
+
+
+# ---------------------------------------------------------------------------
 # SimpleStorage passthrough
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cas_revision.py
+++ b/tests/test_cas_revision.py
@@ -79,9 +79,7 @@ def test_create_if_not_exists_raises_when_resource_id_already_exists():
     rm = _rm()
     info = rm.create(Doc(name="v1"))
     with pytest.raises(DuplicateResourceError):
-        rm.create(
-            Doc(name="loser"), resource_id=info.resource_id, if_not_exists=True
-        )
+        rm.create(Doc(name="loser"), resource_id=info.resource_id, if_not_exists=True)
 
 
 def test_create_if_not_exists_succeeds_when_resource_id_is_new():

--- a/tests/test_cas_revision_http.py
+++ b/tests/test_cas_revision_http.py
@@ -61,9 +61,7 @@ def test_put_with_if_none_match_star_on_existing_returns_412():
     c = _client()
     r1 = c.post("/widget", json={"name": "v1"})
     rid = r1.json()["resource_id"]
-    r2 = c.put(
-        f"/widget/{rid}", json={"name": "v2"}, headers={"If-None-Match": "*"}
-    )
+    r2 = c.put(f"/widget/{rid}", json={"name": "v2"}, headers={"If-None-Match": "*"})
     assert r2.status_code == 412
 
 

--- a/tests/test_disk_fanout_layout.py
+++ b/tests/test_disk_fanout_layout.py
@@ -298,9 +298,7 @@ def _seed_legacy_revision(store, root, rid, rev, uid, data, sv="1.0"):
     )
     symd = root / "resource" / rid / rev / p_sv
     symd.parent.mkdir(parents=True, exist_ok=True)
-    symd.symlink_to(
-        relative_walk_up(reald, symd.parent), target_is_directory=True
-    )
+    symd.symlink_to(relative_walk_up(reald, symd.parent), target_is_directory=True)
 
 
 def test_resource_save_lands_sharded_and_roundtrips(tmp_path: Path):
@@ -374,7 +372,9 @@ def test_resource_collect_orphans_across_layouts(tmp_path: Path):
     assert store.exists("live:1", "live:1:1", "1.0")
     assert not store.exists("dead:1", "dead:1:1", "1.0")
     # the orphan's real data is reclaimed too
-    assert not (sharded_dir(tmp_path / "store", str(orphan_uid)) / str(orphan_uid)).exists()
+    assert not (
+        sharded_dir(tmp_path / "store", str(orphan_uid)) / str(orphan_uid)
+    ).exists()
 
 
 def test_resource_purge_resource(tmp_path: Path):

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -6,6 +6,7 @@ Guards against the doc/reality drift found while evaluating SpecStar 0.11:
   * migrate routes are NOT registered by default (opt-in via MigrateRouteTemplate)
   * the documented migrate -> rollback flow works for a breaking change
 """
+
 import datetime as dt
 from typing import Literal
 
@@ -67,7 +68,9 @@ def test_migrate_routes_are_opt_in(tmp_path):
     app2 = FastAPI()
     sp2.add_model(Schema(User, "v1"))
     sp2.apply(app2)
-    migrate_paths = {r.path for r in app2.routes if hasattr(r, "path") and "migrate" in r.path}
+    migrate_paths = {
+        r.path for r in app2.routes if hasattr(r, "path") and "migrate" in r.path
+    }
     assert "/user/migrate/execute" in migrate_paths
     assert "/user/migrate/single/{resource_id}" in migrate_paths
 
@@ -82,7 +85,9 @@ def test_breaking_migration_then_rollback(tmp_path):
     sp.add_model(Schema(User, "v1"))
     sp.apply(app)
     c = TestClient(app)
-    rid = c.post("/user", json={"name": "Bob", "email": "a@x.com"}).json()["resource_id"]
+    rid = c.post("/user", json={"name": "Bob", "email": "a@x.com"}).json()[
+        "resource_id"
+    ]
     c.put(f"/user/{rid}", json={"name": "Bob", "email": "b@x.com"})
 
     class UserV1(Struct):
@@ -140,9 +145,7 @@ def test_get_old_revision_after_soft_delete_with_include_deleted(tmp_path):
     rm.update(info.resource_id, _Doc(title="Onboarding", body="v2"))
     rm.delete(info.resource_id)
 
-    old = rm.get(
-        info.resource_id, revision_id=info.revision_id, include_deleted=True
-    )
+    old = rm.get(info.resource_id, revision_id=info.revision_id, include_deleted=True)
     assert old.data.body == "v1"
 
 
@@ -267,8 +270,7 @@ def test_prune_union_is_conservative(tmp_path):
     )
     assert len(pruned) == 4
     survivors = {
-        mgr_b.get(rid_b, revision_id=r).data.value
-        for r in mgr_b.list_revisions(rid_b)
+        mgr_b.get(rid_b, revision_id=r).data.value for r in mgr_b.list_revisions(rid_b)
     }
     assert survivors == {"v4", "v5", "v6", "v7"}
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -49,15 +49,22 @@ def test_docs_tldr_runs_end_to_end() -> None:
         Doc(title="a-near", doctype="article", summary=Embedding(content="hello world"))
     )
     mgr.create(
-        Doc(title="b-far", doctype="article", summary=Embedding(content="orthogonal text"))
+        Doc(
+            title="b-far",
+            doctype="article",
+            summary=Embedding(content="orthogonal text"),
+        )
     )
     mgr.create(
         Doc(title="c-wrong-type", doctype="memo", summary=Embedding(content="hello"))
     )
 
     query = (
-        (QB["doctype"] == "article") & (QB["summary"].cosine("near_query") < 0.3)
-    ).sort(QB["summary"].cosine("near_query")).limit(3).build()
+        ((QB["doctype"] == "article") & (QB["summary"].cosine("near_query") < 0.3))
+        .sort(QB["summary"].cosine("near_query"))
+        .limit(3)
+        .build()
+    )
 
     results = mgr.list_resources(query, returns=["data"])
     titles = [r.data.title for r in results]
@@ -246,9 +253,7 @@ def test_docs_distance_metric_alternatives() -> None:
     assert titles == ["near", "far"]
 
     # ip metric
-    r_ip = (
-        (QB["e"].ip([1.0, 1.0]) <= -1.0).sort(QB["e"].ip([1.0, 1.0])).build()
-    )
+    r_ip = (QB["e"].ip([1.0, 1.0]) <= -1.0).sort(QB["e"].ip([1.0, 1.0])).build()
     titles_ip = [r.data.title for r in mgr.list_resources(r_ip, returns=["data"])]
     # far has dot=20 → ip dist=-20; near has dot=2 → ip dist=-2. Both ≤ -1.
     # ascending → most-similar (most-negative) first

--- a/tests/test_exp_aggregate_by.py
+++ b/tests/test_exp_aggregate_by.py
@@ -267,8 +267,12 @@ def test_mixed_self_and_foreign_aggregates_in_one_call():
         {
             "self_n": Count(),
             "chunk_n": ForeignAggregate(rm_chunk, QB["source_doc_id"], Count()),
-            "chunk_total": ForeignAggregate(rm_chunk, QB["source_doc_id"], Sum(QB["size"])),
-            "chunk_biggest": ForeignAggregate(rm_chunk, QB["source_doc_id"], Max(QB["size"])),
+            "chunk_total": ForeignAggregate(
+                rm_chunk, QB["source_doc_id"], Sum(QB["size"])
+            ),
+            "chunk_biggest": ForeignAggregate(
+                rm_chunk, QB["source_doc_id"], Max(QB["size"])
+            ),
         },
     )
     by_name = {

--- a/tests/test_field_source.py
+++ b/tests/test_field_source.py
@@ -81,15 +81,13 @@ def test_foreign_aggregate_link_must_be_field():
 
 
 class DocWithShadow(msgspec.Struct):
-    created_by: str   # collides with ResourceMeta.created_by (the audit field)
+    created_by: str  # collides with ResourceMeta.created_by (the audit field)
 
 
 def test_qb_subscript_reads_indexed_data_even_when_name_collides_with_meta():
     sp = SpecStar()
     sp.configure(default_user="audit-bob")
-    sp.add_model(
-        DocWithShadow, name="doc_shadow", indexed_fields=[("created_by", str)]
-    )
+    sp.add_model(DocWithShadow, name="doc_shadow", indexed_fields=[("created_by", str)])
     rm = sp.get_resource_manager(DocWithShadow)
     # audit user "audit-bob" populates meta.created_by; the struct's created_by
     # populates indexed_data["created_by"] with a *different* value.

--- a/tests/test_lazy_read_migration.py
+++ b/tests/test_lazy_read_migration.py
@@ -39,9 +39,11 @@ def _write_v1(tmp_path) -> str:
     app = FastAPI()
     sp.add_model(Schema(ItemV1, "v1"), name="item")
     sp.apply(app)
-    return TestClient(app).post("/item", json={"name": "widget", "qty": 7}).json()[
-        "resource_id"
-    ]
+    return (
+        TestClient(app)
+        .post("/item", json={"name": "widget", "qty": 7})
+        .json()["resource_id"]
+    )
 
 
 def _reader_v2(tmp_path):
@@ -66,9 +68,9 @@ def test_lazy_read_migration_applies_registered_step(tmp_path, caplog):
     # honest: storage is untouched, revision_info still reports the stored version
     assert results[0].info.schema_version == "v1"
     # the "looks migrated but isn't persisted" gap is surfaced
-    assert any(
-        "migration on read" in r.getMessage() for r in caplog.records
-    ), [r.getMessage() for r in caplog.records]
+    assert any("migration on read" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
 
 
 def test_lazy_read_migration_single_get(tmp_path):

--- a/tests/test_list_count_consistency.py
+++ b/tests/test_list_count_consistency.py
@@ -52,4 +52,6 @@ def test_list_warns_when_dropping_undecodable_rows(tmp_path, caplog):
     assert any(
         "decod" in r.getMessage().lower() or "skip" in r.getMessage().lower()
         for r in caplog.records
-    ), f"expected a decode/skip warning, got: {[r.getMessage() for r in caplog.records]}"
+    ), (
+        f"expected a decode/skip warning, got: {[r.getMessage() for r in caplog.records]}"
+    )

--- a/tests/test_merge_patch_manager.py
+++ b/tests/test_merge_patch_manager.py
@@ -21,9 +21,7 @@ class Item(msgspec.Struct):
 
 def _mgr():
     sp = SpecStar()
-    sp.configure(
-        default_user="t", default_now=lambda: dt.datetime.now(dt.timezone.utc)
-    )
+    sp.configure(default_user="t", default_now=lambda: dt.datetime.now(dt.timezone.utc))
     sp.add_model(Schema(Item, "v1"))
     return sp.get_resource_manager(Item)
 

--- a/tests/test_message_queue/test_delay_retry.py
+++ b/tests/test_message_queue/test_delay_retry.py
@@ -58,9 +58,7 @@ def rm_fixture():
         pytest.param(
             "rabbitmq",
             marks=[
-                pytest.mark.skipif(
-                    not PIKA_AVAILABLE, reason="pika not installed"
-                ),
+                pytest.mark.skipif(not PIKA_AVAILABLE, reason="pika not installed"),
                 pytest.mark.integration,
             ],
             id="rabbitmq",

--- a/tests/test_message_queue/test_periodic_jobs.py
+++ b/tests/test_message_queue/test_periodic_jobs.py
@@ -67,9 +67,7 @@ def rm_fixture():
         pytest.param(
             "rabbitmq",
             marks=[
-                pytest.mark.skipif(
-                    not PIKA_AVAILABLE, reason="pika not installed"
-                ),
+                pytest.mark.skipif(not PIKA_AVAILABLE, reason="pika not installed"),
                 pytest.mark.integration,
             ],
             id="rabbitmq",

--- a/tests/test_openapi_vector.py
+++ b/tests/test_openapi_vector.py
@@ -25,9 +25,7 @@ def test_oa_x_vector_dim_injected() -> None:
     schema = app.openapi_schema
     components = schema["components"]["schemas"]
     # Find the Doc component (name may be prefixed)
-    doc_comp = next(
-        c for n, c in components.items() if n.endswith("Doc") or n == "Doc"
-    )
+    doc_comp = next(c for n, c in components.items() if n.endswith("Doc") or n == "Doc")
     prop = doc_comp["properties"]["embedding"]
     assert prop.get("x-vector-dim") == 1536
 

--- a/tests/test_optimistic_locking.py
+++ b/tests/test_optimistic_locking.py
@@ -75,9 +75,7 @@ def test_put_accepts_quoted_if_match_header(client_and_resource):
 def test_put_with_stale_if_match_header_returns_412(client_and_resource):
     c, rid, rev1 = client_and_resource
     c.put(f"/note/{rid}", json={"title": "b"})
-    r = c.put(
-        f"/note/{rid}", json={"title": "c"}, headers={"If-Match": rev1}
-    )
+    r = c.put(f"/note/{rid}", json={"title": "c"}, headers={"If-Match": rev1})
     assert r.status_code == 412
 
 

--- a/tests/test_patch_many.py
+++ b/tests/test_patch_many.py
@@ -1,0 +1,335 @@
+"""`ResourceManager.patch_many` — one patch, many rows (issue #434).
+
+The shape is deliberately *patch*, not *update*: a caller pushing a derived
+mirror onto every row of a collection should describe the fields that change,
+not read every row out, edit three fields, and write the whole thing back. The
+read then belongs to specstar, which is the only layer that can batch it.
+
+Semantically this is "N patches, whose reads and writes go through the bulk
+path" — **not** a new set of rules. In particular events fire per row, because
+that is where write ACLs live: firing once per batch would let a bulk call
+walk straight past a per-row permission check.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from msgspec import Struct
+
+from specstar.crud.core import SpecStar
+from specstar.permission.checker import IPermissionChecker, PermissionResult
+from specstar.query import QB
+from specstar.resource_manager.core import PermissionEventHandler
+from specstar.types import MergePatch, ResourceAction
+
+_NOW = dt.datetime(2026, 7, 20, tzinfo=dt.timezone.utc)
+
+
+class Doc(Struct):
+    name: str
+    collection_id: str
+    visibility: str = "private"
+    body: str = ""
+
+
+def _spec(**kw):
+    spec = SpecStar(**kw)
+    spec.configure(default_user="owner", default_now=lambda: _NOW)
+    return spec
+
+
+def _seeded(n=3, collection="c1", **kw):
+    spec = _spec(**kw)
+    spec.add_model(Doc, indexed_fields=["collection_id", "visibility"])
+    rm = spec.get_resource_manager(Doc)
+    ids = [
+        rm.create(Doc(name=f"d{i}", collection_id=collection)).resource_id
+        for i in range(n)
+    ]
+    return rm, ids
+
+
+def _in(collection: str):
+    return (QB["collection_id"] == collection).build()
+
+
+# ---------------------------------------------------------------------------
+# The fan-out this exists for
+# ---------------------------------------------------------------------------
+
+
+def test_patch_many_pushes_one_patch_onto_every_matching_row():
+    rm, ids = _seeded(3)
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert result.patched == 3
+    assert all(rm.get(rid).data.visibility == "public" for rid in ids)
+
+
+def test_patch_many_leaves_other_fields_alone():
+    """A merge patch names the fields that change; the rest must survive."""
+    rm, ids = _seeded(2)
+    rm.update(ids[0], Doc(name="kept", collection_id="c1", body="important"))
+
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    doc = rm.get(ids[0]).data
+    assert (doc.name, doc.body, doc.visibility) == ("kept", "important", "public")
+
+
+def test_patch_many_only_touches_rows_the_query_selected():
+    rm, ids = _seeded(2, collection="c1")
+    other = rm.create(Doc(name="elsewhere", collection_id="c2")).resource_id
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert result.patched == 2
+    assert rm.get(other).data.visibility == "private"
+
+
+def test_patch_many_on_an_empty_selection_does_nothing():
+    rm, _ = _seeded(2)
+
+    result = rm.patch_many(_in("nope"), MergePatch({"visibility": "public"}))
+
+    assert (result.patched, result.unchanged) == (0, 0)
+    assert result.failures == [] and result.conflicts == []
+
+
+# ---------------------------------------------------------------------------
+# No-op patches must not churn revisions
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_already_holding_the_target_value_is_reported_unchanged():
+    """The caller should not have to pre-filter to avoid churning revisions.
+
+    `update` already short-circuits when the encoded data hashes the same, so
+    a re-run of a fan-out is nearly free — but "how many rows did this change"
+    is still the number the caller reports, so the two counts stay separate.
+    """
+    rm, ids = _seeded(3)
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert (result.patched, result.unchanged) == (0, 3)
+
+
+def test_a_no_op_patch_creates_no_new_revision():
+    rm, ids = _seeded(1)
+    before = len(rm.list_revisions(ids[0]))
+
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "private"}))
+
+    assert len(rm.list_revisions(ids[0])) == before
+
+
+# ---------------------------------------------------------------------------
+# Per-row permission — the reason events are not fired once per batch
+# ---------------------------------------------------------------------------
+
+
+class _DenyOne(IPermissionChecker):
+    """Denies writes to one specific row, allows everything else.
+
+    Models the real shape of a per-row write ACL: the verdict depends on the
+    row being written, so it cannot be decided once for a whole batch.
+    """
+
+    def __init__(self, denied_id: str) -> None:
+        self.denied_id = denied_id
+        self.seen: list[str | None] = []
+
+    def required_resource_parts(self, action) -> frozenset:
+        return frozenset()
+
+    def check_permission(self, context) -> PermissionResult:
+        if getattr(context, "action", None) is not ResourceAction.patch:
+            return PermissionResult.allow
+        rid = getattr(context, "resource_id", None)
+        self.seen.append(rid)
+        if rid == self.denied_id:
+            return PermissionResult.deny
+        return PermissionResult.allow
+
+
+def _with_checker(denied_index=1, n=3):
+    spec = _spec()
+    rm_probe = None
+    spec.add_model(Doc, indexed_fields=["collection_id", "visibility"])
+    rm = spec.get_resource_manager(Doc)
+    ids = [
+        rm.create(Doc(name=f"d{i}", collection_id="c1")).resource_id for i in range(n)
+    ]
+    checker = _DenyOne(ids[denied_index])
+    rm.event_handlers = [PermissionEventHandler(checker)]
+    return rm, ids, checker, rm_probe
+
+
+def test_the_permission_check_runs_for_every_row():
+    """Firing events once per batch would authorize the batch, not the rows.
+
+    A bulk path that skipped this would be a way to write rows the caller is
+    not allowed to write — the batch equivalent of an unchecked endpoint.
+    """
+    rm, ids, checker, _ = _with_checker()
+
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert sorted(checker.seen) == sorted(ids)
+
+
+def test_a_denied_row_is_reported_and_not_written():
+    rm, ids, checker, _ = _with_checker(denied_index=1)
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert result.patched == 2
+    assert [rid for rid, _ in result.failures] == [ids[1]]
+    assert rm.get(ids[1]).data.visibility == "private"
+
+
+def test_a_denied_row_does_not_stop_the_others():
+    """Collect-and-continue: one bad row must not strand the rest of a
+    collection's permission fan-out."""
+    rm, ids, checker, _ = _with_checker(denied_index=0)
+
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert rm.get(ids[1]).data.visibility == "public"
+    assert rm.get(ids[2]).data.visibility == "public"
+
+
+# ---------------------------------------------------------------------------
+# Optimistic concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_that_moved_since_selection_is_a_conflict_not_a_clobber():
+    """The window between selecting rows and writing them is long in a
+    fan-out. Writing anyway would silently discard the concurrent edit — the
+    whole row, not just the mirrored fields, because a patch rewrites the
+    whole body.
+    """
+    rm, ids = _seeded(3)
+    victim = ids[1]
+
+    original = rm.storage.read_revisions_bulk
+
+    def _racing(items, *, max_bytes):
+        out = original(items, max_bytes=max_bytes)
+        # A concurrent writer lands after we read, before we write.
+        if any(rid == victim for rid, _, _ in items):
+            rm.update(victim, Doc(name="edited by someone else", collection_id="c1"))
+        return out
+
+    rm.storage.read_revisions_bulk = _racing
+    try:
+        result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+    finally:
+        rm.storage.read_revisions_bulk = original
+
+    assert result.conflicts == [victim]
+    assert result.patched == 2
+    assert rm.get(victim).data.name == "edited by someone else"
+
+
+# ---------------------------------------------------------------------------
+# Memory budget
+# ---------------------------------------------------------------------------
+
+
+def test_patch_many_covers_every_row_across_several_batches():
+    """A budget smaller than the selection must not silently truncate it."""
+    rm, ids = _seeded(5)
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}), max_bytes=1)
+
+    assert result.patched == 5
+    assert all(rm.get(rid).data.visibility == "public" for rid in ids)
+
+
+def test_the_budget_bounds_how_much_is_held_at_once():
+    rm, ids = _seeded(4)
+    sizes: list[int] = []
+
+    original = rm.storage.read_revisions_bulk
+
+    def _recording(items, *, max_bytes):
+        payloads, consumed = original(items, max_bytes=max_bytes)
+        sizes.append(sum(len(v) for v in payloads.values()))
+        return payloads, consumed
+
+    rm.storage.read_revisions_bulk = _recording
+    try:
+        rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}), max_bytes=1)
+    finally:
+        rm.storage.read_revisions_bulk = original
+
+    # One row per batch — the budget is below a single row, and the primitive
+    # guarantees at least one so it still makes progress.
+    assert len(sizes) == 4
+
+
+def test_a_row_bigger_than_the_whole_budget_is_still_patched():
+    rm, ids = _seeded(1)
+    rm.update(ids[0], Doc(name="big", collection_id="c1", body="x" * 10_000))
+
+    result = rm.patch_many(
+        _in("c1"), MergePatch({"visibility": "public"}), max_bytes=10
+    )
+
+    assert result.patched == 1
+    assert rm.get(ids[0]).data.visibility == "public"
+
+
+# ---------------------------------------------------------------------------
+# The selection is the query's, limit and all
+# ---------------------------------------------------------------------------
+
+
+def test_a_query_limit_bounds_the_fan_out_and_the_report_says_so():
+    """`patch_many` patches what the query selects — including its `limit`.
+
+    That matters because the default limit is configurable process-wide, so a
+    deployment could cap it without this call site knowing. The cap must not
+    be *silent*: `total` reports how many rows were actually selected, so a
+    caller that expected more can tell the difference between "nothing to do"
+    and "I was truncated".
+    """
+    rm, ids = _seeded(5)
+    query = (QB["collection_id"] == "c1").build()
+    query.limit = 2
+
+    result = rm.patch_many(query, MergePatch({"visibility": "public"}))
+
+    assert result.patched == 2
+    assert result.total == 2
+    assert sum(rm.get(rid).data.visibility == "public" for rid in ids) == 2
+
+
+def test_total_accounts_for_every_selected_row():
+    rm, ids, checker, _ = _with_checker(denied_index=0, n=3)
+
+    result = rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}))
+
+    assert result.total == 3
+    assert result.patched == 2 and len(result.failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+def test_patch_many_records_the_acting_user_as_the_updater():
+    rm, ids = _seeded(2)
+
+    rm.patch_many(_in("c1"), MergePatch({"visibility": "public"}), user="fanout-bot")
+
+    meta = rm.get_meta(ids[0])
+    assert meta.updated_by == "fanout-bot"
+    assert meta.created_by == "owner"  # the row keeps its own creator

--- a/tests/test_per_model_default_user_http.py
+++ b/tests/test_per_model_default_user_http.py
@@ -58,7 +58,8 @@ def test_add_model_default_now_overrides_configure_default_now():
     per_model = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
     sp = SpecStar()
     sp.configure(
-        default_user="t", default_now=lambda: dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+        default_user="t",
+        default_now=lambda: dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
     )
     sp.add_model(Schema(Item, "v1"), default_now=lambda: per_model)
     mgr = sp.get_resource_manager(Item)

--- a/tests/test_pg_pool_meta_store.py
+++ b/tests/test_pg_pool_meta_store.py
@@ -166,9 +166,7 @@ class TestGetConnConnectionLeak:
 
         store = _make_store_with_mock_pool(pool_mock)
 
-        with patch(
-            "specstar.resource_manager.meta_store.postgres.time.sleep"
-        ):
+        with patch("specstar.resource_manager.meta_store.postgres.time.sleep"):
             conn = store.get_conn()
 
         assert conn is good_conn
@@ -183,8 +181,6 @@ class TestGetConnConnectionLeak:
 
         store = _make_store_with_mock_pool(pool_mock)
 
-        with patch(
-            "specstar.resource_manager.meta_store.postgres.time.sleep"
-        ):
+        with patch("specstar.resource_manager.meta_store.postgres.time.sleep"):
             with pytest.raises((psycopg2.pool.PoolError, ConnectionError)):
                 store.get_conn()

--- a/tests/test_postgres_bulk_read.py
+++ b/tests/test_postgres_bulk_read.py
@@ -84,8 +84,8 @@ def _info(resource_id: str) -> RevisionInfo:
     )
 
 
-def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
-    keys: list[tuple[str, str, None]] = []
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, str | None]]:
+    keys: list[tuple[str, str, str | None]] = []
     for rid, size in sizes.items():
         info = _info(rid)
         store.save(info, io.BytesIO(b"x" * size))

--- a/tests/test_postgres_bulk_read.py
+++ b/tests/test_postgres_bulk_read.py
@@ -1,0 +1,146 @@
+"""PostgreSQL bulk read under a memory budget (issue #434).
+
+Needs a live Postgres at ``SPECSTAR_TEST_PG_DSN`` (defaults to the repo's
+local DSN); auto-marked ``integration`` by ``tests/conftest.py``.
+
+The point of the Postgres override is that ``octet_length`` reports payload
+size **without transferring the payload**, so the batch can be packed to the
+budget exactly. The generic fallback cannot do that — it only learns a size
+after reading the row, so it always overshoots by one. The packing tests
+below therefore double as proof the override is actually being used.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import os
+import uuid
+
+import pytest
+
+try:
+    import psycopg2
+
+    from specstar.resource_manager.basic import Encoding
+    from specstar.resource_manager.resource_store.postgres import (
+        PostgresResourceStore,
+    )
+except ImportError:  # pragma: no cover
+    pytest.skip("psycopg2 not installed", allow_module_level=True)
+
+from specstar.types import RevisionInfo, RevisionStatus
+
+PG_DSN = os.environ.get(
+    "SPECSTAR_TEST_PG_DSN",
+    "postgresql://admin:password@localhost:5432/your_database",
+)
+
+_NOW = dt.datetime(2026, 7, 20, tzinfo=dt.timezone.utc)
+
+
+def _pg_reachable() -> bool:
+    try:
+        conn = psycopg2.connect(PG_DSN, connect_timeout=3)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pg_reachable(), reason="no live Postgres at SPECSTAR_TEST_PG_DSN"
+)
+
+
+@pytest.fixture
+def store():
+    prefix = f"t{uuid.uuid4().hex[:12]}_"
+    st = PostgresResourceStore(
+        pg_dsn=PG_DSN, encoding=Encoding.json, table_prefix=prefix
+    )
+    yield st
+    conn = psycopg2.connect(PG_DSN)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{prefix}resource_index"')
+            cur.execute(f'DROP TABLE IF EXISTS "{prefix}resource_data"')
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _info(resource_id: str) -> RevisionInfo:
+    return RevisionInfo(
+        uid=uuid.uuid4(),
+        resource_id=resource_id,
+        revision_id="r1",
+        schema_version=None,
+        status=RevisionStatus.stable,
+        created_time=_NOW,
+        updated_time=_NOW,
+        created_by="tester",
+        updated_by="tester",
+    )
+
+
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
+    keys: list[tuple[str, str, None]] = []
+    for rid, size in sizes.items():
+        info = _info(rid)
+        store.save(info, io.BytesIO(b"x" * size))
+        keys.append((rid, info.revision_id, info.schema_version))
+    return keys
+
+
+def test_octet_length_sizes_the_batch_without_reading_it(store):
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    assert store.payload_sizes(keys) == [10, 20, 30]
+
+
+def test_read_many_packs_the_budget_exactly(store):
+    """40 bytes fits a(10)+b(20); c(30) would overflow, so it is left behind.
+
+    The generic fallback would have consumed all three — it can only notice
+    the overflow after fetching c. Exact packing here means Postgres sized
+    the batch up front.
+    """
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=40)
+
+    assert consumed == 2
+    assert data == {"a": b"x" * 10, "b": b"x" * 20}
+
+
+def test_read_many_returns_the_whole_batch_when_the_budget_is_ample(store):
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3
+    assert data == {"a": b"x" * 10, "b": b"x" * 20, "c": b"x" * 30}
+
+
+def test_read_many_always_makes_progress(store):
+    keys = _seed(store, {"huge": 5_000})
+
+    data, consumed = store.read_many(keys, max_bytes=1)
+
+    assert consumed == 1
+    assert data == {"huge": b"x" * 5_000}
+
+
+def test_read_many_omits_rows_that_are_not_there(store):
+    keys = _seed(store, {"a": 10, "c": 30})
+    keys.insert(1, ("ghost", "r1", None))  # never saved
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3
+    assert set(data) == {"a", "c"}
+
+
+def test_read_many_with_no_items_touches_the_database_not_at_all(store):
+    assert store.read_many([], max_bytes=1_000) == ({}, 0)

--- a/tests/test_postgres_bulk_read.py
+++ b/tests/test_postgres_bulk_read.py
@@ -144,3 +144,60 @@ def test_read_many_omits_rows_that_are_not_there(store):
 
 def test_read_many_with_no_items_touches_the_database_not_at_all(store):
     assert store.read_many([], max_bytes=1_000) == ({}, 0)
+
+
+# ---------------------------------------------------------------------------
+# Meta store bulk read — one ANY(...) instead of N queries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def meta_store():
+    from specstar.resource_manager.meta_store.postgres import PostgresMetaStore
+
+    table = f"t{uuid.uuid4().hex[:12]}_resource_meta"
+    st = PostgresMetaStore(pg_dsn=PG_DSN, table_name=table)
+    yield st
+    conn = psycopg2.connect(PG_DSN)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f'DROP TABLE IF EXISTS "{table}"')
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _meta(resource_id: str):
+    from specstar.types import ResourceMeta
+
+    return ResourceMeta(
+        resource_id=resource_id,
+        current_revision_id="r1",
+        total_revision_count=1,
+        created_time=_NOW,
+        updated_time=_NOW,
+        created_by="tester",
+        updated_by="tester",
+        is_deleted=False,
+        schema_version=None,
+    )
+
+
+def test_meta_get_many_reads_the_whole_set(meta_store):
+    for rid in ("a", "b", "c"):
+        meta_store[rid] = _meta(rid)
+
+    found = meta_store.get_many(["a", "b", "c"])
+
+    assert set(found) == {"a", "b", "c"}
+    assert found["b"].resource_id == "b"
+
+
+def test_meta_get_many_omits_unknown_ids(meta_store):
+    meta_store["a"] = _meta("a")
+
+    assert set(meta_store.get_many(["a", "ghost"])) == {"a"}
+
+
+def test_meta_get_many_with_no_ids_issues_no_query(meta_store):
+    assert meta_store.get_many([]) == {}

--- a/tests/test_postgres_pgvector.py
+++ b/tests/test_postgres_pgvector.py
@@ -54,7 +54,9 @@ def _make_meta(rid: str, *, vector: list[float], doctype: str = "abc") -> Resour
 
 
 # PV1: capability flag is True when pgvector extension is available
-def test_pv_capability_flag_true_when_pgvector_present(store: PostgresMetaStore) -> None:
+def test_pv_capability_flag_true_when_pgvector_present(
+    store: PostgresMetaStore,
+) -> None:
     assert store.supports_native_vector_search is True
 
 

--- a/tests/test_postgres_shared_pool.py
+++ b/tests/test_postgres_shared_pool.py
@@ -51,8 +51,7 @@ pytestmark = pytest.mark.skipif(
 def _count_pool_connections(monitor) -> int:
     with monitor.cursor() as cur:
         cur.execute(
-            "SELECT count(*) FROM pg_stat_activity "
-            "WHERE application_name = %s",
+            "SELECT count(*) FROM pg_stat_activity WHERE application_name = %s",
             (_APP_NAME,),
         )
         return cur.fetchone()[0]

--- a/tests/test_qb_vector.py
+++ b/tests/test_qb_vector.py
@@ -34,7 +34,9 @@ def test_qb_cosine_returns_expr_with_distance() -> None:
 # QB3: lte / gt / gte all produce VectorDistanceCondition with right operator
 def test_qb_comparison_operators_cover_all_four() -> None:
     q = [0.1, 0.2, 0.3]
-    assert _vc(QB["e"].cosine(q) <= 0.5).operator == DataSearchOperator.less_than_or_equal
+    assert (
+        _vc(QB["e"].cosine(q) <= 0.5).operator == DataSearchOperator.less_than_or_equal
+    )
     assert _vc(QB["e"].cosine(q) > 0.5).operator == DataSearchOperator.greater_than
     assert (
         _vc(QB["e"].cosine(q) >= 0.5).operator

--- a/tests/test_s3_bulk_read.py
+++ b/tests/test_s3_bulk_read.py
@@ -1,0 +1,141 @@
+"""S3 bulk read under a memory budget (issue #434).
+
+Needs a live S3 / MinIO at ``SPECSTAR_TEST_S3_ENDPOINT`` (defaults to the
+repo's local MinIO); auto-marked ``integration`` by ``tests/conftest.py``.
+
+Reaching a payload on S3 takes two calls — GET the uid index, then GET the
+object — so ``S3ResourceStore`` overrides ``read_many`` wholesale and fans
+every stage out over a thread pool. ``head_object`` gives the size without
+the body, which is what lets the budget be packed exactly; the generic
+fallback would overshoot by one row. The packing tests below therefore
+double as proof the override is the code path being taken.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import os
+import uuid
+
+import pytest
+
+try:
+    import boto3  # noqa: F401
+
+    from specstar.resource_manager.resource_store.s3 import S3ResourceStore
+except ImportError:  # pragma: no cover
+    pytest.skip("boto3 not installed", allow_module_level=True)
+
+from specstar.types import RevisionInfo, RevisionStatus
+
+S3_ENDPOINT = os.environ.get("SPECSTAR_TEST_S3_ENDPOINT", "http://localhost:9000")
+
+_NOW = dt.datetime(2026, 7, 20, tzinfo=dt.timezone.utc)
+
+
+def _s3_reachable() -> bool:
+    try:
+        S3ResourceStore(endpoint_url=S3_ENDPOINT, bucket="specstar-434-probe")
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _s3_reachable(), reason="no live S3/MinIO at SPECSTAR_TEST_S3_ENDPOINT"
+)
+
+
+@pytest.fixture
+def store():
+    return S3ResourceStore(
+        endpoint_url=S3_ENDPOINT,
+        bucket="specstar-434-test",
+        prefix=f"{uuid.uuid4().hex[:12]}/",
+    )
+
+
+def _info(resource_id: str) -> RevisionInfo:
+    return RevisionInfo(
+        uid=uuid.uuid4(),
+        resource_id=resource_id,
+        revision_id="r1",
+        schema_version=None,
+        status=RevisionStatus.stable,
+        created_time=_NOW,
+        updated_time=_NOW,
+        created_by="tester",
+        updated_by="tester",
+    )
+
+
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
+    keys: list[tuple[str, str, None]] = []
+    for rid, size in sizes.items():
+        info = _info(rid)
+        store.save(info, io.BytesIO(b"x" * size))
+        keys.append((rid, info.revision_id, info.schema_version))
+    return keys
+
+
+def test_read_many_packs_the_budget_exactly(store):
+    """40 bytes fits a(10)+b(20); c(30) overflows and is left for next round.
+
+    The generic fallback would have consumed all three — it only notices the
+    overflow after fetching c. Exact packing means ``head_object`` sized the
+    batch before any body was transferred.
+    """
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=40)
+
+    assert consumed == 2
+    assert data == {"a": b"x" * 10, "b": b"x" * 20}
+
+
+def test_read_many_returns_the_whole_batch_when_the_budget_is_ample(store):
+    keys = _seed(store, {"a": 10, "b": 20, "c": 30})
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3
+    assert data == {"a": b"x" * 10, "b": b"x" * 20, "c": b"x" * 30}
+
+
+def test_read_many_always_makes_progress(store):
+    keys = _seed(store, {"huge": 5_000})
+
+    data, consumed = store.read_many(keys, max_bytes=1)
+
+    assert consumed == 1
+    assert data == {"huge": b"x" * 5_000}
+
+
+def test_read_many_omits_rows_that_are_not_there(store):
+    keys = _seed(store, {"a": 10, "c": 30})
+    keys.insert(1, ("ghost", "r1", None))  # never saved
+
+    data, consumed = store.read_many(keys, max_bytes=10_000)
+
+    assert consumed == 3
+    assert set(data) == {"a", "c"}
+
+
+def test_read_many_preserves_order_when_draining_batch_by_batch(store):
+    """Draining a prefix at a time must eventually cover every row."""
+    keys = _seed(store, {"a": 30, "b": 30, "c": 30})
+
+    seen: dict[str, bytes] = {}
+    pending = list(keys)
+    while pending:
+        data, consumed = store.read_many(pending, max_bytes=40)
+        assert consumed == 1  # 40 bytes fits exactly one 30-byte row
+        seen.update(data)
+        pending = pending[consumed:]
+
+    assert seen.keys() == {"a", "b", "c"}
+
+
+def test_read_many_with_no_items_makes_no_calls(store):
+    assert store.read_many([], max_bytes=1_000) == ({}, 0)

--- a/tests/test_s3_bulk_read.py
+++ b/tests/test_s3_bulk_read.py
@@ -70,8 +70,8 @@ def _info(resource_id: str) -> RevisionInfo:
     )
 
 
-def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, None]]:
-    keys: list[tuple[str, str, None]] = []
+def _seed(store, sizes: dict[str, int]) -> list[tuple[str, str, str | None]]:
+    keys: list[tuple[str, str, str | None]] = []
     for rid, size in sizes.items():
         info = _info(rid)
         store.save(info, io.BytesIO(b"x" * size))

--- a/tests/test_startup_warnings.py
+++ b/tests/test_startup_warnings.py
@@ -37,7 +37,9 @@ def test_warns_when_no_query_limit_configured(monkeypatch):
 
 def test_warns_when_validate_refs_off(monkeypatch):
     monkeypatch.setenv("SPECSTAR_DEFAULT_QUERY_LIMIT", "1000")  # silence
-    sp = SpecStar(forbid_unknown_fields=True, default_get_returns="only-data")  # silence
+    sp = SpecStar(
+        forbid_unknown_fields=True, default_get_returns="only-data"
+    )  # silence
     sp.add_model(Schema(Item, "v1"))
     with pytest.warns(SpecStarWarning, match="validate_refs"):
         sp.apply(FastAPI())

--- a/tests/test_str_query_vector.py
+++ b/tests/test_str_query_vector.py
@@ -56,9 +56,7 @@ def test_q_str_condition_resolved_via_encoder() -> None:
         ],
     )
     metas = mgr.search_resources(q)
-    titles = sorted(
-        mgr.get(m.resource_id).data.title for m in metas
-    )
+    titles = sorted(mgr.get(m.resource_id).data.title for m in metas)
     assert "aligned" in titles
     assert "close" in titles
     assert "opposed" not in titles

--- a/tests/test_validate_refs.py
+++ b/tests/test_validate_refs.py
@@ -71,9 +71,7 @@ def test_validate_refs_on_update_too():
         "resource_id"
     ]
     # Update with bad ref
-    bad = c.put(
-        f"/monster/{mid}", json={"name": "Bear", "zone_id": "zone:nope"}
-    )
+    bad = c.put(f"/monster/{mid}", json={"name": "Bear", "zone_id": "zone:nope"})
     assert bad.status_code == 422
     # Update with good ref
     ok = c.put(f"/monster/{mid}", json={"name": "Bear2", "zone_id": zid})

--- a/tests/test_vector_integration.py
+++ b/tests/test_vector_integration.py
@@ -246,7 +246,9 @@ def test_int_pg_e2e_embedding_with_str_query() -> None:
 
     try:
         mgr.create(Doc(title="hello-row", summary=Embedding(content="hello world")))
-        mgr.create(Doc(title="orthogonal-row", summary=Embedding(content="orthogonal text")))
+        mgr.create(
+            Doc(title="orthogonal-row", summary=Embedding(content="orthogonal text"))
+        )
 
         # Query via str, runs through encoder, dispatched to pgvector SQL
         q = (QB["summary"].cosine("near_query") < 0.3).build()


### PR DESCRIPTION
Closes #434.

## What the issue asked for vs what this does

The issue proposed `rm.update_many([(resource_id, data), ...])` on the grounds that the bulk write primitives already exist and only need wiring out. Two things came out of grilling that:

**1. `update_many` puts the work on the wrong side.** To change three mirrored fields, the caller has to read every row out, edit it, and write the whole body back — which is exactly what `push_mirror_to_docs` does today. And while the *read* belongs to the caller, nobody is in a position to batch it. `patch_many(query, patch)` moves the read inside, which is the only place batching is possible.

**2. "the primitives already exist" was only half true.** The write side (`save_metas_bulk` / `save_revisions_bulk`) did exist. The read side did not: `dump_all_revisions` is an *export* primitive (every revision of every resource, and unimplemented on Postgres), and there was no bulk meta read at all. Since reads were 2 of the 4 round-trips per row, half the win needed new plumbing.

## Round-trips, honestly

Per row today: 2 payload reads (`list_resources` decodes it, then `update` re-reads it for the embedding cache), 1 meta read, 2 writes.

After: one meta search, then per batch — one bulk meta read, one bulk payload read, two bulk writes.

The saving scales with **row count**, not payload size: the per-row decode → patch → encode is untouched and is proportional to total bytes. So for `SourceDoc`, which carries its whole extracted text, this helps but will not amaze; for the small-blob, many-row derived tables the issue was really aimed at, round-trips are the whole cost and this is the win. That matches the issue's own assessment — no attempt made to talk it up.

## Semantics: N patches, bulk I/O — not a second set of rules

- **Events, and so permission checks, fire per row.** Write ACLs are per-row policies. This is also why `patch_many` is *not* wrapped in `execute_with_events`: that arms the permission re-entrancy guard (#402) and turns every row's check into a no-op — a bulk path straight past the gate. The gate sequence is now extracted as `_authorize_and_announce` and shared with the decorator, so there is one implementation rather than a copy that can drift open.
- **Order is authorize-all → write the batch → announce success only for rows that landed.** Announcing first would tell handlers a row was committed that might not be.
- **A row whose revision moved since selection is a conflict, not a clobber.** A patch rewrites the whole body, so writing anyway discards a concurrent edit entirely, not just the mirrored fields. Same guarantee `expected_revision_id` gives and no stronger — compare and write are not atomic, so the window narrows rather than closes.
- **No-op patches create no revision**, so callers need not pre-filter and re-runs are cheap.
- **Failures are collected, not raised** — one unwritable row must not strand a collection.

## Memory

Bounded in **bytes, not rows** (default 256 MiB), because row size varies by orders of magnitude between models. At least one row is always consumed so an oversized row still makes progress.

Sizing is **derived, never stored**: Postgres `octet_length`, S3 `head_object`, `stat` on disk, `len` in memory. A `size` field on `RevisionInfo` would need a backfill and read as `UNSET` for every pre-existing revision — a budget that silently mis-packs the oldest data. Backends with no cheap probe fall back to measuring as they read, overshooting by at most one row.

`PatchManyResult` returns counts plus only the ids that went wrong, so the report does not scale with the fan-out. `total` makes a query `limit` (process-configurable via `SPECSTAR_DEFAULT_QUERY_LIMIT`) visible instead of silently truncating.

## Verification

- New tests: bulk read primitive, Postgres, S3, meta store, `patch_many`.
- **Postgres and S3 paths were run against a live Postgres 16 and a live MinIO**, not just written. The exact-packing assertions double as proof the native override is the path taken — the generic fallback cannot pack exactly.
- Full unit suite green after the `_authorize_and_announce` extraction (pure refactor); affected-area tests green after each later phase.
- `ruff` and whole-project `ty` are byte-identical to the master baseline.

## Deliberately not in scope

- **No HTTP route.** The shape is "one query selects unbounded rows, all mutated". Behind a Python API the query is code; as an endpoint it is external input deciding how many thousand rows one request rewrites — and with no atomicity there is nothing to roll back. Rate limits, dry-run, preview and audit would all need designing first.
- **No ai-workspace change.** specstar has to ship first so the consumer has a version to pin. `push_mirror_to_docs` can then drop its hand-written "already at target, skip" loop, which `patch_many` now guarantees.
- **Revision churn is untouched** — the second-order problem noted at the end of the issue. Batching cannot fix it; a mirror fan-out still creates one revision per changed row. Worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJmp2BYqLTw2dttZjeWvPP