### PR TITLE
feat(make): release alpha|beta|rc|final, and repair the broken bumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ help:
 	@echo "  clean        清理所有暫存和構建文件 (clean-dev + clean-docs)"
 	@echo "  clean-dev    清理開發暫存檔案"
 	@echo ""
+	@echo "釋出："
+	@echo "  changelog-preview  預覽尚未釋出的變更紀錄"
+	@echo "  release <step>     bump 版本 + 生成 CHANGELOG + commit"
+	@echo "                     step = alpha|beta|rc|final|patch|minor|major"
+	@echo "                     或 make release VERSION=X.Y.Z"
+	@echo "  release-publish    打 tag + build + 上傳 PyPI（不可逆）"
+	@echo ""
 	@echo "文檔工具："
 	@echo "  docs         構建 MkDocs HTML 文檔"
 	@echo "  serve        啟動本地文檔服務器（http://127.0.0.1:8000）"
@@ -158,30 +165,65 @@ changelog-preview:
 	uv run git-cliff --unreleased
 
 # 釋出第一步:bump 版本 → 生成 CHANGELOG 區段 → commit "bump vX.Y.Z"。
-# 用法:  make release patch        # 0.11.1 → 0.11.2
+# 用法:  make release alpha        # 0.13.0a1 → 0.13.0a2(0.12.3 → 0.13.0a1)
+#        make release beta         # 0.13.0a2 → 0.13.0b1
+#        make release rc           # 0.13.0b1 → 0.13.0rc1
+#        make release final        # 0.13.0rc1 → 0.13.0(結束預覽期)
+#        make release patch        # 0.11.1 → 0.11.2
 #        make release minor        # 0.11.1 → 0.12.0
 #        make release major        # 0.11.1 → 1.0.0
 #        make release VERSION=1.2.3 # 指定明確版本
-# 版本由 git-cliff 依語意化規則算出;之後接原本流程(打 tag → build → PyPI)。
-.PHONY: release patch minor major
-# patch/minor/major 是 release 的參數,被當成 no-op goal 消化掉
-patch minor major:
+#
+# 版本由 scripts/next_version.py 依 PEP 440 算出,**不是** git-cliff。
+# git-cliff 把 tag 當 SemVer 解析,而我們發的是 PEP 440(0.13.0a1,而非
+# 0.13.0-alpha.1),所以 v0.13.0a1 一被打上去,--bumped-version 就整個報
+# Semver error —— patch/minor/major 也一起靜默壞掉。版號算術因此留在
+# repo 內(有測試:tests/test_next_version.py),git-cliff 只負責它擅長的
+# 事:把 commit 變成 CHANGELOG 文字。
+#
+# 之後接原本流程(打 tag → build → PyPI)。
+.PHONY: release alpha beta rc final patch minor major
+# 這些是 release 的參數,被當成 no-op goal 消化掉
+alpha beta rc final patch minor major:
 	@:
 release:
 	@git diff --quiet && git diff --cached --quiet || { \
 		echo "工作區不乾淨,請先 commit 或 stash 再 release"; exit 1; }; \
-	bump="$(filter patch minor major,$(MAKECMDGOALS))"; \
+	step="$(filter alpha beta rc final patch minor major,$(MAKECMDGOALS))"; \
 	if [ -n "$(VERSION)" ]; then new="$(VERSION)"; \
-	elif [ -n "$$bump" ]; then \
-		new="$$(uv run git-cliff --bumped-version --bump $$bump 2>/dev/null | tail -1 | sed 's/^v//')"; \
-	else echo "用法: make release patch|minor|major  或  make release VERSION=X.Y.Z"; exit 1; fi; \
+	elif [ -n "$$step" ]; then \
+		cur="$$(sed -n 's/^__version__ = "\(.*\)"/\1/p' specstar/__init__.py)"; \
+		new="$$(uv run python scripts/next_version.py "$$cur" "$$step")" || exit 1; \
+	else echo "用法: make release alpha|beta|rc|final|patch|minor|major  或  make release VERSION=X.Y.Z"; exit 1; fi; \
 	[ -n "$$new" ] || { echo "無法決定版本"; exit 1; }; \
+	git rev-parse -q --verify "refs/tags/v$$new" >/dev/null && { \
+		echo "tag v$$new 已存在 —— 該版可能已發佈,PyPI 不接受重傳"; exit 1; }; \
 	echo "release → v$$new"; \
 	sed -i "s/^__version__ = .*/__version__ = \"$$new\"/" specstar/__init__.py; \
-	uv run git-cliff --unreleased --tag "v$$new" --prepend CHANGELOG.md; \
+	uv run git-cliff --unreleased --tag "v$$new" --prepend CHANGELOG.md || { \
+		echo "git-cliff 失敗 —— 已回復 __version__。不留下「版號有動、CHANGELOG 沒動」的半套 bump"; \
+		git checkout -- specstar/__init__.py; exit 1; }; \
 	git add specstar/__init__.py CHANGELOG.md; \
 	git commit -m "bump v$$new"; \
-	echo "✅ 已 commit \"bump v$$new\"。接著:git tag v$$new → build → 發佈。"
+	echo "✅ 已 commit \"bump v$$new\"。接著:make release-publish"
+
+# 釋出第二步:打 tag → build → 上傳 PyPI。
+# 從 specstar/__init__.py 讀版號,所以一定跟上一步 commit 的內容一致。
+# tag 是 lightweight(與既有 v0.12.x 慣例一致),必須明確 push。
+.PHONY: release-publish
+release-publish:
+	@git diff --quiet && git diff --cached --quiet || { \
+		echo "工作區不乾淨,請先 commit 再發佈"; exit 1; }; \
+	v="$$(sed -n 's/^__version__ = "\(.*\)"/\1/p' specstar/__init__.py)"; \
+	[ -n "$$v" ] || { echo "讀不到 __version__"; exit 1; }; \
+	echo "publish → v$$v"; \
+	rm -rf dist; \
+	uv build || exit 1; \
+	uv run twine check dist/* || exit 1; \
+	git rev-parse -q --verify "refs/tags/v$$v" >/dev/null || git tag "v$$v"; \
+	git push origin "v$$v"; \
+	uv run twine upload dist/*; \
+	echo "✅ v$$v 已發佈"
 
 # 清理所有暫存和構建文件
 .PHONY: clean

--- a/scripts/next_version.py
+++ b/scripts/next_version.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Compute the next release version. Used by `make release`.
+
+SpecStar ships **PEP 440** versions (`0.13.0a1`), not the SemVer spelling
+(`0.13.0-alpha.1`). git-cliff parses tags as SemVer, so as soon as a
+pre-release tag exists its `--bumped-version` fails outright::
+
+    $ git-cliff --bumped-version --bump patch
+    ERROR Semver error: `unexpected character 'v' while parsing major version`
+
+which quietly took `make release patch|minor|major` with it. Rather than
+bend the published version scheme to suit the changelog generator, the
+arithmetic lives here and git-cliff is left to do what it is good at:
+turning commits into changelog prose.
+
+Usage::
+
+    python scripts/next_version.py <current> <step>
+
+where *step* is ``alpha``, ``beta``, ``rc``, ``final``, ``patch``, ``minor``
+or ``major``. Prints the next version to stdout.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+#: PEP 440 subset SpecStar actually uses: X.Y.Z with an optional aN / bN / rcN.
+_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?$")
+
+#: Pre-release stages in release order. PEP 440 sorts a < b < rc < final, and
+#: the index is what makes "is this step going backwards?" answerable.
+_STAGES = {"alpha": "a", "beta": "b", "rc": "rc"}
+_ORDER = ["a", "b", "rc"]
+
+
+def _parse(version: str) -> tuple[int, int, int, str | None, int]:
+    m = _VERSION.match(version.strip())
+    if not m:
+        raise ValueError(
+            f"cannot parse {version!r} — expected PEP 440 X.Y.Z, X.Y.ZaN, "
+            f"X.Y.ZbN or X.Y.ZrcN"
+        )
+    major, minor, patch, stage, num = m.groups()
+    return int(major), int(minor), int(patch), stage, int(num or 0)
+
+
+def bump(current: str, step: str) -> str:
+    """Return the version that follows *current* for *step*."""
+    major, minor, patch, stage, num = _parse(current)
+
+    if step in _STAGES:
+        target = _STAGES[step]
+        if stage is None:
+            # A pre-release previews the *next feature release*. Hanging it off
+            # a patch version would promise a bugfix and deliver a feature.
+            return f"{major}.{minor + 1}.0{target}1"
+        if _ORDER.index(target) < _ORDER.index(stage):
+            raise ValueError(
+                f"{current} → {step} goes backwards: PEP 440 orders "
+                f"a < b < rc, so the new version would sort *older* than the "
+                f"one already published"
+            )
+        if target == stage:
+            return f"{major}.{minor}.{patch}{stage}{num + 1}"
+        # New stage, fresh counter — the stage itself carries the ordering.
+        return f"{major}.{minor}.{patch}{target}1"
+
+    if step == "final":
+        if stage is None:
+            raise ValueError(f"{current} is already final")
+        return f"{major}.{minor}.{patch}"
+
+    if step == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    if step == "minor":
+        return f"{major}.{minor + 1}.0"
+    if step == "major":
+        return f"{major + 1}.0.0"
+
+    raise ValueError(
+        f"unknown step {step!r} — expected alpha, beta, rc, final, patch, "
+        f"minor or major"
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    try:
+        print(bump(argv[1], argv[2]))
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/tests/test_next_version.py
+++ b/tests/test_next_version.py
@@ -1,0 +1,166 @@
+"""Version arithmetic for `make release` (PEP 440, not SemVer).
+
+SpecStar ships PEP 440 versions — `0.13.0a1`, not the SemVer spelling
+`0.13.0-alpha.1`. git-cliff parses tags as SemVer, so the moment a
+pre-release tag exists it can no longer compute the next version:
+
+    $ git-cliff --bumped-version --bump patch
+    ERROR Semver error: `unexpected character 'v' while parsing major version`
+
+That took `make release patch|minor|major` down with it, silently, and left
+`make release VERSION=...` as the only working path. So the arithmetic lives
+here instead, and git-cliff is used only for what it is good at — turning
+commits into changelog prose.
+
+These rules only ever run at release time, where a mistake means a wrong
+version on PyPI that cannot be taken back.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_MODULE = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "next_version.py"
+_spec = importlib.util.spec_from_file_location("next_version", _MODULE)
+assert _spec and _spec.loader
+next_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(next_version)
+
+bump = next_version.bump
+
+
+# ---------------------------------------------------------------------------
+# Pre-release steps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [
+        ("0.13.0a1", "0.13.0a2"),
+        ("0.13.0a2", "0.13.0a3"),
+        ("0.13.0a9", "0.13.0a10"),
+        ("1.0.0a1", "1.0.0a2"),
+    ],
+)
+def test_alpha_advances_the_alpha_counter(current, expected):
+    assert bump(current, "alpha") == expected
+
+
+def test_alpha_from_a_final_release_opens_the_next_minor():
+    """0.12.3 is shipped, so the next alpha belongs to 0.13.0 — not 0.12.4.
+
+    An alpha is a preview of the *next* feature release; attaching it to a
+    patch version would promise a bugfix and deliver a feature.
+    """
+    assert bump("0.12.3", "alpha") == "0.13.0a1"
+    assert bump("1.4.7", "alpha") == "1.5.0a1"
+
+
+def test_beta_and_rc_follow_the_same_shape():
+    assert bump("0.13.0b1", "beta") == "0.13.0b2"
+    assert bump("0.13.0rc1", "rc") == "0.13.0rc2"
+
+
+def test_moving_up_a_stage_restarts_the_counter():
+    """a2 → b1, not b3: the counter belongs to the stage, and PEP 440 orders
+    a < b < rc so the version still moves forward."""
+    assert bump("0.13.0a2", "beta") == "0.13.0b1"
+    assert bump("0.13.0b4", "rc") == "0.13.0rc1"
+    assert bump("0.13.0a7", "rc") == "0.13.0rc1"
+
+
+def test_moving_down_a_stage_is_refused():
+    """rc1 → alpha would sort *backwards*; PyPI would keep serving the rc as
+    the newer release and the mistake would be invisible."""
+    with pytest.raises(ValueError, match="backwards"):
+        bump("0.13.0rc1", "alpha")
+    with pytest.raises(ValueError, match="backwards"):
+        bump("0.13.0b2", "alpha")
+
+
+# ---------------------------------------------------------------------------
+# Leaving pre-release
+# ---------------------------------------------------------------------------
+
+
+def test_final_drops_the_pre_release_suffix():
+    """The common exit from an alpha series: 0.13.0a3 ships as 0.13.0."""
+    assert bump("0.13.0a3", "final") == "0.13.0"
+    assert bump("0.13.0rc1", "final") == "0.13.0"
+
+
+def test_final_on_an_already_final_version_is_refused():
+    with pytest.raises(ValueError, match="already final"):
+        bump("0.13.0", "final")
+
+
+# ---------------------------------------------------------------------------
+# Ordinary bumps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "part", "expected"),
+    [
+        ("0.12.3", "patch", "0.12.4"),
+        ("0.12.3", "minor", "0.13.0"),
+        ("0.12.3", "major", "1.0.0"),
+        ("1.4.7", "major", "2.0.0"),
+    ],
+)
+def test_regular_bumps_from_a_final_release(current, part, expected):
+    assert bump(current, part) == expected
+
+
+def test_regular_bumps_from_a_pre_release_work_off_the_base_version():
+    """These are what git-cliff could no longer compute once a1 was tagged.
+
+    From 0.13.0a2 the base is 0.13.0, so minor gives 0.14.0. To *ship* 0.13.0
+    itself use `final` — that is the case this deliberately does not guess at.
+    """
+    assert bump("0.13.0a2", "patch") == "0.13.1"
+    assert bump("0.13.0a2", "minor") == "0.14.0"
+    assert bump("0.13.0a2", "major") == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_step_is_refused():
+    with pytest.raises(ValueError, match="unknown"):
+        bump("0.13.0", "sideways")
+
+
+@pytest.mark.parametrize("bad", ["", "1.2", "v1.2.3", "1.2.3.4", "not-a-version"])
+def test_an_unparseable_current_version_is_refused(bad):
+    with pytest.raises(ValueError, match="cannot parse"):
+        bump(bad, "alpha")
+
+
+def test_every_result_is_a_version_the_next_bump_can_read():
+    """A release tool must not paint itself into a corner: whatever it emits
+    has to be valid input for the following release."""
+    version = "0.12.3"
+    steps = ("alpha", "alpha", "beta", "rc", "final", "patch", "minor", "major")
+    seen = [version]
+    for step in steps:
+        version = bump(version, step)
+        seen.append(version)
+
+    assert seen == [
+        "0.12.3",
+        "0.13.0a1",
+        "0.13.0a2",
+        "0.13.0b1",
+        "0.13.0rc1",
+        "0.13.0",
+        "0.13.1",
+        "0.14.0",
+        "1.0.0",
+    ]


### PR DESCRIPTION
## The bug this started from

`make release patch|minor|major` has been dead since `v0.13.0a1` was tagged:

```
$ uv run git-cliff --bumped-version --bump patch
ERROR Semver error: `unexpected character 'v' while parsing major version number`
```

git-cliff parses tags as **SemVer**, but SpecStar publishes **PEP 440** versions — `0.13.0a1`, not `0.13.0-alpha.1`. The first pre-release tag broke every automatic bump, silently, leaving `make release VERSION=...` as the only working path. That is also why there was no way to cut an alpha at all.

## The fix

Rather than bend the published version scheme to suit the changelog generator, the version arithmetic moves into `scripts/next_version.py`. git-cliff keeps doing what it is good at — turning commits into changelog prose.

It is tested (`tests/test_next_version.py`, 22 cases) because it only ever runs at release time, where a wrong answer becomes a version on PyPI that cannot be withdrawn.

| step | 0.12.3 → | 0.13.0a2 → |
|---|---|---|
| `alpha` | 0.13.0a1 | 0.13.0a3 |
| `beta` | 0.13.0b1 | 0.13.0b1 |
| `rc` | 0.13.0rc1 | 0.13.0rc1 |
| `final` | *(refused — already final)* | 0.13.0 |
| `patch` / `minor` / `major` | 0.12.4 / 0.13.0 / 1.0.0 | 0.13.1 / 0.14.0 / 1.0.0 |

An alpha cut from a final release opens the **next minor** (0.12.3 → 0.13.0a1), because a pre-release previews a feature release; hanging it off a patch version would promise a bugfix and deliver a feature.

## Refusals

- **A step that would sort backwards** (`rc1 → alpha`) — PyPI would keep serving the rc as newer and the mistake would be invisible.
- **A version whose tag already exists** — PyPI does not accept a re-upload, so catching it before the bump is the only place it is cheap.
- **git-cliff failing** — previously the recipe chained on `;`, so a changelog failure still produced a commit that bumped the version and left CHANGELOG untouched. Found while testing this PR; it now restores `__version__` and aborts.

## `make release-publish`

The second half was only ever a comment ("接著:git tag → build → 發佈"). Now it is a target: tag → `uv build` → `twine check` → push tag → `twine upload`. It reads the version from `__init__.py`, so it cannot drift from what the bump commit recorded, and the tag stays lightweight to match the existing `v0.12.x` convention.

## Verified

Both paths run for real against this repo: the happy path produced a correct `bump v0.13.0a3` commit with a generated CHANGELOG section (then reset), and the git-cliff-failure path rolled `__version__` back and left a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJmp2BYqLTw2dttZjeWvPP