### PR TITLE
fix: keep union-backed schema names under PyYAML's 1024-character key limit

### DIFF
--- a/docs/en/contributing/docs.md
+++ b/docs/en/contributing/docs.md
@@ -32,7 +32,7 @@ Use Google-style docstrings with these sections when they apply:
 Do not list generated endpoints in docstrings. Put route behavior under `docs/howto/routes.md` and related guide pages.
 
 ## AI skill set for contributors
-If you want to create or maintain AI skills for this project, see [docs/en/contributing/ai-skills.md](docs/en/contributing/ai-skills.md). That page explains how to author skills under [skills/](skills/) and how they relate to [.github/skills/](.github/skills/) for repo-local use.
+If you want to create or maintain AI skills for this project, see [AI skills](ai-skills.md). That page explains how to author skills under `skills/` in the repository root.
 
 ## Verification before submitting
 Before merging doc changes, build the site locally:

--- a/docs/en/howto/troubleshooting.md
+++ b/docs/en/howto/troubleshooting.md
@@ -179,6 +179,43 @@ See also:
 
 ---
 
+## 9. Client generation fails on a union-backed model
+
+### Symptoms
+
+- `datamodel-codegen` aborts with `yaml.parser.ParserError: while parsing a flow mapping`, `did not find expected ',' or '}'`
+- the same document succeeds when the file is named `spec.json` and fails when it is named `spec.yaml`
+- SpecStar refuses `add_model` with *"Refusing to derive a resource name that is N characters long"*
+
+### What is happening
+
+PyYAML refuses a mapping key longer than 1024 characters. Both an OpenAPI
+component name and a URL path are mapping keys, so once either crosses that
+line the document stops parsing — and `datamodel-code-generator` only bypasses
+PyYAML for inputs whose file name ends in `.json`.
+
+Unions are what push a name over the line. A union's resource name is every
+member name joined with `Or`, and `msgspec` names a generic parameterised by a
+union using *module-qualified* member names — `Wrap[A]` is `Wrap_A_`, but
+`Wrap[A | B]` is `Wrap___main__.A_____main__.B_`. Both grow with the number of
+members, and the second also grows with the length of their module path.
+
+### What to check
+
+- give a union-backed model an explicit name, which keeps the URL path short:
+
+```python
+spec.add_model(MyUnion, name="my-resource")
+```
+
+- component names are shortened automatically once they would break the
+  document, so no action is needed there
+- watch the URL path length independently of code generation: a path that grows
+  with union size will eventually exceed the request-line limit of whatever
+  proxy sits in front of the app, and the endpoint becomes unreachable
+
+---
+
 ## General debugging advice
 
 When diagnosing SpecStar issues, start by narrowing the problem to one layer:

--- a/specstar/crud/core.py
+++ b/specstar/crud/core.py
@@ -116,12 +116,58 @@ from specstar.types import (
 from specstar.util.naming import NameConverter
 from specstar.util.type_utils import (
     get_type_name,
+    get_union_args,
     is_generic_subclass,
+    is_union_type,
     unwrap_annotated,
 )
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+
+
+def _derived_name_too_long_message(model: Any, derived: str) -> str:
+    """Explain the refusal and hand the caller the exact line to write.
+
+    The derived name itself is quoted only as a short prefix: pasting 1500
+    characters into a traceback buries the one instruction that matters.
+    """
+    if is_union_type(model):
+        members = [a for a in get_union_args(model) if a is not type(None)]
+        cause = (
+            f"A union's name is every member name joined with 'Or', so with "
+            f"{len(members)} members it grows past what a URL can carry."
+        )
+    else:
+        cause = f"The name is derived from {model!r}."
+
+    return (
+        f"Refusing to derive a resource name that is {len(derived)} characters "
+        f"long (limit {_MAX_DERIVED_RESOURCE_NAME}).\n"
+        f"\n"
+        f"{cause}\n"
+        f"The derived name becomes the URL path, and an OpenAPI path over 1024 "
+        f"characters cannot be parsed by PyYAML -- which is how "
+        f"datamodel-code-generator and most OpenAPI tooling read the document.\n"
+        f"\n"
+        f"Name the model explicitly instead:\n"
+        f"\n"
+        f'    spec.add_model(YourModel, name="your-resource-name")\n'
+        f"\n"
+        f"Derived name started: {derived[:80]}..."
+    )
+
+
+# A derived resource name becomes the first segment of every URL path for that
+# model, and a path is a mapping key in the OpenAPI document -- which PyYAML
+# refuses past 1024 characters.  The longest route suffix today is
+# "/{resource_id}/switch/{revision_id}" (35 characters); the rest of the budget
+# is headroom for custom actions with longer suffixes.
+#
+# Only auto-derived names are checked.  Truncating one would silently rewrite a
+# live URL, so an over-long name is refused and the caller is told to name the
+# model themselves.
+_MAX_DERIVED_RESOURCE_NAME = 900
 
 
 def _flatten_event_handlers(handlers):
@@ -923,7 +969,10 @@ class SpecStar:
             )
 
         # 使用 NameConverter 進行轉換
-        return NameConverter(original_name).to(self.model_naming)
+        name = NameConverter(original_name).to(self.model_naming)
+        if len(name) > _MAX_DERIVED_RESOURCE_NAME:
+            raise ValueError(_derived_name_too_long_message(model, name))
+        return name
 
     def add_route_template(self, template: IRouteTemplate) -> None:
         """Add a custom route template to extend the API with additional endpoints.

--- a/specstar/crud/route_templates/responses.py
+++ b/specstar/crud/route_templates/responses.py
@@ -8,6 +8,7 @@ into something safe to embed in an OpenAPI document.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Generic, TypeVar
 
 import msgspec
@@ -35,20 +36,55 @@ class MsgspecResponse(Response):
         return msgspec.json.encode(content)
 
 
+# PyYAML refuses a "simple key" longer than 1024 characters, and an OpenAPI
+# component name is exactly that — a mapping key.  Cross the line and the whole
+# document stops parsing for every consumer that routes through PyYAML, which
+# includes ``datamodel-code-generator`` for any input whose file name does not
+# end in ``.json``.  Budget below the cliff rather than on it.
+_MAX_SCHEMA_NAME_LENGTH = 960
+
+# A name that has to be replaced should come back readable, not merely legal —
+# it becomes a class name in every generated client.
+_SHORTENED_NAME_HEAD = 96
+
+
+def _shorten_schema_name(name: str) -> str:
+    """Return a short, deterministic stand-in for an over-long component name.
+
+    The digest is taken over the *whole* original name so two names sharing a
+    prefix stay distinct where plain truncation would merge them, and so the
+    result is stable across runs — a regenerated client must not churn just
+    because it was generated twice.
+    """
+    digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+    return f"{name[:_SHORTENED_NAME_HEAD].rstrip('_')}_{digest}"
+
+
 def _sanitize_schema_names(
     schemas: list[dict], components: dict[str, dict]
 ) -> tuple[list[dict], dict[str, dict]]:
-    """Replace dots in OpenAPI component schema names and update all ``$ref`` pointers.
+    """Normalise OpenAPI component schema names and update all ``$ref`` pointers.
 
-    ``msgspec`` may produce schema names containing dots when a generic type
-    parameter is a union (e.g. ``FullResourceResponse[A | B]``) because it
-    falls back to module-qualified names like ``mymod.A``.  Dots in component
-    names are problematic for code generators, so we replace them with ``_``.
+    Two problems, both created by ``msgspec`` naming a generic whose parameter
+    is a union (e.g. ``FullResourceResponse[A | B]``): it falls back to
+    module-qualified member names like ``mymod.A``, so the name both contains
+    dots *and* grows with the number of members times the length of their
+    module path.
+
+    * Dots are replaced with ``_`` — code generators choke on them.
+    * Names past :data:`_MAX_SCHEMA_NAME_LENGTH` are replaced with a short
+      deterministic name, because past 1024 characters PyYAML cannot read the
+      document at all.
+
+    Names already within budget are left exactly as they are: renaming one
+    would break the generated client code that imports it by name.
     """
     rename_map: dict[str, str] = {}
     for name in list(components):
-        if "." in name:
-            new_name = name.replace(".", "_")
+        new_name = name.replace(".", "_")
+        if len(new_name) > _MAX_SCHEMA_NAME_LENGTH:
+            new_name = _shorten_schema_name(new_name)
+        if new_name != name:
             while new_name in components and new_name not in rename_map.values():
                 new_name += "_"
             rename_map[name] = new_name

--- a/specstar/resource_manager/embedding_processor.py
+++ b/specstar/resource_manager/embedding_processor.py
@@ -19,7 +19,7 @@ from specstar.resource_manager.encoder_registry import (
     EncoderRegistry,
     lookup_encoder,
 )
-from specstar.types import Embedding, extract_vector_field_infos
+from specstar.types import extract_vector_field_infos
 
 
 def _content_hash(content: str) -> str:

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -7,7 +7,6 @@ import io
 import sys
 from typing import Annotated
 
-import pytest
 from msgspec import UNSET, Struct
 
 from specstar import Embedding, SpecStar, Vector

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -9,7 +9,7 @@ import datetime as dt
 from typing import Annotated
 
 import pytest
-from msgspec import UNSET, Struct
+from msgspec import Struct
 
 from specstar import Embedding, SpecStar, ValidationError, Vector
 from specstar.query import QB

--- a/tests/test_qb_vector.py
+++ b/tests/test_qb_vector.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from specstar.query import QB, Query
 from specstar.query_types import (
     DataSearchOperator,

--- a/tests/test_schema_name_length.py
+++ b/tests/test_schema_name_length.py
@@ -1,0 +1,208 @@
+"""Tests for OpenAPI schema name length limits.
+
+PyYAML refuses a "simple key" longer than 1024 characters.  An OpenAPI
+component name and a URL path are both mapping keys, so once either crosses
+that line the whole document becomes unparseable for every consumer that
+routes through PyYAML — which includes ``datamodel-code-generator`` for any
+input whose file name does not end in ``.json``.
+
+``msgspec`` walks straight into this: a generic parameterised by a *union*
+falls back to module-qualified member names (``Wrap[A]`` → ``Wrap_A_`` but
+``Wrap[A | B]`` → ``Wrap___main__.A_____main__.B_``), so the name grows with
+the number of union members *times* the length of their module path.
+
+Covers:
+- ``_sanitize_schema_names`` shortens over-budget component names and rewrites
+  every ``$ref`` and ``discriminator.mapping`` that pointed at them.
+- Shortening is deterministic, so a regenerated client does not churn.
+- Names within budget are left exactly as they are.
+- End-to-end: a union-backed model produces no mapping key over the limit.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import msgspec
+import pytest
+from fastapi import FastAPI
+
+from specstar.crud.core import SpecStar
+from specstar.crud.route_templates.responses import (
+    _MAX_SCHEMA_NAME_LENGTH,
+    _sanitize_schema_names,
+)
+
+# PyYAML's hard limit on a simple key.
+PYYAML_SIMPLE_KEY_LIMIT = 1024
+
+
+def _long_name(prefix: str = "Wrap", length: int = 1500) -> str:
+    """A component name that is over budget but contains no dots."""
+    return prefix + "X" * (length - len(prefix))
+
+
+class TestComponentNameBudget:
+    def test_budget_is_below_the_pyyaml_limit(self):
+        """The budget must leave room, not sit exactly on the cliff."""
+        assert _MAX_SCHEMA_NAME_LENGTH < PYYAML_SIMPLE_KEY_LIMIT
+
+    def test_over_budget_name_is_shortened(self):
+        name = _long_name()
+        _, components = _sanitize_schema_names([], {name: {"type": "object"}})
+        assert name not in components
+        (new_name,) = components
+        assert len(new_name) <= _MAX_SCHEMA_NAME_LENGTH
+
+    def test_shortened_name_is_much_shorter_than_the_budget(self):
+        """A name that had to be replaced should come back readable, not merely legal."""
+        _, components = _sanitize_schema_names([], {_long_name(): {"type": "object"}})
+        (new_name,) = components
+        assert len(new_name) <= 128
+
+    def test_shortened_name_keeps_a_recognisable_prefix(self):
+        _, components = _sanitize_schema_names(
+            [], {_long_name(prefix="FullResourceResponse"): {"type": "object"}}
+        )
+        (new_name,) = components
+        assert new_name.startswith("FullResourceResponse")
+
+    def test_shortening_is_deterministic(self):
+        name = _long_name()
+        first = _sanitize_schema_names([], {name: {"type": "object"}})[1]
+        second = _sanitize_schema_names([], {name: {"type": "object"}})[1]
+        assert list(first) == list(second)
+
+    def test_two_different_long_names_do_not_collide(self):
+        """Same prefix, different tails — truncation alone would merge them."""
+        a = "Wrap" + "A" * 1500
+        b = "Wrap" + "A" * 1499 + "B"
+        _, components = _sanitize_schema_names(
+            [], {a: {"type": "object"}, b: {"type": "object"}}
+        )
+        assert len(components) == 2
+
+    def test_name_within_budget_is_untouched(self):
+        """Renaming a working name would break the client code that imports it."""
+        name = "Wrap" + "X" * 100
+        _, components = _sanitize_schema_names([], {name: {"type": "object"}})
+        assert list(components) == [name]
+
+    def test_refs_to_a_shortened_name_are_rewritten(self):
+        name = _long_name()
+        schemas, components = _sanitize_schema_names(
+            [{"$ref": f"#/components/schemas/{name}"}],
+            {name: {"type": "object"}},
+        )
+        (new_name,) = components
+        assert schemas[0]["$ref"] == f"#/components/schemas/{new_name}"
+
+    def test_nested_refs_are_rewritten(self):
+        name = _long_name()
+        schemas, components = _sanitize_schema_names(
+            [
+                {
+                    "properties": {
+                        "item": {"items": {"$ref": f"#/components/schemas/{name}"}}
+                    }
+                }
+            ],
+            {name: {"type": "object"}},
+        )
+        (new_name,) = components
+        ref = schemas[0]["properties"]["item"]["items"]["$ref"]
+        assert ref == f"#/components/schemas/{new_name}"
+
+    def test_discriminator_mapping_is_rewritten(self):
+        name = _long_name()
+        schemas, components = _sanitize_schema_names(
+            [
+                {
+                    "discriminator": {
+                        "propertyName": "t",
+                        "mapping": {"a": f"#/components/schemas/{name}"},
+                    }
+                }
+            ],
+            {name: {"type": "object"}},
+        )
+        (new_name,) = components
+        assert (
+            schemas[0]["discriminator"]["mapping"]["a"]
+            == f"#/components/schemas/{new_name}"
+        )
+
+    def test_dotted_and_over_budget_name_gets_both_treatments(self):
+        """The module-qualified msgspec name is the case that actually happens."""
+        name = "Wrap_" + "_".join(f"__main__.Member{i:03d}Payload" for i in range(60))
+        assert len(name) > _MAX_SCHEMA_NAME_LENGTH
+        _, components = _sanitize_schema_names([], {name: {"type": "object"}})
+        (new_name,) = components
+        assert "." not in new_name
+        assert len(new_name) <= _MAX_SCHEMA_NAME_LENGTH
+
+
+class TestUnionModelEndToEnd:
+    """A union-backed model must produce a document PyYAML can actually read."""
+
+    @staticmethod
+    def _union_of(n: int):
+        members = [
+            msgspec.defstruct(
+                f"CreateNewCharacter{i:02d}JobPayload",
+                [("kind", str, msgspec.field(default=f"k{i}")), ("value", int, 0)],
+                tag=True,
+            )
+            for i in range(n)
+        ]
+        union = members[0]
+        for m in members[1:]:
+            union = union | m
+        return union
+
+    @pytest.fixture
+    def schema(self):
+        spec = SpecStar(default_user="tester", default_now=dt.datetime.now)
+        spec.add_model(self._union_of(40), name="animal")
+        app = FastAPI()
+        spec.apply(app)
+        spec.openapi(app)
+        return app.openapi()
+
+    def test_no_component_name_over_the_pyyaml_limit(self, schema):
+        components = schema["components"]["schemas"]
+        over = [k for k in components if len(k) > PYYAML_SIMPLE_KEY_LIMIT]
+        assert over == []
+
+    def test_no_path_over_the_pyyaml_limit(self, schema):
+        over = [p for p in schema["paths"] if len(p) > PYYAML_SIMPLE_KEY_LIMIT]
+        assert over == []
+
+    def test_every_ref_still_resolves(self, schema):
+        components = schema["components"]["schemas"]
+        prefix = "#/components/schemas/"
+        missing: list[str] = []
+
+        def walk(obj):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if k == "$ref" and isinstance(v, str) and v.startswith(prefix):
+                        target = v[len(prefix) :]
+                        if target not in components:
+                            missing.append(target)
+                    else:
+                        walk(v)
+            elif isinstance(obj, list):
+                for item in obj:
+                    walk(item)
+
+        walk(schema)
+        assert missing == []
+
+    def test_document_parses_as_yaml(self, schema):
+        """The regression that started this: PyYAML must be able to read it."""
+        import json
+
+        import yaml
+
+        yaml.safe_load(json.dumps(schema))

--- a/tests/test_schema_name_length.py
+++ b/tests/test_schema_name_length.py
@@ -28,6 +28,7 @@ import pytest
 from fastapi import FastAPI
 
 from specstar.crud.core import SpecStar
+from specstar.crud.core import _MAX_DERIVED_RESOURCE_NAME
 from specstar.crud.route_templates.responses import (
     _MAX_SCHEMA_NAME_LENGTH,
     _sanitize_schema_names,
@@ -206,3 +207,63 @@ class TestUnionModelEndToEnd:
         import yaml
 
         yaml.safe_load(json.dumps(schema))
+
+
+class TestDerivedResourceNameTooLong:
+    """A union's auto-derived name becomes the URL path, so it has a ceiling.
+
+    Shortening it silently would rewrite a live URL, so this is refused up
+    front instead — and the refusal has to say exactly what to change.
+    """
+
+    @staticmethod
+    def _spec() -> SpecStar:
+        return SpecStar(default_user="tester", default_now=dt.datetime.now)
+
+    def test_registering_an_oversized_union_is_refused(self):
+        union = TestUnionModelEndToEnd._union_of(40)
+        with pytest.raises(ValueError):
+            self._spec().add_model(union)
+
+    def test_an_explicit_name_is_accepted(self):
+        """The fix the message tells you to apply has to actually work."""
+        union = TestUnionModelEndToEnd._union_of(40)
+        self._spec().add_model(union, name="animal")
+
+    def test_a_small_union_still_derives_its_name(self):
+        """Only names that would break the document are refused."""
+        spec = self._spec()
+        spec.add_model(TestUnionModelEndToEnd._union_of(2))
+        assert spec.resource_managers
+
+    # --- the message itself -------------------------------------------------
+
+    @pytest.fixture
+    def message(self) -> str:
+        union = TestUnionModelEndToEnd._union_of(40)
+        with pytest.raises(ValueError) as excinfo:
+            self._spec().add_model(union)
+        return str(excinfo.value)
+
+    def test_message_shows_the_exact_call_to_write(self, message):
+        assert "spec.add_model(" in message
+        assert 'name="' in message
+
+    def test_message_reports_the_measured_length_and_the_limit(self, message):
+        assert str(_MAX_DERIVED_RESOURCE_NAME) in message
+        assert "1516" in message  # the derived kebab name for 40 members
+
+    def test_message_names_the_union_as_the_cause(self, message):
+        assert "union" in message.lower()
+        assert "40" in message  # the member count
+
+    def test_message_explains_why_the_limit_exists(self, message):
+        assert "1024" in message
+        assert "yaml" in message.lower()
+
+    def test_message_quotes_the_start_of_the_derived_name(self, message):
+        assert "create-new-character00-job-payload" in message
+
+    def test_message_does_not_dump_the_whole_derived_name(self, message):
+        """A 1516-character name in a traceback buries the instruction."""
+        assert len(message) < 1000

--- a/tests/test_schema_name_length.py
+++ b/tests/test_schema_name_length.py
@@ -27,8 +27,7 @@ import msgspec
 import pytest
 from fastapi import FastAPI
 
-from specstar.crud.core import SpecStar
-from specstar.crud.core import _MAX_DERIVED_RESOURCE_NAME
+from specstar.crud.core import _MAX_DERIVED_RESOURCE_NAME, SpecStar
 from specstar.crud.route_templates.responses import (
     _MAX_SCHEMA_NAME_LENGTH,
     _sanitize_schema_names,

--- a/tests/test_schema_name_length.py
+++ b/tests/test_schema_name_length.py
@@ -32,6 +32,7 @@ from specstar.crud.route_templates.responses import (
     _MAX_SCHEMA_NAME_LENGTH,
     _sanitize_schema_names,
 )
+from specstar.schema import Schema
 
 # PyYAML's hard limit on a simple key.
 PYYAML_SIMPLE_KEY_LIMIT = 1024
@@ -228,6 +229,16 @@ class TestDerivedResourceNameTooLong:
         """The fix the message tells you to apply has to actually work."""
         union = TestUnionModelEndToEnd._union_of(40)
         self._spec().add_model(union, name="animal")
+
+    def test_a_schema_wrapped_union_is_refused_too(self):
+        """add_model(X) and add_model(Schema(X)) derive the same name."""
+        union = TestUnionModelEndToEnd._union_of(40)
+        with pytest.raises(ValueError):
+            self._spec().add_model(Schema(union, "v1"))
+
+    def test_an_explicit_name_is_accepted_for_a_schema_too(self):
+        union = TestUnionModelEndToEnd._union_of(40)
+        self._spec().add_model(Schema(union, "v1"), name="animal")
 
     def test_a_small_union_still_derives_its_name(self):
         """Only names that would break the document are refused."""

--- a/tests/test_vector_integration.py
+++ b/tests/test_vector_integration.py
@@ -205,8 +205,9 @@ def test_int_add_model_creates_pgvector_column() -> None:
 
 # INT6: e2e on pg — create rows with Embedding, query with QB cosine via str
 def test_int_pg_e2e_embedding_with_str_query() -> None:
-    import psycopg2
     import uuid as _uuid
+
+    import psycopg2
 
     from specstar import BackendBinding, BackendConfig
     from specstar.query import QB


### PR DESCRIPTION
## The bug

`datamodel-codegen` aborts on a union-backed model:

```
yaml.parser.ParserError: while parsing a flow mapping
did not find expected ',' or '}'
  in "spec.yaml", line 1, column 1606
```

**PyYAML refuses a mapping key longer than 1024 characters.** Verified directly: a 1020-character key loads, 1030 fails, on both `CSafeLoader` (libyaml) and the pure-Python `SafeLoader` — this is not a missing-libyaml issue.

An OpenAPI component name and a URL path are both mapping keys, and two independent things push them over the line:

| | produced by | at 40 union members |
|---|---|---|
| **URL path** | `get_type_name` joins union member names with `"Or"` → resource name | 1552 chars |
| **component name** | msgspec names a generic parameterised by a *union* using module-qualified members | 1699 chars |

The msgspec half is the surprising one — the fallback only kicks in for unions:

```
Wrap[Alpha]        → 'Wrap_Alpha_'
Wrap[Alpha|Beta]   → 'Wrap___main__.Alpha_____main__.Beta_'
```

so the name grows with member count **times module path length**. The same 40-member union yields 1683 characters under `__main__` and 3323 under a 49-character module path — which is why this bites on a smaller union than a toy reproduction suggests.

### Why it looked intermittent

`datamodel-code-generator` only bypasses PyYAML for inputs whose file name ends in `.json` (`load_data_from_path`). **The same bytes succeed as `spec.json` and fail as `spec.yaml`.** `--url` also takes the JSON-first path, so `specstar config` happens to be safe today — which is why the failure looks like it depends on the consumer rather than the document.

## The fix

Both halves had to be addressed — fixing only the component name still left 19 path keys over 1024.

**Component names** (`_sanitize_schema_names`): names past 960 characters are replaced by their first 96 characters plus a digest of the whole original. That function already rewrote every `$ref` and `discriminator.mapping` to strip dots from these exact names, so the budget goes in beside it rather than as a new pass. The digest covers the full name, so two names sharing a prefix stay distinct and the result is stable — a regenerated client must not churn just because it ran twice. Names already within budget are left untouched; renaming one would break the client code that imports it.

**Resource names** (`add_model`): refused rather than truncated. The derived name is a live URL, and rewriting it silently breaks callers. The message hands over the exact line to write:

```
Refusing to derive a resource name that is 1516 characters long (limit 900).

A union's name is every member name joined with 'Or', so with 40 members it
grows past what a URL can carry.
The derived name becomes the URL path, and an OpenAPI path over 1024
characters cannot be parsed by PyYAML -- which is how datamodel-code-generator
and most OpenAPI tooling read the document.

Name the model explicitly instead:

    spec.add_model(YourModel, name="your-resource-name")

Derived name started: create-new-character00-job-payload-or-create-new-...
```

Only *derived* names are checked, and only past 900 characters — the longest route suffix today is 35 characters, so nothing that works now is refused. The name is quoted as a prefix because pasting 1500 characters into a traceback buries the one instruction that matters.

## Verification

End-to-end with the real tool, through the YAML path that used to fail:

| | before | after |
|---|---|---|
| longest path | 1552 | 43 |
| longest component name | 1699 | 105 |
| document size | 443 KB | 182 KB |
| `datamodel-codegen` (`.yaml` input) | ParserError | exit 0 |
| longest generated class | 1380 | 90 |
| generated model imports | — | OK |

- full unit suite: **3501 passed, 4 skipped** (integration deselected)
- 26 new tests, mutation-checked (disabling the shortening turns 5 red)
- `ruff check` / `ruff format --check` clean
- `ty`: 363 diagnostics vs **364 on master** — one fewer, none added
- `mkdocs build --strict`: warnings 2 → 1 (the remaining one is the pre-existing `mkdocs-static-i18n` / `navigation.instant` theme conflict)

## Also in here

Boy Scout cleanup, each verified before removal and each touched file re-run: four unused imports, one un-sorted import block, and a self-referential docs link that made `mkdocs --strict` warn.

Not addressed: the URL path grows ~38 characters per union member independently of code generation, so a large union will eventually exceed the request-line limit of whatever proxy fronts the app. The refusal now catches that before it ships, but there is no runtime guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeh7XrFrVmA8JXQdHL6iN6