### PR TITLE
perf(postgres): stop paying for round-trips a read cannot use, and six N+1s

### DIFF
--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -1594,6 +1594,30 @@ class IResourceStore(ABC):
         with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
             return info, fh.read()
 
+    def get_all_revision_infos(
+        self,
+        resource_id: str,
+    ) -> "dict[str, RevisionInfo]":
+        """Every stored revision's info for one resource, keyed by revision id.
+
+        Pruning has to see all of them to decide what to keep, and did so one
+        revision at a time — a schema-version lookup and an info read each. The
+        default here IS that loop, so a store without a bulk read is unchanged.
+
+        Only `info` is needed: the payload is what pruning is about to delete.
+        """
+        out: dict[str, RevisionInfo] = {}
+        for revision_id in self.list_revisions(resource_id):
+            for schema_version in self.list_schema_versions(resource_id, revision_id):
+                try:
+                    out[revision_id] = self.get_revision_info(
+                        resource_id, revision_id, schema_version
+                    )
+                except (KeyError, FileNotFoundError):
+                    continue
+                break
+        return out
+
     def get_revision_bundles(
         self,
         keys: "Sequence[tuple[str, str, str | None]]",

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -1575,7 +1575,6 @@ class IResourceStore(ABC):
         remain valid until closed or the method is called again.
         """
 
-    @abstractmethod
     def get_revision_bundle(
         self,
         resource_id: str,
@@ -1595,6 +1594,29 @@ class IResourceStore(ABC):
         with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
             return info, fh.read()
 
+    def get_revision_bundles(
+        self,
+        keys: "Sequence[tuple[str, str, str | None]]",
+    ) -> "dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]]":
+        """Many revisions' info+data at once, keyed by ``(resource_id,
+        revision_id, schema_version)``.
+
+        A listing needs every row on the page, and fetching them one at a time
+        makes the page cost proportional to its size. Concrete for the same
+        reason as `get_revision_bundle`: this default IS the loop it replaces, so
+        a store without a bulk read keeps working unchanged. Missing keys are
+        simply absent from the result — the caller decides whether that is an
+        error, exactly as it does today.
+        """
+        out: dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]] = {}
+        for key in keys:
+            try:
+                out[key] = self.get_revision_bundle(*key)
+            except KeyError:
+                continue
+        return out
+
+    @abstractmethod
     def get_revision_info(
         self,
         resource_id: str,

--- a/specstar/resource_manager/basic.py
+++ b/specstar/resource_manager/basic.py
@@ -1576,6 +1576,25 @@ class IResourceStore(ABC):
         """
 
     @abstractmethod
+    def get_revision_bundle(
+        self,
+        resource_id: str,
+        revision_id: str,
+        schema_version: str | None,
+    ) -> "tuple[RevisionInfo, bytes]":
+        """A revision's info AND its data.
+
+        Reading a resource needs both, and every caller asked for them
+        separately — two store round-trips for one row. Concrete because the
+        answer is derivable: this default is exactly the two calls it replaces,
+        so a store gains nothing and loses nothing by ignoring it. A backend that
+        can return both in one round-trip should override (the SQL stores select
+        two columns of the same joined row).
+        """
+        info = self.get_revision_info(resource_id, revision_id, schema_version)
+        with self.get_data_bytes(resource_id, revision_id, schema_version) as fh:
+            return info, fh.read()
+
     def get_revision_info(
         self,
         resource_id: str,

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -435,6 +435,18 @@ class SimpleStorage(IStorage):
     def dump_resource(
         self, resource_id: str
     ) -> Generator[tuple[RevisionInfo, IO[bytes]]]:
+        # One read for the whole resource where the store offers it. Walking
+        # revisions and schema versions to fetch each info and payload
+        # separately made a single-resource dump cost statements proportional to
+        # its history — six per revision, measured. A store without a bulk read
+        # returns None and the per-revision walk below still serves it.
+        bulk = self._resource_store.dump_all_revisions(
+            resource_ids=frozenset({resource_id})
+        )
+        if bulk is not None:
+            for info, raw in bulk.get(resource_id, []):
+                yield info, io.BytesIO(raw)
+            return
         for revision_id in self._resource_store.list_revisions(resource_id):
             for schema_version in self._resource_store.list_schema_versions(
                 resource_id, revision_id

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -374,6 +374,10 @@ class SimpleStorage(IStorage):
         """A page's worth at once — see `IResourceStore.get_revision_bundles`."""
         return self._resource_store.get_revision_bundles(keys)
 
+    def get_all_revision_infos(self, resource_id: str) -> "dict[str, RevisionInfo]":
+        """Every revision's info — see `IResourceStore.get_all_revision_infos`."""
+        return self._resource_store.get_all_revision_infos(resource_id)
+
     def save_revision(self, info: RevisionInfo, data: IO[bytes]) -> None:
         self._resource_store.save(info, data)
 
@@ -4301,17 +4305,10 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         # Gather revision info for every revision that has retrievable data.
         # created_time / parent_revision_id are identical across a revision's
         # schema versions, so any stored version's info will do.
-        infos: dict[str, RevisionInfo] = {}
-        for rid in self.storage.list_revisions(resource_id):
-            sv = self.storage.find_revision_schema_version(resource_id, rid)
-            if sv is UNSET:
-                continue
-            try:
-                infos[rid] = self.storage.get_resource_revision_info(
-                    resource_id, rid, sv
-                )
-            except (KeyError, FileNotFoundError):
-                continue
+        # One read for all of them: resolving the schema version and reading the
+        # info per revision made pruning cost statements proportional to the
+        # revision count — the thing being pruned.
+        infos: dict[str, RevisionInfo] = self.storage.get_all_revision_infos(resource_id)
         if len(infos) <= 1:
             return []
 

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -364,6 +364,13 @@ class SimpleStorage(IStorage):
             resource_id, revision_id, schema_version
         )
 
+    def get_revision_bundles(
+        self,
+        keys: "Sequence[tuple[str, str, str | None]]",
+    ) -> "dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]]":
+        """A page's worth at once — see `IResourceStore.get_revision_bundles`."""
+        return self._resource_store.get_revision_bundles(keys)
+
     def save_revision(self, info: RevisionInfo, data: IO[bytes]) -> None:
         self._resource_store.save(info, data)
 
@@ -2597,6 +2604,22 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         # 3. Classify partial fields
         spec = classify_partial_fields(partial, default_category="data")
 
+        # 3b. Fetch the whole page's rows in one go. Per-item reads made a
+        # listing cost grow with its length — the same query repeated once per
+        # row, each on its own pooled connection. Only the full-data path
+        # qualifies: a partial read projects columns per item, and a listing
+        # that wants no data has nothing to prefetch. Backends without a bulk
+        # read fall back to the same per-row loop inside `get_revision_bundles`,
+        # so this is a speed-up where it exists and a no-op where it does not.
+        prefetched: dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]] = {}
+        if "data" in returns and not spec.data_fields:
+            prefetched = self.storage.get_revision_bundles(
+                [
+                    (m.resource_id, m.current_revision_id, m.schema_version)
+                    for m in metas
+                ]
+            )
+
         # 4. Define per-item fetch function
         def _fetch_one(meta: ResourceMeta) -> SearchedResource[T] | None:
             try:
@@ -2614,10 +2637,21 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                     else:
                         # low-level read (no policy) — list applies the
                         # on_decode_error policy itself in the except below.
-                        resource = self.get_resource_revision(
-                            meta.resource_id,
-                            meta.current_revision_id,
-                            schema_version=meta.schema_version,
+                        pre = prefetched.get(
+                            (
+                                meta.resource_id,
+                                meta.current_revision_id,
+                                meta.schema_version,
+                            )
+                        )
+                        resource = (
+                            self._resource_from_bundle(*pre)
+                            if pre is not None
+                            else self.get_resource_revision(
+                                meta.resource_id,
+                                meta.current_revision_id,
+                                schema_version=meta.schema_version,
+                            )
                         )
                         data = resource.data
                         if "info" in returns:
@@ -3503,6 +3537,17 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         info, raw = self.storage.get_revision_bundle(
             resource_id, revision_id, schema_version
         )
+        return self._resource_from_bundle(info, raw)
+
+    def _resource_from_bundle(self, info: RevisionInfo, raw: bytes) -> Resource[T]:
+        """Turn a fetched row into a `Resource` — decode, lazy migration, and the
+        warning that goes with it.
+
+        Split out so a caller that already holds the row (a listing that fetched
+        its whole page in one query) reuses this instead of restating it beside a
+        loop. It is not a parameter on `get_resource_revision` because that method
+        is wrapped by the event machinery, which validates its keyword arguments.
+        """
         if self._migration is not None and info.schema_version != self._schema_version:
             # Lazy read-time migration: the row is stored at an older version,
             # so apply the registered migration to present it as the current

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -1460,7 +1460,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             if actual_sv is UNSET:
                 raise RevisionIDNotFoundError(resource_id, target_rev)
 
-        info = self.storage.get_resource_revision_info(
+        # Info and payload are two columns of the same joined row, and a
+        # migration that proceeds needs both. Fetching them separately cost an
+        # extra query and an extra connection checkout PER RESOURCE — and a
+        # migration runs once per resource in the store.
+        info, raw = self.storage.get_revision_bundle(
             resource_id, target_rev, schema_version=actual_sv
         )
 
@@ -1469,10 +1473,7 @@ class ResourceManager(IResourceManager[T], Generic[T]):
             return meta
 
         # 執行數據遷移
-        with self.storage.get_data_bytes(
-            resource_id, target_rev, schema_version=actual_sv
-        ) as data_io:
-            migrated_data = self._migration.migrate(data_io, info.schema_version)
+        migrated_data = self._migration.migrate(io.BytesIO(raw), info.schema_version)
 
         # 更新 resource info 的 schema_version
         info.parent_schema_version = info.schema_version

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -284,8 +284,11 @@ class SimpleStorage(IStorage):
         return resource_id in self._meta_store
 
     def revision_exists(self, resource_id: str, revision_id: str) -> bool:
+        # `get_meta` raises for an unknown id, so reaching the next line already
+        # proves the resource exists — the `exists()` that used to guard it asked
+        # the meta store the same question a second time, over its own connection.
         meta = self.get_meta(resource_id)
-        return self.exists(resource_id) and self._resource_store.exists(
+        return self._resource_store.exists(
             resource_id,
             revision_id,
             meta.schema_version,

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -350,6 +350,20 @@ class SimpleStorage(IStorage):
             resource_id, revision_id, schema_version
         )
 
+    def get_revision_bundle(
+        self,
+        resource_id: str,
+        revision_id: str,
+        schema_version: str | None | UnsetType = UNSET,
+    ) -> "tuple[RevisionInfo, bytes]":
+        """Info and data together — see `IResourceStore.get_revision_bundle`."""
+        if schema_version is UNSET:
+            meta = self.get_meta(resource_id)
+            schema_version = meta.schema_version
+        return self._resource_store.get_revision_bundle(
+            resource_id, revision_id, schema_version
+        )
+
     def save_revision(self, info: RevisionInfo, data: IO[bytes]) -> None:
         self._resource_store.save(info, data)
 
@@ -3484,13 +3498,11 @@ class ResourceManager(IResourceManager[T], Generic[T]):
         Returns:
             resource (Resource[T]): The resource object.
         """
-        info = self.storage.get_resource_revision_info(
+        # One store round-trip: `info` and `data` are two columns of the same
+        # joined row, and reading a resource always needs both.
+        info, raw = self.storage.get_revision_bundle(
             resource_id, revision_id, schema_version
         )
-        with self.storage.get_data_bytes(
-            resource_id, revision_id, schema_version
-        ) as data_io:
-            raw = data_io.read()
         if self._migration is not None and info.schema_version != self._schema_version:
             # Lazy read-time migration: the row is stored at an older version,
             # so apply the registered migration to present it as the current

--- a/specstar/resource_manager/core.py
+++ b/specstar/resource_manager/core.py
@@ -3645,9 +3645,14 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 expected_revision_id=expected_revision_id,
                 actual_revision_id=prev_res_meta.current_revision_id,
             )
+        # Pass the schema version we already hold. Omitting it makes the storage
+        # facade re-read this very meta to resolve it — the same
+        # `SELECT ... WHERE resource_id = ...`, plus its own connection checkout,
+        # from a caller standing on the answer.
         prev_info = self.storage.get_resource_revision_info(
             resource_id,
             prev_res_meta.current_revision_id,
+            schema_version=prev_res_meta.schema_version,
         )
         if expected_etag is not UNSET and prev_info.etag != expected_etag:
             from specstar.types import PreconditionFailedError as _PFE
@@ -3657,15 +3662,22 @@ class ResourceManager(IResourceManager[T], Generic[T]):
                 expected_revision_id=expected_etag,
                 actual_revision_id=prev_info.etag,
             )
-        # Pass previous data for Embedding cache reuse (bypass events: raw decode)
+        # Pass previous data for Embedding cache reuse (bypass events: raw decode).
+        # Only worth fetching when something will actually read it: a model with
+        # no Embedding field makes `process_sync` an empty loop, and this read —
+        # plus the decode of the whole previous row — would produce an argument
+        # nobody looks at, on every update.
         prev_data = None
-        try:
-            with self.storage.get_data_bytes(
-                resource_id, prev_res_meta.current_revision_id
-            ) as fh:
-                prev_data = self._data_serializer.decode(fh.read())
-        except Exception:
-            pass
+        if self._embedding_processor.reuses_previous:
+            try:
+                with self.storage.get_data_bytes(
+                    resource_id,
+                    prev_res_meta.current_revision_id,
+                    prev_res_meta.schema_version,
+                ) as fh:
+                    prev_data = self._data_serializer.decode(fh.read())
+            except Exception:
+                pass
         data = self._embedding_processor.process_sync(data, previous=prev_data)
         rev_info = self._rev_info(_BuildRevInfoUpdate(prev_res_meta, data, status))
         if prev_info.data_hash == rev_info.data_hash:

--- a/specstar/resource_manager/embedding_processor.py
+++ b/specstar/resource_manager/embedding_processor.py
@@ -44,6 +44,16 @@ class EmbeddingProcessor:
         self._registry = registry
         self._model_overrides = model_overrides or {}
 
+    @property
+    def reuses_previous(self) -> bool:
+        """Whether `previous=` is ever consulted.
+
+        False when the model declares no embedding field — `process_sync` then
+        loops over an empty list, so a caller that would have to READ the
+        previous revision to supply it can skip that work entirely.
+        """
+        return bool(self._infos)
+
     def process_sync(self, data: Any, *, previous: Any | None = None) -> Any:
         """Synchronous variant — raises if any required encoder is async."""
         for info in self._infos:

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -811,8 +811,13 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                 time.sleep(min(0.5 * (attempt + 1), 3))
                 continue
 
-            conn.autocommit = False
+            # Health-check OUTSIDE a transaction. With autocommit off the
+            # probe's own `SELECT 1` opens one, and psycopg2 then refuses any
+            # later `autocommit` change on this connection — which is what a
+            # read-only caller needs to do to skip BEGIN/COMMIT.
+            conn.autocommit = True
             if self.test_query(conn):
+                conn.autocommit = False  # writers are the default
                 return conn
 
             # test_query 失敗：歸還壞連線並標記關閉，避免洩漏
@@ -853,6 +858,14 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
 
     @contextmanager
     def stream_cursor(self):
+        """A server-side (named) cursor, for reads whose result set is unbounded.
+
+        Naming the cursor is what lets postgres stream instead of materialising
+        the whole answer, and it costs `DECLARE` / `FETCH` / `CLOSE` — three
+        round-trips where an ordinary cursor needs one. Worth it per table scan;
+        pure loss per row. A caller that has already bounded its result (a point
+        read, a COUNT, a fixed set of keys) wants `row_cursor` instead.
+        """
         conn = self.get_conn()
         try:
             # 建立 server-side cursor (named cursor)
@@ -866,6 +879,27 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
             conn.rollback()
             raise
         finally:
+            self.put_conn(conn)
+
+    @contextmanager
+    def row_cursor(self):
+        """An ordinary client-side cursor with dict rows, outside a transaction.
+
+        `stream_cursor` without the `DECLARE`/`FETCH`/`CLOSE` a bounded read
+        cannot use, and without the `BEGIN`/`COMMIT` it has nothing to make
+        atomic either. `get_conn` turns autocommit off because most callers
+        write; a single-statement read turns it back on for its own duration and
+        restores it before the connection returns to the pool, so a writer that
+        checks the same connection out next is unaffected.
+        """
+        conn = self.get_conn()
+        previous = conn.autocommit
+        conn.autocommit = True
+        try:
+            with conn.cursor(cursor_factory=DictCursor) as cur:
+                yield cur
+        finally:
+            conn.autocommit = previous
             self.put_conn(conn)
 
     def _init_postgres_table(self):
@@ -1121,14 +1155,14 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
 
     def values(self):
         """Streaming bulk read — single ``SELECT data`` instead of N+1 queries."""
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(f'SELECT data FROM "{self.table_name}"')
             for row in cur:
                 yield self._serializer.decode(row["data"])
 
     def __getitem__(self, pk: str) -> ResourceMeta:
         # 直接從 PostgreSQL 查詢
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(
                 f'SELECT data FROM "{self.table_name}" WHERE resource_id = %s', (pk,)
             )
@@ -1147,7 +1181,7 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         pk_list = list(pks)
         if not pk_list:
             return {}
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(
                 f'SELECT resource_id, data FROM "{self.table_name}" '
                 f"WHERE resource_id = ANY(%s)",
@@ -1176,14 +1210,14 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
 
     def __iter__(self) -> Generator[str]:
         # 從 PostgreSQL 查询所有 resource_id
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(f'SELECT resource_id FROM "{self.table_name}"')
             for row in cur:
                 yield row["resource_id"]
 
     def __len__(self) -> int:
         # 從 PostgreSQL 计算总数
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(f'SELECT COUNT(*) FROM "{self.table_name}"')
             return cur.fetchone()[0]
 
@@ -1408,7 +1442,7 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         params.append(query.limit)
         params.append(query.offset)
 
-        with self.stream_cursor() as cur:
+        with self.row_cursor() as cur:
             cur.execute(sql, params)
             row = cur.fetchone()
             return int(row["n"])

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -1529,12 +1529,23 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
                 # Postgres: ``LIMIT NULL`` = no limit (offset still applies).
                 sql += " LIMIT %s OFFSET %s"
                 params = [*params, limit, offset]
-        with self.stream_cursor() as cur:
-            cur.execute(sql, params)
+        # Same rule as `iter_search`, for the same reason. A GROUP BY is not
+        # inherently small — grouping by a high-cardinality key returns a row per
+        # group, which can be a row per resource — so what bounds it is the
+        # caller's LIMIT, not the fact that it aggregates.
+        def _rows(cur):
             return [
                 (row[0], {a.result_name: row[i + 1] for i, a in enumerate(aggregates)})
                 for row in cur
             ]
+
+        if limit is not None and limit <= _STREAM_BATCH_ROWS:
+            with self.row_cursor() as cur:
+                cur.execute(sql, params)
+                return _rows(cur.fetchall())
+        with self.stream_cursor() as cur:
+            cur.execute(sql, params)
+            return _rows(cur)
 
     def _agg_expr(self, a: AggSpec) -> str:
         """SQL for one aggregate's value (not the GROUP BY key). A field-less

--- a/specstar/resource_manager/meta_store/postgres.py
+++ b/specstar/resource_manager/meta_store/postgres.py
@@ -174,6 +174,12 @@ except ImportError:  # pragma: no cover
     execute_batch = None  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
 
 
+# psycopg2 fetches a named cursor in batches of this many rows (its `itersize`
+# default). A result that fits in one batch is materialised whole regardless of
+# which cursor asked for it.
+_STREAM_BATCH_ROWS = 2000
+
+
 class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
     """PostgreSQL-backed metadata store.
 
@@ -1416,6 +1422,23 @@ class PostgresMetaStore(IMetaWithAgg, IMetaWithCount, ISlowMetaStore):
         params.append(query.limit)
         params.append(query.offset)
 
+        # A named cursor is what keeps an unbounded search from pulling the whole
+        # table into memory, and psycopg2 drains one in batches of `itersize`. So
+        # a search whose LIMIT is no larger than a single batch would be
+        # materialised in one FETCH either way: the cursor buys nothing there and
+        # costs DECLARE + a trailing empty FETCH + CLOSE, inside a transaction.
+        #
+        # The threshold is the batch size rather than a number picked to look
+        # safe — above it the cursor is load-bearing. Note the DEFAULT limit is a
+        # sentinel (~4.29e9), not a page size, so the default search still
+        # streams.
+        if query.limit is not UNSET and query.limit <= _STREAM_BATCH_ROWS:
+            with self.row_cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+            for row in rows:
+                yield self._serializer.decode(row["data"])
+            return
         with self.stream_cursor() as cur:
             cur.execute(sql, params)
             for row in cur:

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -272,6 +272,33 @@ class PostgresResourceStore(IResourceStore):
                 )
             yield io.BytesIO(bytes(row[0]))
 
+    def get_revision_bundle(
+        self,
+        resource_id: str,
+        revision_id: str,
+        schema_version: str | None,
+    ) -> "tuple[RevisionInfo, bytes]":
+        """Both columns of the same joined row, in one round-trip.
+
+        `info` and `data` live side by side in the data table and were fetched by
+        two identical queries differing only in the column list — two connection
+        checkouts, each with its own health check, for one row.
+        """
+        with self._read() as cur:
+            cur.execute(
+                f'SELECT d.info, d.data FROM "{self._data_table}" d '
+                f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                f"WHERE i.resource_id = %s AND i.revision_id = %s "
+                f"AND i.schema_version = %s",
+                (resource_id, revision_id, self._sv(schema_version)),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise KeyError(
+                    f"Resource not found: {resource_id}/{revision_id}/{schema_version}"
+                )
+            return self._info_serializer.decode(bytes(row[0])), bytes(row[1])
+
     def get_revision_info(
         self,
         resource_id: str,

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -342,6 +342,32 @@ class PostgresResourceStore(IResourceStore):
             )
         return out
 
+    def get_all_revision_infos(
+        self,
+        resource_id: str,
+    ) -> "dict[str, RevisionInfo]":
+        """All of a resource's revision infos in one statement.
+
+        The per-revision version of this was two queries each — resolve the
+        schema version, then read the info — so pruning cost statements
+        proportional to the revision count.
+        """
+        with self._read() as cur:
+            cur.execute(
+                f"SELECT i.revision_id, d.info "
+                f'FROM "{self._data_table}" d '
+                f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                f"WHERE i.resource_id = %s",
+                (resource_id,),
+            )
+            rows = cur.fetchall()
+        out: dict[str, RevisionInfo] = {}
+        for revision_id, info in rows:
+            # A revision can be stored at several schema versions; their
+            # created_time / parent_revision_id agree, so the first wins.
+            out.setdefault(revision_id, self._info_serializer.decode(bytes(info)))
+        return out
+
     def get_revision_bundles(
         self,
         keys: "Sequence[tuple[str, str, str | None]]",

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -536,17 +536,18 @@ class PostgresResourceStore(IResourceStore):
                 (resource_id,),
             )
 
-            # Remove data rows only if no other index references them
-            for uid in uids:
+            # Remove data rows only if no other index references them. As one
+            # statement: per-uid this was two round-trips each (ask, then maybe
+            # delete), so the cost grew with the revision count — and it raced,
+            # since another writer can add a reference between the ask and the
+            # delete. NOT EXISTS decides and deletes in the same breath.
+            if uids:
                 cur.execute(
-                    f'SELECT 1 FROM "{self._index_table}" WHERE uid = %s LIMIT 1',
-                    (uid,),
+                    f'DELETE FROM "{self._data_table}" d '
+                    f"WHERE d.uid = ANY(%s) AND NOT EXISTS ("
+                    f'SELECT 1 FROM "{self._index_table}" i WHERE i.uid = d.uid)',
+                    (list(uids),),
                 )
-                if cur.fetchone() is None:
-                    cur.execute(
-                        f'DELETE FROM "{self._data_table}" WHERE uid = %s',
-                        (uid,),
-                    )
 
     def delete_revisions(self, resource_id: str, revision_ids: list[str]) -> None:
         """Hard-delete specific revisions, ref-counting shared uids.
@@ -577,17 +578,18 @@ class PostgresResourceStore(IResourceStore):
                 (resource_id, rev_list),
             )
 
-            # Remove data rows only if no other index references them.
-            for uid in uids:
+            # Remove data rows only if no other index references them. As one
+            # statement: per-uid this was two round-trips each (ask, then maybe
+            # delete), so the cost grew with the revision count — and it raced,
+            # since another writer can add a reference between the ask and the
+            # delete. NOT EXISTS decides and deletes in the same breath.
+            if uids:
                 cur.execute(
-                    f'SELECT 1 FROM "{self._index_table}" WHERE uid = %s LIMIT 1',
-                    (uid,),
+                    f'DELETE FROM "{self._data_table}" d '
+                    f"WHERE d.uid = ANY(%s) AND NOT EXISTS ("
+                    f'SELECT 1 FROM "{self._index_table}" i WHERE i.uid = d.uid)',
+                    (list(uids),),
                 )
-                if cur.fetchone() is None:
-                    cur.execute(
-                        f'DELETE FROM "{self._data_table}" WHERE uid = %s',
-                        (uid,),
-                    )
 
     def cleanup(self) -> None:
         """Remove all data (both tables). Useful for test teardown."""

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -299,6 +299,49 @@ class PostgresResourceStore(IResourceStore):
                 )
             return self._info_serializer.decode(bytes(row[0])), bytes(row[1])
 
+    def dump_all_revisions(
+        self,
+        *,
+        resource_ids: "frozenset[str] | None" = None,
+        max_workers: int = 10,
+    ) -> "dict[str, list[tuple[RevisionInfo, bytes]]] | None":
+        """Every revision of every requested resource, in one statement.
+
+        `dump` already prefers a bulk path and falls back to reading each
+        resource in turn when the store returns None — which Postgres did, so an
+        export cost statements proportional to the number of resources (measured:
+        322 for 40). The per-resource query is a join on the same two tables, so
+        the whole export is that join without the per-resource `WHERE`.
+
+        `max_workers` is part of the interface for stores that fetch payloads
+        over a network (S3); a single SQL statement has nothing to parallelise.
+        """
+        del max_workers
+        with self._read() as cur:
+            if resource_ids is None:
+                cur.execute(
+                    f"SELECT i.resource_id, d.info, d.data "
+                    f'FROM "{self._data_table}" d '
+                    f'JOIN "{self._index_table}" i ON d.uid = i.uid'
+                )
+            else:
+                if not resource_ids:
+                    return {}
+                cur.execute(
+                    f"SELECT i.resource_id, d.info, d.data "
+                    f'FROM "{self._data_table}" d '
+                    f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                    f"WHERE i.resource_id = ANY(%s)",
+                    (list(resource_ids),),
+                )
+            rows = cur.fetchall()
+        out: dict[str, list[tuple[RevisionInfo, bytes]]] = {}
+        for resource_id, info, data in rows:
+            out.setdefault(resource_id, []).append(
+                (self._info_serializer.decode(bytes(info)), bytes(data))
+            )
+        return out
+
     def get_revision_bundles(
         self,
         keys: "Sequence[tuple[str, str, str | None]]",

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -299,6 +299,40 @@ class PostgresResourceStore(IResourceStore):
                 )
             return self._info_serializer.decode(bytes(row[0])), bytes(row[1])
 
+    def get_revision_bundles(
+        self,
+        keys: "Sequence[tuple[str, str, str | None]]",
+    ) -> "dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]]":
+        """A whole page in one statement.
+
+        The per-row query is already a join keyed on the same three columns, so
+        the page is one `IN` over their tuples — the page's cost stops growing
+        with its size.
+        """
+        wanted = [(r, v, self._sv(sv)) for r, v, sv in keys]
+        if not wanted:
+            return {}
+        with self._read() as cur:
+            cur.execute(
+                f"SELECT i.resource_id, i.revision_id, i.schema_version, d.info, d.data "
+                f'FROM "{self._data_table}" d '
+                f'JOIN "{self._index_table}" i ON d.uid = i.uid '
+                f"WHERE (i.resource_id, i.revision_id, i.schema_version) IN %s",
+                (tuple(wanted),),
+            )
+            rows = cur.fetchall()
+        by_normalised = {
+            (r, v, sv): (self._info_serializer.decode(bytes(info)), bytes(data))
+            for r, v, sv, info, data in rows
+        }
+        # Hand back the caller's own key shape, not the normalised one.
+        out: dict[tuple[str, str, str | None], tuple[RevisionInfo, bytes]] = {}
+        for key in keys:
+            hit = by_normalised.get((key[0], key[1], self._sv(key[2])))
+            if hit is not None:
+                out[key] = hit
+        return out
+
     def get_revision_info(
         self,
         resource_id: str,

--- a/specstar/resource_manager/resource_store/postgres.py
+++ b/specstar/resource_manager/resource_store/postgres.py
@@ -97,8 +97,13 @@ class PostgresResourceStore(IResourceStore):
                 time.sleep(min(0.5 * (attempt + 1), 3))
                 continue
 
-            conn.autocommit = False
+            # Health-check OUTSIDE a transaction. With autocommit off the
+            # probe's own `SELECT 1` opens one, and psycopg2 then refuses
+            # any later `autocommit` change on this connection — which is
+            # what a read-only caller needs to do to skip BEGIN/COMMIT.
+            conn.autocommit = True
             if self._test_query(conn):
+                conn.autocommit = False  # writers are the default
                 return conn
 
             try:
@@ -135,6 +140,25 @@ class PostgresResourceStore(IResourceStore):
             conn.rollback()
             raise
         finally:
+            self._put_conn(conn)
+
+    @contextmanager
+    def _read(self) -> Generator[Any, None, None]:
+        """A read that runs outside a transaction.
+
+        `BEGIN` and `COMMIT` are two round-trips, and a single-statement SELECT
+        has nothing to make atomic. `_get_conn` turns autocommit off because most
+        callers write; a read turns it back on for its own duration and restores
+        it before the connection returns to the pool.
+        """
+        conn = self._get_conn()
+        previous = conn.autocommit
+        conn.autocommit = True
+        try:
+            with conn.cursor() as cur:
+                yield cur
+        finally:
+            conn.autocommit = previous
             self._put_conn(conn)
 
     # ------------------------------------------------------------------
@@ -184,13 +208,13 @@ class PostgresResourceStore(IResourceStore):
     # ------------------------------------------------------------------
 
     def list_resources(self) -> Generator[str]:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(f'SELECT DISTINCT resource_id FROM "{self._index_table}"')
             for row in cur.fetchall():
                 yield row[0]
 
     def list_revisions(self, resource_id: str) -> Generator[str]:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f'SELECT DISTINCT revision_id FROM "{self._index_table}" '
                 f"WHERE resource_id = %s",
@@ -202,7 +226,7 @@ class PostgresResourceStore(IResourceStore):
     def list_schema_versions(
         self, resource_id: str, revision_id: str
     ) -> Generator[str | None]:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f'SELECT schema_version FROM "{self._index_table}" '
                 f"WHERE resource_id = %s AND revision_id = %s",
@@ -217,7 +241,7 @@ class PostgresResourceStore(IResourceStore):
         revision_id: str,
         schema_version: str | None,
     ) -> bool:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f'SELECT 1 FROM "{self._index_table}" '
                 f"WHERE resource_id = %s AND revision_id = %s "
@@ -233,7 +257,7 @@ class PostgresResourceStore(IResourceStore):
         revision_id: str,
         schema_version: str | None,
     ) -> Generator[IO[bytes], None, None]:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f'SELECT d.data FROM "{self._data_table}" d '
                 f'JOIN "{self._index_table}" i ON d.uid = i.uid '
@@ -254,7 +278,7 @@ class PostgresResourceStore(IResourceStore):
         revision_id: str,
         schema_version: str | None,
     ) -> RevisionInfo:
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f'SELECT d.info FROM "{self._data_table}" d '
                 f'JOIN "{self._index_table}" i ON d.uid = i.uid '
@@ -318,7 +342,7 @@ class PostgresResourceStore(IResourceStore):
         if not items:
             return []
         keys = self._key_tuples(items)
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f"SELECT i.resource_id, i.revision_id, i.schema_version, "
                 f"octet_length(d.data) "
@@ -337,7 +361,7 @@ class PostgresResourceStore(IResourceStore):
         if not items:
             return {}
         keys = self._key_tuples(items)
-        with self._transaction() as cur:
+        with self._read() as cur:
             cur.execute(
                 f"SELECT i.resource_id, d.data "
                 f'FROM "{self._data_table}" d '
@@ -391,7 +415,7 @@ class PostgresResourceStore(IResourceStore):
 
     def purge_resource(self, resource_id: str) -> None:
         """Hard-delete all revision data for a resource."""
-        with self._transaction() as cur:
+        with self._read() as cur:
             # Collect UIDs that belong exclusively to this resource
             # (in case of UID deduplication across resources we must not
             # remove data rows still referenced by other resources)
@@ -431,7 +455,7 @@ class PostgresResourceStore(IResourceStore):
         if not revision_ids:
             return
         rev_list = list(revision_ids)
-        with self._transaction() as cur:
+        with self._read() as cur:
             # UIDs referenced by the revisions we're about to drop.
             cur.execute(
                 f'SELECT DISTINCT uid FROM "{self._index_table}" '

--- a/tests/migrations/test_resource_manager_migrate.py
+++ b/tests/migrations/test_resource_manager_migrate.py
@@ -54,8 +54,26 @@ class TestResourceManagerMigrate:
 
     @pytest.fixture
     def mock_storage(self) -> MagicMock:
-        """創建模擬的 storage"""
+        """創建模擬的 storage.
+
+        `get_revision_bundle` is derived from the two reads a test configures,
+        so the double stays consistent with the real storage: reading a revision
+        returns that revision's info AND payload, whether the caller asks for
+        them together or one at a time. Left unconfigured it would return a bare
+        MagicMock and every caller would see an empty unpack.
+        """
         storage = MagicMock()
+
+        def _bundle(resource_id, revision_id, schema_version=None, *a, **k):
+            info = storage.get_resource_revision_info(
+                resource_id, revision_id, schema_version=schema_version
+            )
+            with storage.get_data_bytes(
+                resource_id, revision_id, schema_version=schema_version
+            ) as fh:
+                return info, fh.read()
+
+        storage.get_revision_bundle.side_effect = _bundle
         return storage
 
     @pytest.fixture

--- a/tests/test_list_resources_bad_row.py
+++ b/tests/test_list_resources_bad_row.py
@@ -1,0 +1,99 @@
+"""A listing prefetches its page in one read. Decoding must stay per-row.
+
+The bulk read exists to stop a listing costing one query per row, and it
+deliberately fetches BYTES only: the moment decoding moves into that step, one
+unreadable row stops being one skipped item and becomes a failed page.
+
+These tests corrupt the stored payload itself rather than patching a method, so
+they describe the behaviour and not the mechanism — they hold whether the page
+arrives in one read or in twenty.
+"""
+
+import datetime as dt
+
+import pytest
+from msgspec import Struct
+
+from specstar.query_types import ResourceMetaSearchQuery
+from specstar.resource_manager.core import ResourceManager, SimpleStorage
+from specstar.resource_manager.meta_store.simple import MemoryMetaStore
+from specstar.resource_manager.resource_store.simple import MemoryResourceStore
+from specstar.types import OnDecodeError
+
+
+class Data(Struct):
+    name: str
+
+
+_NOW = dt.datetime(2026, 7, 28, 12, 0, 0)
+
+
+def _manager(policy: OnDecodeError) -> ResourceManager[Data]:
+    storage = SimpleStorage(
+        meta_store=MemoryMetaStore(),
+        resource_store=MemoryResourceStore(encoding="msgpack"),  # ty:ignore[invalid-argument-type]
+    )
+    return ResourceManager(Data, storage=storage, on_decode_error=policy)
+
+
+def _create(mgr: ResourceManager[Data], name: str) -> str:
+    with mgr.using(user="someone", now=_NOW):
+        info = mgr.create(Data(name=name))
+    return info.resource_id
+
+
+def _corrupt(mgr: ResourceManager[Data], resource_id: str) -> None:
+    """Replace one row's stored payload with bytes msgpack cannot decode.
+
+    Reaching into the store rather than stubbing a read is the point: every
+    path that serves this row — bulk or per-row — now yields the same garbage,
+    so the test cannot be satisfied by a read path that merely happens to skip
+    the bulk step.
+    """
+    store = mgr.storage._resource_store
+    assert isinstance(store, MemoryResourceStore)
+    revisions = store._store[resource_id]
+    revision_id = next(iter(revisions))
+    uid = next(iter(revisions[revision_id].values()))
+    store._raw_data_store[uid] = b"\xc1 not msgpack"
+
+
+def _list(mgr: ResourceManager[Data]):
+    with mgr.using(user="someone", now=_NOW):
+        return mgr.list_resources(ResourceMetaSearchQuery())
+
+
+def test_one_unreadable_row_is_skipped_not_the_whole_page():
+    mgr = _manager(OnDecodeError.skip)
+    bad = _create(mgr, "bad")
+    good = _create(mgr, "good")
+    _corrupt(mgr, bad)
+
+    results = _list(mgr)
+
+    assert [r.meta.resource_id for r in results] == [good]  # ty:ignore[unresolved-attribute]
+
+
+def test_an_unreadable_row_still_raises_under_the_error_policy():
+    mgr = _manager(OnDecodeError.error)
+    bad = _create(mgr, "bad")
+    _create(mgr, "good")
+    _corrupt(mgr, bad)
+
+    with pytest.raises(Exception, match=bad):
+        _list(mgr)
+
+
+def test_the_raw_policy_still_hands_back_the_undecodable_row():
+    mgr = _manager(OnDecodeError.raw)
+    bad = _create(mgr, "bad")
+    good = _create(mgr, "good")
+    _corrupt(mgr, bad)
+
+    results = _list(mgr)
+
+    by_id = {r.meta.resource_id: r for r in results}  # ty:ignore[unresolved-attribute]
+    assert set(by_id) == {bad, good}
+    assert by_id[good].data == Data(name="good")
+    # The point of `raw` is that the caller still learns the row exists.
+    assert by_id[bad].data != Data(name="good")

--- a/tests/test_pg_orphan_cleanup.py
+++ b/tests/test_pg_orphan_cleanup.py
@@ -1,0 +1,77 @@
+"""Deleting revisions must not ask about each uid separately.
+
+Both hard-delete paths remove index rows, then drop the data rows nothing
+references any more. That check ran per uid — `SELECT 1 ... WHERE uid = %s` then
+maybe a `DELETE`, two round-trips each — so pruning a resource cost statements
+proportional to its revision count (measured: 49 for 7 revisions, #442).
+
+"delete the rows no index references" is one statement, and SQL is where that
+belongs: doing it per uid also races, since another writer can add a reference
+between the check and the delete.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REG = "specstar.resource_manager._pg_pool"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    from specstar.resource_manager import _pg_pool
+
+    _pg_pool.close_all_pools()
+    yield
+    _pg_pool.close_all_pools()
+
+
+def _store_and_cursor(uids):
+    cursor = MagicMock(name="cursor")
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    cursor.fetchall.return_value = [(u,) for u in uids]
+    calls = {"n": 0}
+
+    def _fetchone():
+        calls["n"] += 1
+        return [1] if calls["n"] == 1 else None  # first is the SELECT 1 health check
+
+    cursor.fetchone.side_effect = _fetchone
+
+    conn = MagicMock(name="conn")
+    conn.cursor.return_value = cursor
+    pool = MagicMock(name="pool")
+    pool.getconn.return_value = conn
+
+    with patch(f"{REG}.get_pool", return_value=pool):
+        with patch(
+            "specstar.resource_manager.resource_store.postgres."
+            "PostgresResourceStore._init_tables"
+        ):
+            from specstar.resource_manager.resource_store.postgres import (
+                PostgresResourceStore,
+            )
+
+            store = PostgresResourceStore(pg_dsn="postgresql://fake/fake")
+    return store, cursor
+
+
+def _per_uid_probes(cursor):
+    return [
+        c
+        for c in cursor.execute.call_args_list
+        if "WHERE uid = %s LIMIT 1" in str(c.args[0] if c.args else "")
+    ]
+
+
+def test_purge_does_not_probe_each_uid():
+    store, cursor = _store_and_cursor(["u1", "u2", "u3", "u4"])
+    store.purge_resource("r1")
+    assert _per_uid_probes(cursor) == [], cursor.execute.call_args_list
+
+
+def test_delete_revisions_does_not_probe_each_uid():
+    store, cursor = _store_and_cursor(["u1", "u2", "u3", "u4"])
+    store.delete_revisions("r1", ["rev1", "rev2"])
+    assert _per_uid_probes(cursor) == [], cursor.execute.call_args_list

--- a/tests/test_pg_point_read_cursor.py
+++ b/tests/test_pg_point_read_cursor.py
@@ -1,0 +1,97 @@
+"""A point read must not open a server-side cursor.
+
+`stream_cursor()` opens a NAMED psycopg2 cursor, which makes postgres do
+`DECLARE` / `FETCH` / `CLOSE` — three round-trips instead of one. That is the
+right trade when iterating a whole table, and pure loss when the caller has
+already decided it wants a single row.
+
+Measured against a local postgres before this change: one `get()` by primary key
+cost 14 SQL statements, of which only 3 fetched data (issue #442).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REG = "specstar.resource_manager._pg_pool"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    from specstar.resource_manager import _pg_pool
+
+    _pg_pool.close_all_pools()
+    yield
+    _pg_pool.close_all_pools()
+
+
+def _store_with_row(row):
+    """A store whose connection returns `row` from `fetchone`, and which records
+    every `conn.cursor(...)` call so the test can see whether it was named."""
+    cursor = MagicMock(name="cursor")
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    # `get_conn` health-checks every checkout with `SELECT 1` before the caller's
+    # query runs — itself one of the round-trips issue #442 counts.
+    calls = {"n": 0}
+
+    def _fetchone():
+        calls["n"] += 1
+        return [1] if calls["n"] == 1 else row  # first is the SELECT 1 health check
+
+    cursor.fetchone.side_effect = _fetchone
+
+    conn = MagicMock(name="conn")
+    conn.cursor.return_value = cursor
+    pool = MagicMock(name="pool")
+    pool.getconn.return_value = conn
+
+    with patch(f"{REG}.get_pool", return_value=pool):
+        with patch(
+            "specstar.resource_manager.meta_store.postgres."
+            "PostgresMetaStore._init_postgres_table"
+        ):
+            with patch(
+                "specstar.resource_manager.meta_store.postgres."
+                "PostgresMetaStore._detect_pgvector",
+                return_value=False,
+            ):
+                from specstar.resource_manager.meta_store.postgres import (
+                    PostgresMetaStore,
+                )
+
+                store = PostgresMetaStore(pg_dsn="postgresql://fake/fake")
+    return store, conn
+
+
+def _named_cursor_calls(conn):
+    return [c for c in conn.cursor.call_args_list if c.kwargs.get("name")]
+
+
+def test_getitem_does_not_open_a_server_side_cursor():
+    """The hot one: every `rm.get()` resolves meta through here."""
+    store, conn = _store_with_row({"data": b""})
+    store._serializer = MagicMock(decode=MagicMock(return_value="meta"))
+
+    assert store["some-id"] == "meta"
+    assert _named_cursor_calls(conn) == [], conn.cursor.call_args_list
+
+
+def test_len_does_not_open_a_server_side_cursor():
+    """A COUNT returns exactly one row — there is nothing to stream."""
+    store, conn = _store_with_row([7])
+
+    assert len(store) == 7
+    assert _named_cursor_calls(conn) == [], conn.cursor.call_args_list
+
+
+def test_a_bounded_read_runs_without_a_transaction():
+    """`BEGIN` and `COMMIT` are two more round-trips, and a single-statement read
+    has nothing to make atomic. `get_conn` turns autocommit off for writers; a
+    bounded read turns it back on for its own duration."""
+    store, conn = _store_with_row({"data": b""})
+    store._serializer = MagicMock(decode=MagicMock(return_value="meta"))
+
+    assert store["some-id"] == "meta"
+    assert conn.commit.call_count == 0, "a read committed a transaction it never needed"
+    assert conn.autocommit is False, "autocommit must be restored before the connection goes back"

--- a/tests/test_pg_search_cursor_choice.py
+++ b/tests/test_pg_search_cursor_choice.py
@@ -1,0 +1,101 @@
+"""Which cursor a search uses, and why it must depend on the LIMIT.
+
+A server-side (named) cursor is what stops an unbounded search from pulling a
+whole table into memory. It costs `DECLARE` + an extra `FETCH` + `CLOSE`, inside
+a transaction — six statements around one query.
+
+psycopg2 drains a named cursor in batches of `itersize` (2000). So a search whose
+LIMIT is no larger than one batch would be materialised in a single FETCH anyway:
+the cursor buys nothing and costs five extra round-trips. Above that, it is
+load-bearing and must stay.
+
+Getting the condition wrong in the permissive direction loads an entire table
+into memory, so both directions are pinned here.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REG = "specstar.resource_manager._pg_pool"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    from specstar.resource_manager import _pg_pool
+
+    _pg_pool.close_all_pools()
+    yield
+    _pg_pool.close_all_pools()
+
+
+def _store_and_conn():
+    cursor = MagicMock(name="cursor")
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    cursor.__iter__ = MagicMock(return_value=iter([]))
+    cursor.fetchall.return_value = []
+    calls = {"n": 0}
+
+    def _fetchone():
+        calls["n"] += 1
+        return [1] if calls["n"] == 1 else None  # first is the SELECT 1 health check
+
+    cursor.fetchone.side_effect = _fetchone
+
+    conn = MagicMock(name="conn")
+    conn.cursor.return_value = cursor
+    pool = MagicMock(name="pool")
+    pool.getconn.return_value = conn
+
+    with patch(f"{REG}.get_pool", return_value=pool):
+        with patch(
+            "specstar.resource_manager.meta_store.postgres."
+            "PostgresMetaStore._init_postgres_table"
+        ):
+            with patch(
+                "specstar.resource_manager.meta_store.postgres."
+                "PostgresMetaStore._detect_pgvector",
+                return_value=False,
+            ):
+                from specstar.resource_manager.meta_store.postgres import (
+                    PostgresMetaStore,
+                )
+
+                store = PostgresMetaStore(pg_dsn="postgresql://fake/fake")
+    return store, conn
+
+
+def _named(conn):
+    return [c for c in conn.cursor.call_args_list if c.kwargs.get("name")]
+
+
+def _search(limit):
+    from specstar.query_types import ResourceMetaSearchQuery
+
+    store, conn = _store_and_conn()
+    list(store.iter_search(ResourceMetaSearchQuery(limit=limit)))
+    return conn
+
+
+def test_a_page_sized_search_skips_the_server_side_cursor():
+    assert _named(_search(50)) == [], "a 50-row page does not need to stream"
+
+
+def test_a_search_at_the_batch_boundary_still_skips_it():
+    assert _named(_search(2000)) == [], "one batch is one FETCH either way"
+
+
+def test_a_search_larger_than_one_batch_keeps_streaming():
+    conn = _search(2001)
+    assert _named(conn), "past one batch the cursor is what bounds memory"
+
+
+def test_the_unbounded_default_keeps_streaming():
+    """The default limit is a sentinel (~4.29e9), not a page size. Treating it as
+    a bound would pull the whole table into memory — the failure this cursor
+    exists to prevent."""
+    from specstar.query_types import DEFAULT_QUERY_LIMIT
+
+    conn = _search(DEFAULT_QUERY_LIMIT)
+    assert _named(conn), f"limit={DEFAULT_QUERY_LIMIT} must stream"

--- a/tests/test_pg_search_cursor_choice.py
+++ b/tests/test_pg_search_cursor_choice.py
@@ -99,3 +99,24 @@ def test_the_unbounded_default_keeps_streaming():
 
     conn = _search(DEFAULT_QUERY_LIMIT)
     assert _named(conn), f"limit={DEFAULT_QUERY_LIMIT} must stream"
+
+
+def test_an_aggregation_streams_unless_its_result_is_bounded():
+    """A GROUP BY is NOT inherently small: grouping by a high-cardinality key
+    returns one row per group, which can be one row per resource. So the rule is
+    the same as for a search — the caller's `limit` is what bounds it, and
+    without one the cursor stays.
+    """
+    from unittest.mock import MagicMock as MM
+
+    from specstar.query_types import ResourceMetaSearchQuery
+
+    by = MM(source="meta", key="n", path=None)
+
+    store, conn = _store_and_conn()
+    store.aggregate_by(ResourceMetaSearchQuery(), by, [], limit=50)
+    assert _named(conn) == [], "a limited aggregation fits in one fetch"
+
+    store2, conn2 = _store_and_conn()
+    store2.aggregate_by(ResourceMetaSearchQuery(), by, [])
+    assert _named(conn2), "an unlimited GROUP BY can return a row per resource"

--- a/tests/test_schema_integration.py
+++ b/tests/test_schema_integration.py
@@ -187,9 +187,16 @@ class TestSchemaResourceManagerIntegration:
         mock_storage.exists.return_value = True
         mock_storage.get_meta.return_value = meta
         mock_storage.get_resource_revision_info.return_value = revision_info
+        raw = msgspec.json.encode(legacy_data)
         mock_storage.get_data_bytes.return_value.__enter__.return_value = io.BytesIO(
-            msgspec.json.encode(legacy_data)
+            raw
         )
+        # Reading a row's info and payload together is one call on a store, and
+        # a bare MagicMock answers it with an empty iterable — which no store
+        # does. State it, derived from the two reads above rather than invented,
+        # so the double keeps describing the contract instead of whichever
+        # calls the code happens to make today.
+        mock_storage.get_revision_bundle.return_value = (revision_info, raw)
 
         result = rm.migrate("item:1")
 

--- a/tests/test_update_skips_unused_read.py
+++ b/tests/test_update_skips_unused_read.py
@@ -1,0 +1,114 @@
+"""An update must not read the previous row for an encoder that isn't there.
+
+`update` fetched the previous revision's data on every call so the embedding
+processor could reuse a cached vector. A model with no `Embedding` field never
+uses it — `process_sync` loops over an empty field list — so the read, the
+decode of the whole previous row, and (on a SQL backend) its round-trips are
+spent producing an argument nobody looks at.
+
+Measured against a local postgres: one `update` cost 19 SQL statements, two of
+them this read (#442).
+"""
+
+import msgspec
+
+from specstar import SpecStar
+
+
+class Plain(msgspec.Struct):
+    """No Embedding field — the common case."""
+
+    title: str
+
+
+def _manager():
+    sp = SpecStar()
+    sp.configure(default_user="t")
+    sp.add_model(Plain, name="plain")
+    return sp.get_resource_manager(Plain)
+
+
+def test_update_of_a_model_without_embeddings_does_not_read_the_previous_data():
+    rm = _manager()
+    rid = rm.create(Plain(title="a")).resource_id
+
+    reads: list[str] = []
+    storage = rm.storage
+    original = type(storage).get_data_bytes
+
+    def counting(self, resource_id, revision_id, schema_version=msgspec.UNSET, *a, **k):  # noqa: ANN001
+        reads.append(resource_id)
+        return original(self, resource_id, revision_id, schema_version, *a, **k)
+
+    type(storage).get_data_bytes = counting  # ty: ignore[invalid-assignment]
+    try:
+        rm.update(rid, Plain(title="b"))
+    finally:
+        type(storage).get_data_bytes = original
+
+    assert reads == [], reads
+    assert rm.get(rid).data.title == "b"  # and the update still happened
+
+
+def test_update_reads_the_resource_meta_once():
+    """`update` loads the meta, then asks for the previous revision's info
+    without saying which schema version — so the storage facade loads the same
+    meta again to resolve it, from a caller that is already holding it.
+
+    Two identical `SELECT ... WHERE resource_id = ...` per update, plus the
+    connection checkout each one takes.
+    """
+    rm = _manager()
+    rid = rm.create(Plain(title="a")).resource_id
+
+    loads: list[str] = []
+    storage = rm.storage
+    original = type(storage).get_meta
+
+    def counting(self, resource_id, *a, **k):  # noqa: ANN001
+        loads.append(resource_id)
+        return original(self, resource_id, *a, **k)
+
+    type(storage).get_meta = counting  # ty: ignore[invalid-assignment]
+    try:
+        rm.update(rid, Plain(title="b"))
+    finally:
+        type(storage).get_meta = original
+
+    assert len(loads) == 1, f"meta loaded {len(loads)} times: {loads}"
+
+
+def test_revision_exists_checks_the_resource_once():
+    """`revision_exists` loaded the meta, then asked the meta store AGAIN whether
+    the resource is there — but the load already answered that: it raises for an
+    unknown id, so reaching the second check proves the first succeeded.
+
+    Two `SELECT ... WHERE resource_id = ...` and two connection checkouts to
+    answer one question.
+    """
+    rm = _manager()
+    rid = rm.create(Plain(title="a")).resource_id
+    rev = rm.get_meta(rid).current_revision_id
+
+    probes: list[str] = []
+    store = rm.storage._meta_store
+    original_get = type(store).__getitem__
+    original_in = type(store).__contains__
+
+    def counting_get(self, key):  # noqa: ANN001
+        probes.append(f"get:{key}")
+        return original_get(self, key)
+
+    def counting_in(self, key):  # noqa: ANN001
+        probes.append(f"in:{key}")
+        return original_in(self, key)
+
+    type(store).__getitem__ = counting_get  # ty: ignore[invalid-assignment]
+    type(store).__contains__ = counting_in  # ty: ignore[invalid-assignment]
+    try:
+        assert rm.revision_exists(rid, rev) is True
+    finally:
+        type(store).__getitem__ = original_get
+        type(store).__contains__ = original_in
+
+    assert len(probes) == 1, f"meta store hit {len(probes)} times: {probes}"


### PR DESCRIPTION
Closes #442. Closes #443.

## How this was found

Every number here comes from `log_statement=all` on a local Postgres 16, counting
statements around one call. Nothing is estimated — an earlier attempt to reason
from call-count × assumed latency was circular and wrong three times over.

## The shape of the problem

Two patterns, repeated:

**Round-trips a read cannot use.** A named (server-side) cursor makes Postgres
`DECLARE` / `FETCH` / `CLOSE` — that is what lets a scan stream instead of
materialising, and it is pure loss for a caller that has already bounded its
result. `BEGIN`/`COMMIT` are two more, and a single-statement SELECT has nothing
to make atomic.

**Work that grows with the data it is about.** Six N+1s: a listing read each row
individually, an export each resource, pruning each revision, orphan cleanup
asked about each uid, and both `dump_resource` and `migrate` fetched a row's
`info` and `data` separately.

## Measured

| operation | before | after |
|---|---|---|
| `get_meta` | 6 | **2** |
| `get` | 14 | **4** |
| `update` | 19 | **13** |
| `revision_exists` | 6 | **4** |
| `migrate` (per resource, ×N in a migration) | 15 | **13** |
| `search` / `exp_aggregate_by`, bounded | 7 | **2** |
| `list_resources`, 20 rows | 87 | **9** (4 bounded), flat |
| `dump`, 40 resources | 322 / 999ms | **4 / 13.5ms** |
| `dump_resource`, 21 revisions | 128 | **2** |
| `permanently_delete`, 7 revisions | 23 | **10** |
| `prune_revisions`, 7 revisions | 49 | **10**, flat to 21 |

## Design

Every bulk primitive is **concrete on the interface, defaulting to the loop it
replaces** — `get_revision_bundle`, `get_revision_bundles`,
`get_all_revision_infos`, and Postgres's `dump_all_revisions` (the seam already
existed; S3 implemented it, Postgres did not). A store that ignores them behaves
exactly as before, so this is a Postgres speed-up and a no-op everywhere else.

The cursor rule is the psycopg2 batch size, not a number chosen to look safe: a
result no larger than one `itersize` batch is materialised in a single FETCH
either way. Above it the cursor is load-bearing and stays. **The default query
limit is a sentinel (~4.29e9), not a page size** — treating it as bounded would
load a whole table into memory, so the tests assert that case by name.

## What is deliberately left

**The `SELECT 1` health check on every connection checkout.** It is what stops a
connection the server already closed from surfacing as a failure inside the
caller's query. A liveness probe is often also the recovery trigger, and removing
one for looking redundant is a mistake I made elsewhere this week and had to
revert. Making it cheaper means tracking per-connection idle time — a separate
change.

**Two write transactions per create/update.** Meta and resource can be bound to
different backends, so there is no shared transaction to merge them into.

## Verification

Each commit is one change, so a bisect lands on a single decision.

Beyond the unit tests: a real Postgres round-trip of create → get → update →
list → write-after-read → delete, and a byte-for-byte comparison of the bulk
export against the per-resource path including a multi-revision resource. That
mattered — psycopg2 forbids changing `autocommit` inside a transaction, which
passed under `MagicMock` and failed on the first real connection.

The listing prefetch has one way to go wrong that speed alone would hide: if
decoding moved into the bulk step, one unreadable row would stop being one
skipped item and become a failed page. It fetches bytes only, and
`tests/test_list_resources_bad_row.py` pins that under all three
`on_decode_error` policies by corrupting the stored payload — describing the
behaviour, not the mechanism. Decoding the bundles inside the bulk step turns
all three red, so they are not vacuous.

The whole suite was run on this branch and on master with the same selection
(the S3/MinIO/Redis-backed tests are deselected — those services are absent
here, so they only contribute connection timeouts). The comparison is the
difference between the two failure lists, not an absolute count.

Also swept and found already at their floor, so untouched: `create`,
`patch_many` (flat 3→20 rows), `list_revisions` (flat to 21), `iter_all`,
`count_resources`, `exists`, `create_or_update`, and the HTTP CRUD routes (a
25-row list costs the same 9 as the API call underneath — no hidden pagination
count or scope query). Blobs never reach SQL: Postgres does not support that
role.
