### PR TITLE
ci: make the npm release actually reach OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -70,23 +70,34 @@ jobs:
         with:
           version: 10
 
-      # NO `registry-url:` here, deliberately. Setting it makes setup-node
-      # write `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into an
-      # .npmrc and default NODE_AUTH_TOKEN to the literal placeholder
-      # `XXXXX-XXXXX-XXXXX-XXXXX`. npm then authenticates with that junk
-      # bearer token instead of performing the OIDC exchange, and the
-      # registry answers an unauthorized PUT with 404 — which reads as "no
-      # such package" and sends you hunting for a publishing permission
-      # problem that isn't there. actions/setup-node#1551.
-      #
-      # registry.npmjs.org is npm's default registry anyway, so dropping the
-      # input costs nothing and leaves auth unconfigured, which is exactly
-      # what trusted publishing needs.
+      # `registry-url` is kept (npm's own trusted-publishing example sets it,
+      # and it is what pins the registry npm authenticates against) — but the
+      # .npmrc it generates has to be repaired before publishing, see below.
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
           cache-dependency-path: web/generator/pnpm-lock.yaml
+
+      # setup-node writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+      # and defaults NODE_AUTH_TOKEN to the literal placeholder
+      # `XXXXX-XXXXX-XXXXX-XXXXX`. npm then authenticates with that junk bearer
+      # token instead of exchanging its OIDC token, and the registry answers the
+      # unauthorized PUT with a bare 404 — which reads as "no such package" and
+      # sends you hunting for a permission problem that does not exist. That is
+      # exactly how web-v0.3.5 failed. actions/setup-node#1551.
+      #
+      # Strip the line rather than dropping `registry-url`: this is the
+      # workaround the issue thread settled on, and it keeps the registry
+      # explicitly configured.
+      - name: Remove the placeholder auth line setup-node writes
+        run: |
+          for f in "$NPM_CONFIG_USERCONFIG" "$HOME/.npmrc"; do
+            [ -n "$f" ] && [ -f "$f" ] || continue
+            sed -i '/_authToken/d' "$f"
+            echo "cleaned $f"
+          done
 
       # Belt and braces: if anything else in the toolchain (a future
       # setup-node, pnpm, a cached runner image) leaves an auth line behind,
@@ -105,7 +116,7 @@ jobs:
             fi
           done
           if [ -n "$found" ]; then
-            echo "::error::stored npm credentials will pre-empt trusted publishing (found in:$found) — remove registry-url/NODE_AUTH_TOKEN so OIDC is used"
+            echo "::error::stored npm credentials will pre-empt trusted publishing (found in:$found) — the sed step above should have removed them"
             exit 1
           fi
           echo "no stored npm credentials — OIDC will be used"
@@ -117,6 +128,24 @@ jobs:
         run: |
           npm install -g npm@^11.5.1
           npm --version
+
+      # npm reports every trusted-publishing failure as ENEEDAUTH or 404
+      # (npm/cli#9088), which cannot distinguish "GitHub issued us no OIDC
+      # token" from "npm never asked for one" from "npm asked and npmjs.com
+      # has no matching trusted publisher". Print the one fact that splits
+      # those apart. Booleans only — never the token itself.
+      - name: OIDC preconditions
+        run: |
+          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
+            echo "id-token permission: GRANTED (runner can mint an OIDC token)"
+          else
+            echo "::error::id-token permission MISSING — the job needs permissions.id-token: write"
+            exit 1
+          fi
+          echo "repository:  ${{ github.repository }}"
+          echo "workflow:    $(basename "${{ github.workflow_ref }}" | cut -d@ -f1)"
+          echo "environment: npm"
+          echo "These three must match the trusted publisher on npmjs.com exactly."
 
       - name: Install dependencies
         working-directory: web/generator

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -143,7 +143,7 @@ jobs:
             exit 1
           fi
           echo "repository:  ${{ github.repository }}"
-          echo "workflow:    $(basename "${{ github.workflow_ref }}" | cut -d@ -f1)"
+          echo "workflow:    $(basename "$(echo '${{ github.workflow_ref }}' | cut -d@ -f1)")"
           echo "environment: npm"
           echo "These three must match the trusted publisher on npmjs.com exactly."
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -4,13 +4,17 @@ name: Release (npm)
 # `specstar-web-generator` CLI) to npm. The Python distribution is a separate
 # artefact on its own `v*` stream — see release-pypi.yml.
 #
-# ONE-TIME BOOTSTRAP: npm cannot publish a package's *first* version over
-# OIDC. A trusted publisher is configured on the package's settings page,
-# which only exists once the package does (npm/cli#8544). So `0.3.4` has to
-# be published once from a workstation — `make -C web bootstrap-publish` —
-# and the trusted publisher enabled afterwards. Until that is done, this
-# workflow will fail at the publish step with a 404/ENEEDAUTH (npm/cli#9088
-# reports missing trusted-publishing diagnostics as a plain 404).
+# The bootstrap is DONE: 0.3.4 was published by hand on 2026-07-28, because
+# npm cannot publish a package's *first* version over OIDC — the trusted
+# publisher is configured on a settings page that only exists once the
+# package does (npm/cli#8544). Kept here because it explains why
+# `make -C web bootstrap-publish` exists and why it must never be used again.
+#
+# Note for anyone debugging a failure here: npm reports every unauthorized
+# publish as a bare 404 "not found" (npm/cli#9088), so a 404 means "npm did
+# not accept who you are", not "the package is missing". Check the trusted
+# publisher's repo/workflow/environment tuple, and check that nothing has
+# written npm credentials into an .npmrc — see the guard below.
 on:
   push:
     tags:
@@ -66,12 +70,45 @@ jobs:
         with:
           version: 10
 
+      # NO `registry-url:` here, deliberately. Setting it makes setup-node
+      # write `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into an
+      # .npmrc and default NODE_AUTH_TOKEN to the literal placeholder
+      # `XXXXX-XXXXX-XXXXX-XXXXX`. npm then authenticates with that junk
+      # bearer token instead of performing the OIDC exchange, and the
+      # registry answers an unauthorized PUT with 404 — which reads as "no
+      # such package" and sends you hunting for a publishing permission
+      # problem that isn't there. actions/setup-node#1551.
+      #
+      # registry.npmjs.org is npm's default registry anyway, so dropping the
+      # input costs nothing and leaves auth unconfigured, which is exactly
+      # what trusted publishing needs.
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
           cache-dependency-path: web/generator/pnpm-lock.yaml
+
+      # Belt and braces: if anything else in the toolchain (a future
+      # setup-node, pnpm, a cached runner image) leaves an auth line behind,
+      # npm would silently prefer it over OIDC and fail as another opaque
+      # 404. Fail loudly here instead, where the message can say why.
+      # Checks the npmrc FILES, not `npm config list` — that command hides
+      # auth values, so it reports nothing even when a token is configured
+      # and would make this guard permanently green.
+      - name: No stored credentials may pre-empt OIDC
+        run: |
+          found=""
+          for f in "$NPM_CONFIG_USERCONFIG" "$HOME/.npmrc" ".npmrc" "web/generator/.npmrc"; do
+            [ -n "$f" ] && [ -f "$f" ] || continue
+            if grep -qE '_authToken|^\s*_auth\s*=' "$f"; then
+              found="$found $f"
+            fi
+          done
+          if [ -n "$found" ]; then
+            echo "::error::stored npm credentials will pre-empt trusted publishing (found in:$found) — remove registry-url/NODE_AUTH_TOKEN so OIDC is used"
+            exit 1
+          fi
+          echo "no stored npm credentials — OIDC will be used"
 
       # Trusted publishing needs npm >= 11.5.1 (Node 24 already ships an
       # 11.x, but the floor is what matters and a stale npm fails as an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,13 +292,44 @@ tag 指到的 commit，所以這道檢查是把那個步驟換成一個會紅的
 
 ### 一次性設定
 
-- **PyPI**：在專案設定新增 Trusted Publisher（repo `HYChou0515/specstar`、
-  workflow `release-pypi.yml`、environment `pypi`）。
-- **npm**：npm **不能用 OIDC 發套件的第一版**（trusted publisher 要在套件設
-  定頁設定，而設定頁得等套件存在，見 npm/cli#8544）。首次請執行
-  `make -C web bootstrap-publish`（需先 `npm login`），發完再到 npmjs.com 開
-  trusted publisher（repo、workflow `release-npm.yml`、environment `npm`），
-  之後就只走 `make -C web release`。
+**PyPI** —— 在專案設定新增 Trusted Publisher（repo `HYChou0515/specstar`、
+workflow `release-pypi.yml`、environment `pypi`）。
+
+**npm** —— 兩步，且順序不能反。
+
+1. npm **不能用 OIDC 發套件的第一版**：trusted publisher 要在套件設定頁設
+   定，而設定頁得等套件存在（npm/cli#8544）。`0.3.4` 已於 2026-07-28 用
+   `make -C web bootstrap-publish` 手動發過，這一步**不需要再做**。
+2. 註冊 trusted publisher。用 CLI 就好，不必開網頁：
+
+   ```bash
+   npx -y npm@11 trust github specstar-web-generator \
+     --file release-npm.yml --repo HYChou0515/specstar \
+     --env npm --allow-publish
+   ```
+
+   npm 規定 trust 操作必須通過**帳號層級 2FA**，並且明文不接受
+   bypass-2FA 的 granular token —— 所以這行只能由維護者本人跑，會跳出
+   one-time password 提示。先 `--dry-run` 可以確認參數。
+
+### 排查：npm 發布失敗
+
+npm 把**所有**未通過認證的 publish 都回報成 `E404 Not Found` 或
+`ENEEDAUTH`（npm/cli#9088）。看到 404 不要去查「套件不存在」或權限，那是
+假線索 —— 它的意思是「npm 不接受你的身分」。依序看：
+
+- workflow 的 **OIDC preconditions** 步驟有沒有印出 `id-token permission:
+  GRANTED`。沒有 → job 少了 `permissions: id-token: write`。
+- **No stored credentials may pre-empt OIDC** 有沒有紅。紅了表示有東西把
+  憑證寫進 `.npmrc`，npm 會**優先用它而完全不去做 OIDC 交換**。最常見的兇
+  手是 `actions/setup-node` 的 `registry-url:` —— 它會寫入
+  `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` 並把
+  `NODE_AUTH_TOKEN` 預設成字面字串 `XXXXX-XXXXX-XXXXX-XXXXX`
+  （actions/setup-node#1551）。workflow 裡那道 `sed '/_authToken/d'` 就是
+  為此存在，**不要拿掉**。
+- 以上都綠但仍 `ENEEDAUTH` → npmjs.com 上沒有相符的 trusted publisher，回
+  上面第 2 步。三元組（repository / workflow 檔名 / environment）必須逐字
+  相同，workflow 只填檔名不含路徑。
 
 ## 授權
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -42,7 +42,8 @@ help:
 	@echo "  make sync-templates    - 把 app/ 同步進 generator/templates/base"
 	@echo "  make check-templates   - 驗證 templates 已同步（不寫入）"
 	@echo "  make release           - 打 web-vX.Y.Z tag + push；上傳由 CI 執行"
-	@echo "  make bootstrap-publish - 一次性：首發到 npm（OIDC 發不了第一版）"
+	@echo "  make trust             - 一次性：註冊 npm trusted publisher（要 2FA）"
+	@echo "  make bootstrap-publish - 一次性：首發到 npm（已完成，勿再用）"
 	@echo ""
 	@echo "其他："
 	@echo "  make clean        - 清理生成的檔案"
@@ -240,15 +241,31 @@ release: check-templates
 	echo "✅ 已 push tag web-v$$v"; \
 	echo "   追蹤：https://github.com/HYChou0515/specstar/actions/workflows/release-npm.yml"
 
+# 一次性：把這個 repo 註冊成 npm 的 trusted publisher，讓 CI 免 token 發布。
+#
+# 用 CLI 而不是網頁設定頁；三元組必須跟 release-npm.yml 逐字相同，所以寫死
+# 在這裡而不是靠人手打。npm 規定 trust 操作要過**帳號層級 2FA**，且明文不
+# 接受 bypass-2FA 的 granular token，所以它會跳出 one-time password 提示，
+# 只能由維護者本人完成 —— 這是憑證邊界，不是可以自動化的步驟。
+#
+# 本機 npm 若低於 11 沒有 `trust` 子指令，故走 npx，不動全域安裝。
+# 先看會送出什麼：make trust DRY_RUN=1
+.PHONY: trust
+trust:
+	@echo "🔐 註冊 npm trusted publisher（會要求輸入 2FA 六位數）..."
+	npx -y npm@11 trust github specstar-web-generator \
+		--file release-npm.yml \
+		--repo HYChou0515/specstar \
+		--env npm \
+		--allow-publish $(if $(DRY_RUN),--dry-run)
+	@echo "✅ 完成後，發 web-vX.Y.Z tag 即可全自動發布（make release）"
+
 # 一次性的 bootstrap：把 generator 的「第一版」發到 npm。
 #
 # npm 不能用 OIDC 發套件的第一版 —— trusted publisher 是在套件設定頁設定
-# 的，而設定頁要等套件存在才有（npm/cli#8544）。所以 0.3.4 必須從工作站手
-# 動發一次，之後到 npmjs.com 開 trusted publisher，往後就只走 `make
-# release` 推 tag → CI。需要先 `npm login`。
-#
-# 這不是 `make release` 的替代路徑，是它的前置條件；bootstrap 完成後不該
-# 再用。
+# 的，而設定頁要等套件存在才有（npm/cli#8544）。0.3.4 已於 2026-07-28 用這
+# 個 target 發過，**不該再用**；往後一律 `make trust`（一次）+ `make
+# release`（每次）走 CI。需要先 `npm login`。
 .PHONY: bootstrap-publish
 bootstrap-publish: style sync-templates build-gen
 	@echo "🚀 首次發布 generator 到 npm（bootstrap，只做一次）..."

--- a/web/generator/package.json
+++ b/web/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specstar-web-generator",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Code generator for SpecStar frontend - generates React/Mantine/TanStack apps from OpenAPI spec",
   "type": "module",
   "bin": {

--- a/web/generator/package.json
+++ b/web/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specstar-web-generator",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Code generator for SpecStar frontend - generates React/Mantine/TanStack apps from OpenAPI spec",
   "type": "module",
   "bin": {

--- a/web/generator/package.json
+++ b/web/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specstar-web-generator",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Code generator for SpecStar frontend - generates React/Mantine/TanStack apps from OpenAPI spec",
   "type": "module",
   "bin": {

--- a/web/generator/package.json
+++ b/web/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specstar-web-generator",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Code generator for SpecStar frontend - generates React/Mantine/TanStack apps from OpenAPI spec",
   "type": "module",
   "bin": {


### PR DESCRIPTION
`web-v0.3.5` failed with a bare `E404` that reads as "no such package". The package exists — npm returns 404 for *any* unauthorized publish (npm/cli#9088). Two real defects were behind it.

## 1. `registry-url` fed npm a junk token instead of letting it use OIDC

`actions/setup-node` with `registry-url:` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and defaults `NODE_AUTH_TOKEN` to the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX`. npm authenticated with that junk bearer token and **never attempted the OIDC exchange** — nothing in the failing run's log mentions OIDC at all. ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551))

Fixed by keeping `registry-url` (so the registry stays pinned, as npm's own example does) and deleting the `_authToken` line it generates — the workaround that issue thread settled on. My first attempt dropped `registry-url` entirely, which was my own invention; it moved the error from `E404` to `ENEEDAUTH` but was not the proven fix.

## 2. The diagnostic printed the tag where it meant the workflow filename

`basename` ran before the `@`-split, so it reported `web-v0.3.7` instead of `release-npm.yml` — the one string that must be copied verbatim into npm's trusted publisher form.

## Guards added

- **No stored credentials may pre-empt OIDC** — greps the npmrc *files*, not `npm config list` (that command hides auth values and would have left the guard permanently green). Verified red against a real token and against setup-node's placeholder line; green on a clean environment.
- **OIDC preconditions** — asserts the runner can mint an OIDC token and prints the repository/workflow/environment triple that must match npmjs.com. Booleans and identifiers only, never the token. This exists because npm collapses every trusted-publishing failure into `ENEEDAUTH`/`404`, which cannot distinguish "no token issued" from "npm never asked" from "no matching trusted publisher".

## Verified

With this branch, `web-v0.3.7` produced:

```
id-token permission: GRANTED (runner can mint an OIDC token)
cleaned /home/runner/work/_temp/.npmrc
no stored npm credentials — OIDC will be used
npm 11.18.0
```

Every CI-side precondition is satisfied and proven. The publish still returns `ENEEDAUTH`, which now isolates the cause to the one variable outside this repo: no matching trusted publisher on npmjs.com yet. That is configured with

```
npx -y npm@11 trust github specstar-web-generator \
  --file release-npm.yml --repo HYChou0515/specstar --env npm --allow-publish
```

which npm requires be confirmed with an account 2FA one-time password (GAT bypass-2FA tokens are explicitly unsupported for trust commands), so it has to be run by the maintainer. `--dry-run` confirms the resulting configuration is exactly right.

PyPI was never affected — `v0.13.0a3` published successfully on its first run, tokenless.

`web/generator/package.json` is at `0.3.7`; nothing above `0.3.4` has been published, so those version numbers are still free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtKAtHbUUdmdDQyvA2GekH